### PR TITLE
Signing confirmation

### DIFF
--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -24,6 +24,7 @@ from rest_framework import serializers
 
 from api.models.CreditTrade import CreditTrade
 from api.models.CreditTradeStatus import CreditTradeStatus
+from api.models.CreditTradeType import CreditTradeType
 
 from .CreditTradeStatus import CreditTradeStatusMinSerializer
 from .CreditTradeType import CreditTradeTypeSerializer

--- a/backend/api/serializers/SigningAuthorityConfirmation.py
+++ b/backend/api/serializers/SigningAuthorityConfirmation.py
@@ -7,6 +7,7 @@
 
     OpenAPI spec version: v1
 
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
@@ -19,30 +20,13 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+from rest_framework import serializers
 
-from .CompliancePeriod import *
-from .CreditTrade import *
-from .CreditTradeHistory import *
-from .CreditTradeStatus import *
-from .CreditTradeType import *
-from .CreditTradeZeroReason import *
-from .CurrentUserViewModel import *
-from .Organization import *
-from .OrganizationActionsType import *
-from .OrganizationAttachment import *
-from .OrganizationBalance import *
-from .OrganizationHistory import *
-from .OrganizationStatus import *
-from .Permission import *
-from .PermissionViewModel import *
-from .Role import *
-from .RolePermission import *
-from .RolePermissionViewModel import *
-from .RoleViewModel import *
-from .SigningAuthorityAssertion import *
-from .SigningAuthorityConfirmation import *
-from .User import *
-from .UserDetailsViewModel import *
-from .UserRole import *
-from .UserRoleViewModel import *
-from .UserViewModel import *
+from api.models.SigningAuthorityConfirmation \
+  import SigningAuthorityConfirmation
+
+
+class SigningAuthorityConfirmationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SigningAuthorityConfirmation
+        fields = '__all__'

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -34,6 +34,8 @@ from .viewsets.CreditTrade import CreditTradeViewSet
 from .viewsets.Organization import OrganizationViewSet
 from .viewsets.SigningAuthorityAssertion \
     import SigningAuthorityAssertionViewSet
+from .viewsets.SigningAuthorityConfirmation \
+    import SigningAuthorityConfirmationViewSet
 from .viewsets.User import UserViewSet
 
 from rest_framework.documentation import include_docs_urls
@@ -48,6 +50,8 @@ router.register(r'credit_trades', CreditTradeViewSet)
 router.register(r'organizations', OrganizationViewSet)
 router.register(r'signing_authority_assertions',
                 SigningAuthorityAssertionViewSet)
+router.register(r'signing_authority_confirmations',
+                SigningAuthorityConfirmationViewSet)
 router.register(r'users', UserViewSet)
 
 

--- a/backend/api/viewsets/SigningAuthorityAssertion.py
+++ b/backend/api/viewsets/SigningAuthorityAssertion.py
@@ -8,8 +8,7 @@ from django.db.models import Q
 import datetime
 
 from api.models.SigningAuthorityAssertion import SigningAuthorityAssertion
