### PR TITLE
Follow-up fix for the currency filter. This allows decimal filtering

### DIFF
--- a/frontend/src/admin/historical_data_entry/components/HistoricalDataTable.js
+++ b/frontend/src/admin/historical_data_entry/components/HistoricalDataTable.js
@@ -76,7 +76,7 @@ const HistoricalDataTable = (props) => {
         return -1; // this is to fix sorting (value can't be negative)
       }
 
-      return parseFloat(item.totalValue);
+      return parseFloat(item.totalValue).toFixed(2);
     },
     className: 'col-price',
     Cell: row => (

--- a/frontend/src/credit_transfers/components/CreditTransferTable.js
+++ b/frontend/src/credit_transfers/components/CreditTransferTable.js
@@ -75,7 +75,7 @@ const CreditTransferTable = (props) => {
         return -1; // this is to fix sorting (value can't be negative)
       }
 
-      return parseFloat(item.fairMarketValuePerCredit);
+      return parseFloat(item.fairMarketValuePerCredit).toFixed(2);
     },
     minWidth: 100,
     Cell: row => (


### PR DESCRIPTION
#246 

I noticed that when I tried to add .00 on the currency column, it removes the matching rows. This was caused by the values in the accessor had no decimal places when it ends with .00