### PR TITLE
Field Validation in CreditTrade model class

### DIFF
--- a/server/exceptions.py
+++ b/server/exceptions.py
@@ -4,11 +4,19 @@ from rest_framework import status
 
 
 class CustomValidation(APIException):
-    status_code = 422
-    default_detail = 'Validation Error'
 
     def __init__(self, detail, field, status_code):
-        if status_code is not None:self.status_code = status_code
+        self.detail = detail
         if detail is not None:
             self.detail = {field: force_text(detail)}
-        else: self.detail = {'detail': force_text(self.default_detail)}
+        self.message = detail
+        self.field = field
+        self.status_code = status_code
+
+    def __call__(self, value):
+        detail = self.detail
+        message = self.message
+        field = self.field
+        status_code = self.status_code
+        if value <= 0:
+            raise CustomValidation(message, field, status_code)

--- a/server/models/CreditTrade.py
+++ b/server/models/CreditTrade.py
@@ -27,6 +27,7 @@ from .CreditTradeStatus import CreditTradeStatus
 from .FuelSupplier import FuelSupplier
 from .CreditTradeType import CreditTradeType
 from .CreditTradeHistory import CreditTradeHistory
+from server.exceptions import CustomValidation
 
 
 class CreditTrade(models.Model):	    
@@ -35,7 +36,7 @@ class CreditTrade(models.Model):
     respondent = models.ForeignKey('FuelSupplier', related_name='CreditTraderespondent')   
     tradeEffectiveDate = models.DateField(blank=True, null=True)   
     creditTradeTypeId = models.ForeignKey('CreditTradeType', related_name='CreditTradecreditTradeTypeId')   
-    numberOfCredits = models.IntegerField()   
+    numberOfCredits = models.IntegerField(validators=[CustomValidation('Value must be a positive integer','numberOfCredits',status_code=422)])
     fairMarketValuePerCredit = models.CharField(blank=True, null=True, max_length=255)   
     history = models.ManyToManyField('CreditTradeHistory', related_name='CreditTradehistory', blank=True)   
     plainEnglishPhrase = models.CharField(max_length=255)   

--- a/server/serializers.py
+++ b/server/serializers.py
@@ -58,7 +58,6 @@ from .models.UserFavouriteViewModel import UserFavouriteViewModel
 from .models.UserRole import UserRole
 from .models.UserRoleViewModel import UserRoleViewModel
 from .models.UserViewModel import UserViewModel
-from server.exceptions import CustomValidation
 
 class AuditSerializer(serializers.ModelSerializer):
   class Meta:
@@ -66,16 +65,6 @@ class AuditSerializer(serializers.ModelSerializer):
     fields = ('id','appCreateTimestamp','appCreateUserid','appCreateUserGuid','appCreateUserDirectory','appLastUpdateTimestamp','appLastUpdateUserid','appLastUpdateUserGuid','appLastUpdateUserDirectory','entityName','entityId','propertyName','oldValue','newValue','isDelete')
 
 class CreditTradeSerializer(serializers.ModelSerializer):
-  def validate(self, data):
-    """
-    Check numberOfCredits should be positive integer
-    """
-    number_of_credits = data['numberOfCredits']
-    if number_of_credits <= 0:
-      raise CustomValidation('Value must be a positive integer','numberOfCredits', status_code=422)
-
-    return data
-
   class Meta:
     model = CreditTrade
     fields = ('id','creditTradeStatusId','initiator','respondent','tradeEffectiveDate','creditTradeTypeId','numberOfCredits','fairMarketValuePerCredit','history','plainEnglishPhrase')


### PR DESCRIPTION
This commit re-adds the validation for the credit trade class on the numberOfCredits field, only allowing positive integers.