-from api.serializers.SigningAuthorityAssertion \
-  import SigningAuthorityAssertionSerializer
+from api.serializers import SigningAuthorityAssertionSerializer
 
 
 class SigningAuthorityAssertionViewSet(AuditableMixin, mixins.ListModelMixin,

--- a/backend/api/viewsets/SigningAuthorityConfirmation.py
+++ b/backend/api/viewsets/SigningAuthorityConfirmation.py
@@ -16,7 +16,8 @@ class SigningAuthorityConfirmationViewSet(AuditableMixin,
                                           mixins.CreateModelMixin,
                                           viewsets.GenericViewSet):
     """
-    This viewset automatically provides `create`
+    This viewset automatically provides `list`, `create`, `retrieve`,
+    `update` and `destroy` actions.
     """
     permission_classes = (permissions.AllowAny,)
     http_method_names = ['post']
@@ -25,16 +26,3 @@ class SigningAuthorityConfirmationViewSet(AuditableMixin,
     ordering_fields = '__all__'
     ordering = ('display_order',)
     serializer_class = SigningAuthorityConfirmationSerializer
-
-    @list_route(methods=['post'])
-    def sign(self, request):
-        for assertion in request.data['assertions']:
-            confirmation = SigningAuthorityConfirmation(
-                credit_trade_id=request.data['credit_trade'],
-                has_accepted=assertion['value'],
-                signing_authority_assertion_id=assertion['id']
-            )
-
-            confirmation.save()
-
-        return Response(None, status=status.HTTP_200_OK)

--- a/backend/api/viewsets/SigningAuthorityConfirmation.py
+++ b/backend/api/viewsets/SigningAuthorityConfirmation.py
@@ -1,0 +1,40 @@
+from rest_framework import viewsets, permissions, status, mixins, exceptions
+from rest_framework.decorators import list_route, detail_route
+from rest_framework.response import Response
+from rest_framework import filters
+
+from auditable.views import AuditableMixin
+from django.db.models import Q
+import datetime
+
+from api.models.SigningAuthorityConfirmation \
+  import SigningAuthorityConfirmation
+from api.serializers import SigningAuthorityConfirmationSerializer
+
+
+class SigningAuthorityConfirmationViewSet(AuditableMixin,
+                                          mixins.CreateModelMixin,
+                                          viewsets.GenericViewSet):
+    """
+    This viewset automatically provides `create`
+    """
+    permission_classes = (permissions.AllowAny,)
+    http_method_names = ['post']
+    queryset = SigningAuthorityConfirmation.objects.all()
+    filter_backends = (filters.OrderingFilter,)
+    ordering_fields = '__all__'
+    ordering = ('display_order',)
+    serializer_class = SigningAuthorityConfirmationSerializer
+
+    @list_route(methods=['post'])
+    def sign(self, request):
+        for assertion in request.data['assertions']:
+            confirmation = SigningAuthorityConfirmation(
+                credit_trade_id=request.data['credit_trade'],
+                has_accepted=assertion['value'],
+                signing_authority_assertion_id=assertion['id']
+            )
+
+            confirmation.save()
+
+        return Response(None, status=status.HTTP_200_OK)

--- a/frontend/__tests__/actions/signingAuthorityConfirmationsActions/prepareSigningAuthorityConfirmations.js
+++ b/frontend/__tests__/actions/signingAuthorityConfirmationsActions/prepareSigningAuthorityConfirmations.js
@@ -1,0 +1,14 @@
+import { prepareSigningAuthorityConfirmations } from '../../../src/actions/signingAuthorityConfirmationsActions';
+
+test('prepareSigningAuthorityConfirmations should return the right data for Confirmations', () => {
+  const data = prepareSigningAuthorityConfirmations(123, [{
+    id: 456,
+    value: true
+  }]);
+
+  expect([{
+    creditTrade: 123,
+    hasAccepted: true,
+    signingAuthorityAssertion: 456
+  }]).toEqual(data);
+});

--- a/frontend/__tests__/app/components/__snapshots__/StatusInterceptor.js.snap
+++ b/frontend/__tests__/app/components/__snapshots__/StatusInterceptor.js.snap
@@ -16,7 +16,7 @@ exports[`StatusInterceptor should display the proper message for 401 errors 1`] 
     <a
       href="mailto:lcfrr@gov.bc.ca?subject=Account%20Setup%20for%20TFRS"
     >
-      contact us
+       contact us 
     </a>
     for help.
   </p>
@@ -39,7 +39,7 @@ exports[`StatusInterceptor should display the proper message for 403 errors 1`] 
     <a
       href="mailto:lcfrr@gov.bc.ca?subject=Account%20Setup%20for%20TFRS"
     >
-      contact us
+       contact us 
     </a>
     for help.
   </p>

--- a/frontend/src/actions/creditTransfersActions.js
+++ b/frontend/src/actions/creditTransfersActions.js
@@ -221,6 +221,7 @@ export const addCreditTransfer = data => (dispatch) => {
     .post(Routes.BASE_URL + Routes.CREDIT_TRADE_API, data)
     .then((response) => {
       dispatch(addCreditTransferSuccess(response.data));
+      return Promise.resolve(response);
     }).catch((error) => {
       dispatch(addCreditTransferError(error.response.data));
       return Promise.reject(error);
@@ -254,6 +255,7 @@ export const updateCreditTransfer = (id, data) => (dispatch) => {
     .put(`${Routes.BASE_URL}${Routes.CREDIT_TRADE_API}/${id}`, data)
     .then((response) => {
       dispatch(updateCreditTransferSuccess(response.data));
+      return Promise.resolve(response);
     }).catch((error) => {
       dispatch(updateCreditTransferError(error.response.data));
       return Promise.reject(error);

--- a/frontend/src/actions/signingAuthorityConfirmationsActions.js
+++ b/frontend/src/actions/signingAuthorityConfirmationsActions.js
@@ -2,7 +2,20 @@ import axios from 'axios';
 
 import * as Routes from '../constants/routes';
 
-const addSigningAuthorityConfirmation = data => (dispatch) => {
+export const prepareSigningAuthorityConfirmations = (creditTradeId, terms) => {
+  const data = [];
+  terms.forEach((term) => {
+    data.push({
+      creditTrade: creditTradeId,
+      hasAccepted: term.value,
+      signingAuthorityAssertion: term.id
+    });
+  });
+
+  return data;
+};
+
+export const addSigningAuthorityConfirmation = data => (dispatch) => {
   dispatch(addSigningAuthorityConfirmationRequest());
 
   return axios
@@ -31,5 +44,3 @@ const addSigningAuthorityConfirmationError = error => ({
   type: 'ERROR',
   errorMessage: error
 });
-
-export default addSigningAuthorityConfirmation;

--- a/frontend/src/actions/signingAuthorityConfirmationsActions.js
+++ b/frontend/src/actions/signingAuthorityConfirmationsActions.js
@@ -1,0 +1,35 @@
+import axios from 'axios';
+
+import * as Routes from '../constants/routes';
+
+const addSigningAuthorityConfirmation = data => (dispatch) => {
+  dispatch(addSigningAuthorityConfirmationRequest());
+
+  return axios
+    .post(Routes.BASE_URL + Routes.SIGNING_AUTHORITY_CONFIRMATIONS.SIGN, data)
+    .then((response) => {
+      dispatch(addSigningAuthorityConfirmationSuccess(response.data));
+    }).catch((error) => {
+      dispatch(addSigningAuthorityConfirmationError(error.response.data));
+      return Promise.reject(error);
+    });
+};
+
+const addSigningAuthorityConfirmationRequest = () => ({
+  name: 'ADD_SIGNING_AUTHORITY_CONFIRMATION_REQUEST',
+  type: 'ADD_SIGNING_AUTHORITY_CONFIRMATION'
+});
+
+const addSigningAuthorityConfirmationSuccess = data => ({
+  name: 'SUCCESS_ADD_SIGNING_AUTHORITY_CONFIRMATION_SUCCESS',
+  type: 'SUCCESS_ADD_SIGNING_AUTHORITY_CONFIRMATION_SUCCESS',
+  data
+});
+
+const addSigningAuthorityConfirmationError = error => ({
+  name: 'ERROR_ADD_SIGNING_AUTHORITY_CONFIRMATION',
+  type: 'ERROR',
+  errorMessage: error
+});
+
+export default addSigningAuthorityConfirmation;

--- a/frontend/src/admin/historical_data_entry/components/HistoricalDataEntryPage.js
+++ b/frontend/src/admin/historical_data_entry/components/HistoricalDataEntryPage.js
@@ -8,8 +8,7 @@ import Loading from '../../../app/components/Loading';
 import HistoricalDataEntryForm from './HistoricalDataEntryForm';
 import HistoricalDataEntryFormButtons from './HistoricalDataEntryFormButtons';
 import HistoricalDataTable from './HistoricalDataTable';
-import ModalDeleteCreditTransfer from '../../../credit_transfers/components/ModalDeleteCreditTransfer';
-import ModalProcessApprovedCreditTransfer from '../../../credit_transfers/components/ModalProcessApprovedCreditTransfer';
+import Modal from '../../../app/components/Modal';
 import SuccessAlert from '../../../app/components/SuccessAlert';
 
 const buttonActions = [Lang.BTN_CANCEL, Lang.BTN_COMMIT];
@@ -55,14 +54,21 @@ const HistoricalDataEntryPage = (props) => {
         <HistoricalDataEntryFormButtons actions={buttonActions} />
       </div>
 
-      <ModalDeleteCreditTransfer
-        deleteCreditTransfer={props.deleteCreditTransfer}
-        selectedId={props.selectedId}
-      />
+      <Modal
+        handleSubmit={() => props.deleteCreditTransfer(props.selectedId)}
+        id="confirmDelete"
+        title="Confirm Delete"
+      >
+        Do you want to delete this credit transfer?
+      </Modal>
 
-      <ModalProcessApprovedCreditTransfer
-        processApprovedCreditTransfers={props.processApprovedCreditTransfers}
-      />
+      <Modal
+        handleSubmit={props.processApprovedCreditTransfers}
+        id="confirmProcess"
+        title="Confirm Process"
+      >
+        Are you sure you want to commit the approved credit transfers?
+      </Modal>
     </div>
   );
 };

--- a/frontend/src/app/components/CheckBox.js
+++ b/frontend/src/app/components/CheckBox.js
@@ -7,10 +7,13 @@ class CheckBox extends Component {
   constructor (props) {
     super(props);
 
-    props.addToFields({
-      id: props.id,
-      value: false
-    });
+    // sometimes we might re-render so best to check and make sure we're not duplicating
+    if (!this.props.fields.find(field => field.id === this.props.id)) {
+      props.addToFields({
+        id: props.id,
+        value: false
+      });
+    }
   }
 
   render () {

--- a/frontend/src/app/components/Modal.js
+++ b/frontend/src/app/components/Modal.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 
 import * as Lang from '../../constants/langEnUs';
 
-const ModalProcessApprovedCreditTransfer = props => (
+const Modal = props => (
   <div
     className="modal fade"
-    id="confirmProcess"
+    id={props.id}
     tabIndex="-1"
     role="dialog"
-    aria-labelledby="confirmProcessLabel"
+    aria-labelledby="confirmSubmitLabel"
   >
     <div className="modal-dialog" role="document">
       <div className="modal-content">
@@ -24,13 +24,13 @@ const ModalProcessApprovedCreditTransfer = props => (
           </button>
           <h4
             className="modal-title"
-            id="confirmProcessLabel"
+            id="confirmSubmitLabel"
           >
-            Confirm Process
+            {props.title}
           </h4>
         </div>
         <div className="modal-body">
-          Are you sure you want to commit the approved credit transfers?
+          {props.children}
         </div>
         <div className="modal-footer">
           <button
@@ -38,15 +38,15 @@ const ModalProcessApprovedCreditTransfer = props => (
             className="btn btn-default"
             data-dismiss="modal"
           >
-            {Lang.BTN_APP_CANCEL}
+            {props.cancelLabel}
           </button>
           <button
             type="button"
             className="btn btn-primary"
             data-dismiss="modal"
-            onClick={props.processApprovedCreditTransfers}
+            onClick={props.handleSubmit}
           >
-            {Lang.BTN_PROCESS}
+            {props.confirmLabel}
           </button>
         </div>
       </div>
@@ -54,13 +54,23 @@ const ModalProcessApprovedCreditTransfer = props => (
   </div>
 );
 
-ModalProcessApprovedCreditTransfer.defaultProps = {
-  selectedId: 0
+Modal.defaultProps = {
+  cancelLabel: Lang.BTN_NO,
+  confirmLabel: Lang.BTN_YES,
+  handleSubmit: null,
+  title: 'Confirmation'
 };
 
-ModalProcessApprovedCreditTransfer.propTypes = {
-  processApprovedCreditTransfers: PropTypes.func.isRequired,
-  selectedId: PropTypes.number
+Modal.propTypes = {
+  cancelLabel: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]).isRequired,
+  confirmLabel: PropTypes.string,
+  handleSubmit: PropTypes.func,
+  id: PropTypes.string.isRequired,
+  title: PropTypes.string
 };
 
-export default ModalProcessApprovedCreditTransfer;
+export default Modal;

--- a/frontend/src/app/components/StatusInterceptor.js
+++ b/frontend/src/app/components/StatusInterceptor.js
@@ -10,7 +10,7 @@ class StatusInterceptor extends Component {
           a page that you do not have permissions to see.
         </p>
         <p>You will need to
-          <a href="mailto:lcfrr@gov.bc.ca?subject=Account%20Setup%20for%20TFRS">contact us</a>
+          <a href="mailto:lcfrr@gov.bc.ca?subject=Account%20Setup%20for%20TFRS"> contact us </a>
           for help.
         </p>
       </div>
@@ -25,7 +25,7 @@ class StatusInterceptor extends Component {
           a page that you do not have permissions to see.
         </p>
         <p>You will need to
-          <a href="mailto:lcfrr@gov.bc.ca?subject=Account%20Setup%20for%20TFRS">contact us</a>
+          <a href="mailto:lcfrr@gov.bc.ca?subject=Account%20Setup%20for%20TFRS"> contact us </a>
           for help.
         </p>
       </div>

--- a/frontend/src/constants/langEnUs.js
+++ b/frontend/src/constants/langEnUs.js
@@ -15,4 +15,5 @@ export const BTN_RESCIND = 'Rescind';
 export const BTN_SAVE = 'Save';
 export const BTN_SAVE_DRAFT = 'Save Draft';
 export const BTN_SIGN_1_2 = 'Sign 1/2';
+export const BTN_SIGN_2_2 = 'Sign 2/2';
 export const BTN_YES = 'Yes';

--- a/frontend/src/constants/routes.js
+++ b/frontend/src/constants/routes.js
@@ -54,3 +54,4 @@ export const DELETE = '/delete';
 
 export { default as COMPLIANCE_PERIODS } from './routes/CompliancePeriods';
 export { default as SIGNING_AUTHORITY_ASSERTIONS } from './routes/SigningAuthorityAssertions';
+export { default as SIGNING_AUTHORITY_CONFIRMATIONS } from './routes/SigningAuthorityConfirmations';

--- a/frontend/src/constants/routes/SigningAuthorityConfirmations.js
+++ b/frontend/src/constants/routes/SigningAuthorityConfirmations.js
@@ -1,7 +1,7 @@
 const BASE_PATH = '/signing_authority_confirmations';
 
 const SIGNING_AUTHORITY_CONFIRMATIONS = {
-  SIGN: `${BASE_PATH}/sign`
+  SIGN: `${BASE_PATH}`
 };
 
 export default SIGNING_AUTHORITY_CONFIRMATIONS;

--- a/frontend/src/constants/routes/SigningAuthorityConfirmations.js
+++ b/frontend/src/constants/routes/SigningAuthorityConfirmations.js
@@ -1,0 +1,7 @@
+const BASE_PATH = '/signing_authority_confirmations';
+
+const SIGNING_AUTHORITY_CONFIRMATIONS = {
+  SIGN: `${BASE_PATH}/sign`
+};
+
+export default SIGNING_AUTHORITY_CONFIRMATIONS;

--- a/frontend/src/credit_transfers/CreditTransferAddContainer.js
+++ b/frontend/src/credit_transfers/CreditTransferAddContainer.js
@@ -139,6 +139,7 @@ class CreditTransferAddContainer extends Component {
       fairMarketValuePerCredit: parseFloat(this.state.fields.fairMarketValuePerCredit).toFixed(2),
       note: this.state.fields.note,
       status: status.id,
+      terms: this.state.fields.terms,
       type: this.state.fields.tradeType.id,
       tradeEffectiveDate: null
     };

--- a/frontend/src/credit_transfers/CreditTransferAddContainer.js
+++ b/frontend/src/credit_transfers/CreditTransferAddContainer.js
@@ -9,6 +9,7 @@ import { bindActionCreators } from 'redux';
 
 import CreditTransferForm from './components/CreditTransferForm';
 import ModalSubmitCreditTransfer from './components/ModalSubmitCreditTransfer';
+
 import { getFuelSuppliers } from '../actions/organizationActions';
 import { getLoggedInUser } from '../actions/userActions';
 import { addCreditTransfer, invalidateCreditTransfers } from '../actions/creditTransfersActions';
@@ -206,13 +207,17 @@ class CreditTransferAddContainer extends Component {
         totalValue={this.state.totalValue}
       />,
       <ModalSubmitCreditTransfer
-        id="confirmSubmit"
-        key="confirmSubmit"
-        submitCreditTransfer={(event) => {
+        handleSubmit={(event) => {
           this._handleSubmit(event, CREDIT_TRANSFER_STATUS.proposed);
         }}
-        message="Do you want to sign and send this document to the other party
-        named in this transfer?"
+        item={
+          {
+            creditsFrom: this.state.creditsFrom,
+            creditsTo: this.state.creditsTo,
+            fairMarketValuePerCredit: this.state.fields.fairMarketValuePerCredit,
+            numberOfCredits: this.state.fields.numberOfCredits
+          }
+        }
       />
     ]);
   }

--- a/frontend/src/credit_transfers/CreditTransferEditContainer.js
+++ b/frontend/src/credit_transfers/CreditTransferEditContainer.js
@@ -7,8 +7,9 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import CREDIT_TRANSACTIONS from '../constants/routes/CreditTransactions';
-import history from '../app/History';
+import CreditTransferForm from './components/CreditTransferForm';
+import ModalDeleteCreditTransfer from './components/ModalDeleteCreditTransfer';
+import ModalSubmitCreditTransfer from './components/ModalSubmitCreditTransfer';
 
 import { getFuelSuppliers } from '../actions/organizationActions';
 import {
@@ -21,10 +22,9 @@ import {
   addSigningAuthorityConfirmation,
   prepareSigningAuthorityConfirmations
 } from '../actions/signingAuthorityConfirmationsActions';
-import CreditTransferForm from './components/CreditTransferForm';
+import history from '../app/History';
+import CREDIT_TRANSACTIONS from '../constants/routes/CreditTransactions';
 import { CREDIT_TRANSFER_STATUS } from '../constants/values';
-import ModalDeleteCreditTransfer from './components/ModalDeleteCreditTransfer';
-import ModalSubmitCreditTransfer from './components/ModalSubmitCreditTransfer';
 import * as Lang from '../constants/langEnUs';
 
 const buttonActions = [Lang.BTN_DELETE_DRAFT, Lang.BTN_SAVE_DRAFT, Lang.BTN_SIGN_1_2];
@@ -261,20 +261,19 @@ class CreditTransferEditContainer extends Component {
         tradeStatus={this.state.tradeStatus}
       />,
       <ModalSubmitCreditTransfer
-        id="confirmSubmit"
-        key="confirmSubmit"
-        submitCreditTransfer={(event) => {
+        handleSubmit={(event) => {
           this._handleSubmit(event, CREDIT_TRANSFER_STATUS.proposed);
         }}
-        message="Do you want to sign and send this document to the other party
-        named in this transfer?"
+        item={
+          {
+            creditsFrom: this.state.creditsFrom,
+            creditsTo: this.state.creditsTo,
+            fairMarketValuePerCredit: item.fairMarketValuePerCredit,
+            numberOfCredits: item.numberOfCredits
+          }
+        }
       />,
-      <ModalDeleteCreditTransfer
-        key="confirmDelete"
-        deleteCreditTransfer={this._deleteCreditTransfer}
-        message="Do you want to delete this draft?"
-        selectedId={item.id}
-      />
+      <ModalDeleteCreditTransfer handleSubmit={() => this._deleteCreditTransfer(item.id)} />
     ]);
   }
 }

--- a/frontend/src/credit_transfers/CreditTransferViewContainer.js
+++ b/frontend/src/credit_transfers/CreditTransferViewContainer.js
@@ -17,6 +17,7 @@ import {
   invalidateCreditTransfer,
   updateCreditTransfer
 } from '../actions/creditTransfersActions';
+import addSigningAuthorityConfirmation from '../actions/signingAuthorityConfirmationsActions';
 import { getLoggedInUser } from '../actions/userActions';
 import history from '../app/History';
 import * as Lang from '../constants/langEnUs';
@@ -67,18 +68,17 @@ class CreditTransferViewContainer extends Component {
 
     // API data structure
     const data = {
-      fields: this.state.fields,
       initiator: item.initiator.id,
-      numberOfCredits: item.numberOfCredits,
-      respondent: item.respondent.id,
       fairMarketValuePerCredit: item.fairMarketValuePerCredit,
       note: item.note,
+      numberOfCredits: item.numberOfCredits,
+      respondent: item.respondent.id,
       status: status.id,
-      type: item.type.id,
-      tradeEffectiveDate: null
+      tradeEffectiveDate: null,
+      type: item.type.id
     };
 
-    // Update credit transfer (status and capture the acceptance of terms)
+    // Update credit transfer (status only)
 
     const { id } = this.props.item;
 
@@ -87,6 +87,12 @@ class CreditTransferViewContainer extends Component {
       history.push(CREDIT_TRANSACTIONS.LIST);
     }, () => {
       // Failed to update
+    });
+
+    // Capture the acceptance of terms
+    this.props.addSigningAuthorityConfirmation({
+      assertions: this.state.fields.terms,
+      credit_trade: id
     });
   }
 
@@ -170,6 +176,7 @@ class CreditTransferViewContainer extends Component {
 }
 
 CreditTransferViewContainer.propTypes = {
+  addSigningAuthorityConfirmation: PropTypes.func.isRequired,
   deleteCreditTransfer: PropTypes.func.isRequired,
   getCreditTransferIfNeeded: PropTypes.func.isRequired,
   invalidateCreditTransfer: PropTypes.func.isRequired,
@@ -214,6 +221,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
+  addSigningAuthorityConfirmation: bindActionCreators(addSigningAuthorityConfirmation, dispatch),
   deleteCreditTransfer: bindActionCreators(deleteCreditTransfer, dispatch),
   getCreditTransferIfNeeded: bindActionCreators(getCreditTransferIfNeeded, dispatch),
   getLoggedInUser: bindActionCreators(getLoggedInUser, dispatch),

--- a/frontend/src/credit_transfers/components/CreditTransferDetails.js
+++ b/frontend/src/credit_transfers/components/CreditTransferDetails.js
@@ -4,14 +4,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Loading from '../../app/components/Loading';
-
+import CreditTransferFormButtons from './CreditTransferFormButtons';
 import CreditTransferProgress from './CreditTransferProgress';
+import CreditTransferTerms from './CreditTransferTerms';
 import CreditTransferTextRepresentation from './CreditTransferTextRepresentation';
 import CreditTransferVisualRepresentation from './CreditTransferVisualRepresentation';
-import CreditTransferFormButtons from './CreditTransferFormButtons';
-import CreditTransferTerms from './CreditTransferTerms';
+
 import { getCreditTransferType } from '../../actions/creditTransfersActions';
+import Loading from '../../app/components/Loading';
+import * as Lang from '../../constants/langEnUs';
 
 const CreditTransferDetails = props => (
   <div className="credit-transfer">
@@ -52,11 +53,14 @@ const CreditTransferDetails = props => (
           </div>
         }
         <form onSubmit={e => e.preventDefault()}>
+          {(props.buttonActions.includes(Lang.BTN_SIGN_1_2) ||
+          props.buttonActions.includes(Lang.BTN_SIGN_2_2)) &&
           <CreditTransferTerms
             addToFields={props.addToFields}
             fields={props.fields}
             toggleCheck={props.toggleCheck}
           />
+          }
 
           <CreditTransferFormButtons
             actions={props.buttonActions}

--- a/frontend/src/credit_transfers/components/CreditTransferDetails.js
+++ b/frontend/src/credit_transfers/components/CreditTransferDetails.js
@@ -64,6 +64,8 @@ const CreditTransferDetails = props => (
             disabled={
               {
                 BTN_SIGN_1_2: props.fields.terms.findIndex(term => term.value === false) >= 0 ||
+                props.fields.terms.length === 0,
+                BTN_SIGN_2_2: props.fields.terms.findIndex(term => term.value === false) >= 0 ||
                 props.fields.terms.length === 0
               }
             }

--- a/frontend/src/credit_transfers/components/CreditTransferFormButtons.js
+++ b/frontend/src/credit_transfers/components/CreditTransferFormButtons.js
@@ -55,29 +55,33 @@ const CreditTransferFormButtons = props => (
         {Lang.BTN_SIGN_1_2}
       </button>
       }
-      {props.actions.includes(Lang.BTN_ACCEPT) &&
-      <button
-        className="btn btn-primary"
-        onClick={() => props.changeStatus(CREDIT_TRANSFER_STATUS.accepted)}
-        type="submit"
-      >
-        {Lang.BTN_ACCEPT}
-      </button>
-      }
       {props.actions.includes(Lang.BTN_REFUSE) &&
       <button
         className="btn btn-danger"
-        onClick={() => props.changeStatus(CREDIT_TRANSFER_STATUS.refused)}
-        type="submit"
+        data-target="#confirmRefuse"
+        data-toggle="modal"
+        type="button"
       >
         {Lang.BTN_REFUSE}
+      </button>
+      }
+      {props.actions.includes(Lang.BTN_SIGN_2_2) &&
+      <button
+        className="btn btn-primary"
+        data-target="#confirmAccept"
+        data-toggle="modal"
+        disabled={props.disabled.BTN_SIGN_2_2}
+        type="button"
+      >
+        {Lang.BTN_SIGN_2_2}
       </button>
       }
       {props.actions.includes(Lang.BTN_RESCIND) &&
       <button
         className="btn btn-danger"
-        onClick={() => props.changeStatus(CREDIT_TRANSFER_STATUS.rescinded)}
-        type="submit"
+        data-target="#confirmRescind"
+        data-toggle="modal"
+        type="button"
       >
         {Lang.BTN_RESCIND}
       </button>
@@ -88,7 +92,8 @@ const CreditTransferFormButtons = props => (
 
 CreditTransferFormButtons.defaultProps = {
   disabled: {
-    BTN_SIGN_1_2: true
+    BTN_SIGN_1_2: true,
+    BTN_SIGN_2_2: true
   }
 };
 
@@ -96,7 +101,8 @@ CreditTransferFormButtons.propTypes = {
   actions: PropTypes.arrayOf(PropTypes.string).isRequired,
   changeStatus: PropTypes.func.isRequired,
   disabled: PropTypes.shape({
-    BTN_SIGN_1_2: PropTypes.bool
+    BTN_SIGN_1_2: PropTypes.bool,
+    BTN_SIGN_2_2: PropTypes.bool
   }),
   id: PropTypes.number.isRequired
 };

--- a/frontend/src/credit_transfers/components/CreditTransferTerms.js
+++ b/frontend/src/credit_transfers/components/CreditTransferTerms.js
@@ -12,7 +12,10 @@ class CreditTransferTerms extends Component {
   }
 
   render () {
-    return this.props.signingAuthorityAssertions.map(assertion => (
+    let content = [(
+      <h3 className="terms-header" key="header">Signing Authority Declaration</h3>
+    )];
+    content = content.concat(this.props.signingAuthorityAssertions.map(assertion => (
       <div className="terms" key={assertion.id}>
         <div className="check">
           <CheckBox
@@ -24,7 +27,9 @@ class CreditTransferTerms extends Component {
         </div>
         <div>{assertion.description}</div>
       </div>
-    ));
+    )));
+
+    return content;
   }
 }
 

--- a/frontend/src/credit_transfers/components/CreditTransferTerms.js
+++ b/frontend/src/credit_transfers/components/CreditTransferTerms.js
@@ -15,6 +15,7 @@ class CreditTransferTerms extends Component {
     let content = [(
       <h3 className="terms-header" key="header">Signing Authority Declaration</h3>
     )];
+
     content = content.concat(this.props.signingAuthorityAssertions.map(assertion => (
       <div className="terms" key={assertion.id}>
         <div className="check">

--- a/frontend/src/credit_transfers/components/ModalDeleteCreditTransfer.js
+++ b/frontend/src/credit_transfers/components/ModalDeleteCreditTransfer.js
@@ -1,69 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import * as Lang from '../../constants/langEnUs';
+import Modal from '../../app/components/Modal';
 
 const ModalDeleteCreditTransfer = props => (
-  <div
-    className="modal fade"
+  <Modal
+    handleSubmit={props.handleSubmit}
     id="confirmDelete"
-    tabIndex="-1"
-    role="dialog"
-    aria-labelledby="confirmDeleteLabel"
+    key="confirmDelete"
   >
-    <div className="modal-dialog" role="document">
-      <div className="modal-content">
-        <div className="modal-header">
-          <button
-            type="button"
-            className="close"
-            data-dismiss="modal"
-            aria-label="Close"
-          >
-            <span aria-hidden="true">&times;</span>
-          </button>
-          <h4
-            className="modal-title"
-            id="confirmDeleteLabel"
-          >
-            Confirm Delete
-          </h4>
-        </div>
-        <div className="modal-body">
-          {props.message}
-        </div>
-        <div className="modal-footer">
-          <button
-            type="button"
-            className="btn btn-default"
-            data-dismiss="modal"
-          >
-            {Lang.BTN_NO}
-          </button>
-          <button
-            type="button"
-            className="btn btn-danger"
-            data-dismiss="modal"
-            onClick={() => props.deleteCreditTransfer(props.selectedId)}
-          >
-            {Lang.BTN_YES}
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
+    Do you want to delete this draft?
+  </Modal>
 );
 
-ModalDeleteCreditTransfer.defaultProps = {
-  deleteCreditTransfer: null,
-  message: 'Do you want to delete this credit transfer?',
-  selectedId: 0
-};
-
 ModalDeleteCreditTransfer.propTypes = {
-  deleteCreditTransfer: PropTypes.func,
-  message: PropTypes.string,
-  selectedId: PropTypes.number
+  handleSubmit: PropTypes.func.isRequired
 };
 
 export default ModalDeleteCreditTransfer;

--- a/frontend/src/credit_transfers/components/ModalSubmitCreditTransfer.js
+++ b/frontend/src/credit_transfers/components/ModalSubmitCreditTransfer.js
@@ -1,68 +1,48 @@
+import numeral from 'numeral';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import * as Lang from '../../constants/langEnUs';
+import Modal from '../../app/components/Modal';
+import * as NumberFormat from '../../constants/numeralFormats';
 
 const ModalSubmitCreditTransfer = props => (
-  <div
-    className="modal fade"
-    id={props.id}
-    tabIndex="-1"
-    role="dialog"
-    aria-labelledby="confirmSubmitLabel"
+  <Modal
+    handleSubmit={props.handleSubmit}
+    id="confirmSubmit"
+    key="confirmSubmit"
   >
-    <div className="modal-dialog" role="document">
-      <div className="modal-content">
-        <div className="modal-header">
-          <button
-            type="button"
-            className="close"
-            data-dismiss="modal"
-            aria-label="Close"
-          >
-            <span aria-hidden="true">&times;</span>
-          </button>
-          <h4
-            className="modal-title"
-            id="confirmSubmitLabel"
-          >
-            Confirm Submission
-          </h4>
-        </div>
-        <div className="modal-body">
-          {props.message}
-        </div>
-        <div className="modal-footer">
-          <button
-            type="button"
-            className="btn btn-default"
-            data-dismiss="modal"
-          >
-            {Lang.BTN_NO}
-          </button>
-          <button
-            type="button"
-            className="btn btn-primary"
-            data-dismiss="modal"
-            onClick={props.submitCreditTransfer}
-          >
-            {Lang.BTN_YES}
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
+    <h5><b>Credit Transfer Proposal Summary</b></h5>
+    <p>
+      Credits From: {props.item.creditsFrom.name} <br />
+      Credits To: {props.item.creditsTo.name} <br />
+      Quantity of credits to be transferred: {props.item.numberOfCredits} <br />
+      Value per credit: {numeral(props.item.fairMarketValuePerCredit).format(NumberFormat.CURRENCY)}
+    </p>
+    <p>
+      Are you sure you want to sign and send this Credit Transfer Proposal
+      to {props.item.creditsTo.name}?
+    </p>
+  </Modal>
 );
 
-ModalSubmitCreditTransfer.defaultProps = {
-  submitCreditTransfer: null,
-  message: 'Do you want to sign and send this document to the other party named in this transfer?'
-};
-
 ModalSubmitCreditTransfer.propTypes = {
-  id: PropTypes.string.isRequired,
-  submitCreditTransfer: PropTypes.func,
-  message: PropTypes.string
+  handleSubmit: PropTypes.func.isRequired,
+  item: PropTypes.shape({
+    creditsFrom: PropTypes.shape({
+      name: PropTypes.string
+    }),
+    creditsTo: PropTypes.shape({
+      name: PropTypes.string
+    }),
+    fairMarketValuePerCredit: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ]),
+    numberOfCredits: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ])
+  }).isRequired
 };
 
 export default ModalSubmitCreditTransfer;

--- a/frontend/src/credit_transfers/components/ModalSubmitCreditTransfer.js
+++ b/frontend/src/credit_transfers/components/ModalSubmitCreditTransfer.js
@@ -6,7 +6,7 @@ import * as Lang from '../../constants/langEnUs';
 const ModalSubmitCreditTransfer = props => (
   <div
     className="modal fade"
-    id="confirmSubmit"
+    id={props.id}
     tabIndex="-1"
     role="dialog"
     aria-labelledby="confirmSubmitLabel"
@@ -60,6 +60,7 @@ ModalSubmitCreditTransfer.defaultProps = {
 };
 
 ModalSubmitCreditTransfer.propTypes = {
+  id: PropTypes.string.isRequired,
   submitCreditTransfer: PropTypes.func,
   message: PropTypes.string
 };

--- a/frontend/styles/CreditTransfers.scss
+++ b/frontend/styles/CreditTransfers.scss
@@ -212,6 +212,10 @@
     }
   }
 
+  .terms-header {
+    margin-bottom: 15px;
+  }
+
   .well {
     &.transparent {
       background-color: transparent;


### PR DESCRIPTION
#290 #293 #294 #295 #297

This captures the confirmations from the user when they're about to propose a Credit Transfer, or when the other part responds to the proposal.

Changelog:
- Signing Confirmation Model
- Signing Confirmation Serializer
- Signing Confirmation Viewset
- Refactored Modal so it's more abstracted
- Changed logic on how some buttons and modals are added