### PR TITLE
correct class path delimiter in bash script

### DIFF
--- a/APISpec/extcodegen.sh
+++ b/APISpec/extcodegen.sh
@@ -9,7 +9,7 @@ TARGET_STACK="aspnetmvc"
 TARGET_STACK="django"
 
 # Adjust these lines to set the names and locations of the code generator jars
-executable="swagger-codegen-extension-1.0.1-jar-with-dependencies.jar;swagger-codegen-cli.jar"
+executable="swagger-codegen-extension-1.0.1-jar-with-dependencies.jar:swagger-codegen-cli.jar"
 
 # Set the code elements to be generate
 GEN_OPTIONS="-DapiTests=true -DmodelTests=true"


### PR DESCRIPTION
The classpath delimiter for linux/mac machines is a colon whereas it
is a semicolon for windows. This makes the switch so the bash script
runs without issues.