### PR TITLE
Fixed delete and update not working in admin

### DIFF
--- a/backend/api/services/CreditTradeService.py
+++ b/backend/api/services/CreditTradeService.py
@@ -26,14 +26,14 @@ class CreditTradeService(object):
             # Government
             """
             If organization == Government
-              don't show "Cancelled", "Accepted" transactions
+              don't show "Cancelled" transactions
               don't show "Draft", "Submitted" transactions unless the
               initiator was government
               (Please note that government creating drafts and submitted is
               for testing only, in reality government will not do this)
             """
             credit_trades = CreditTrade.objects.filter(
-                ~Q(status__status__in=["Cancelled", "Approved"]) &
+                ~Q(status__status__in=["Cancelled"]) &
                 (~Q(status__status__in=["Draft", "Submitted"]) |
                  Q(initiator=organization))
             )
@@ -41,14 +41,14 @@ class CreditTradeService(object):
             # Fuel suppliers
             """
             If organization == Fuel Supplier
-              don't show "Cancelled", "Accepted" transactions
+              don't show "Cancelled" transactions
               don't show "Draft" transactions unless the initiator was
               the fuel supplier
               show "Submitted" and other transactions where the fuel
               supplier is the respondent
             """
             credit_trades = CreditTrade.objects.filter(
-                ~Q(status__status__in=["Cancelled", "Approved"]) &
+                ~Q(status__status__in=["Cancelled"]) &
                 ((~Q(status__status__in=["Draft"]) &
                  Q(respondent=organization)) |
                  Q(initiator=organization))

--- a/backend/api/services/CreditTradeService.py
+++ b/backend/api/services/CreditTradeService.py
@@ -49,7 +49,7 @@ class CreditTradeService(object):
             """
             credit_trades = CreditTrade.objects.filter(
                 ~Q(status__status__in=["Cancelled"]) &
-                ((~Q(status__status__in=["Draft"]) &
+                (~Q(status__status__in=["Draft"] &
                  Q(respondent=organization)) |
                  Q(initiator=organization))
             )

--- a/backend/api/test_credit_trades.py
+++ b/backend/api/test_credit_trades.py
@@ -487,12 +487,7 @@ class TestCreditTrades(TestCase):
     # As a government user
     # I shouldn't see drafts unless I'm the initiator
     # I shouldn't see cancelled transfers as they're considered (deleted)
-    # I shouldn't see approved transfers as they're the intermediate step
-    # before being completed
     def test_get_organization_credit_trades_gov(self):
-        approved_status, created = CreditTradeStatus.objects.get_or_create(
-            status='Approved')
-
         completed_status, created = CreditTradeStatus.objects.get_or_create(
             status='Completed')
 
@@ -539,18 +534,6 @@ class TestCreditTrades(TestCase):
             trade_effective_date=datetime.datetime.
             today().strftime('%Y-%m-%d'))
 
-        # the function shouldn't see this as it's approved
-        approved_credit_trade = CreditTrade.objects.create(
-            status=approved_status,
-            initiator=from_organization,
-            respondent=to_organization,
-            type=credit_trade_type,
-            number_of_credits=1000,
-            fair_market_value_per_credit=1,
-            zero_reason=None,
-            trade_effective_date=datetime.datetime.
-            today().strftime('%Y-%m-%d'))
-
         # the function should see this as it's completed
         completed_credit_trade = CreditTrade.objects.create(
             status=completed_status,
@@ -569,19 +552,13 @@ class TestCreditTrades(TestCase):
 
         self.assertNotIn(draft_credit_trade, credit_trades)
         self.assertIn(draft_credit_trade_from_gov, credit_trades)
-        self.assertNotIn(approved_credit_trade, credit_trades)
         self.assertIn(completed_credit_trade, credit_trades)
 
     # As a fuel supplier
     # I shouldn't see drafts unless I'm the initiator
     # I shouldn't see cancelled transfers as they're considered (deleted)
-    # I shouldn't see approved transfers as they're the intermediate step
-    # before being completed
     # I shouldn't see submitted transfers unless I'm involved somehow
     def test_get_organization_credit_trades_fuel_supplier(self):
-        approved_status, created = CreditTradeStatus.objects.get_or_create(
-            status='Approved')
-
         completed_status, created = CreditTradeStatus.objects.get_or_create(
             status='Completed')
 
@@ -662,18 +639,6 @@ class TestCreditTrades(TestCase):
             trade_effective_date=datetime.datetime.
             today().strftime('%Y-%m-%d'))
 
-        # the function shouldn't see this as it's approved
-        approved_credit_trade = CreditTrade.objects.create(
-            status=approved_status,
-            initiator=test_organization_1,
-            respondent=test_organization_2,
-            type=credit_trade_type,
-            number_of_credits=1000,
-            fair_market_value_per_credit=1,
-            zero_reason=None,
-            trade_effective_date=datetime.datetime.
-            today().strftime('%Y-%m-%d'))
-
         # the function should see this as it's completed
         completed_credit_trade = CreditTrade.objects.create(
             status=completed_status,
@@ -694,5 +659,4 @@ class TestCreditTrades(TestCase):
         self.assertIn(draft_credit_trade_from_fuel_supplier, credit_trades)
         self.assertNotIn(submitted_credit_trade, credit_trades)
         self.assertIn(submitted_credit_trade_as_respondent, credit_trades)
-        self.assertNotIn(approved_credit_trade, credit_trades)
         self.assertIn(completed_credit_trade, credit_trades)

--- a/backend/api/viewsets/CreditTrade.py
+++ b/backend/api/viewsets/CreditTrade.py
@@ -18,6 +18,8 @@ from api.serializers import CreditTradeHistory2Serializer \
 
 from api.services.CreditTradeService import CreditTradeService
 
+from django.db.models import Q
+
 
 class CreditTradeViewSet(AuditableMixin, mixins.CreateModelMixin,
                          mixins.RetrieveModelMixin, mixins.UpdateModelMixin,
@@ -56,6 +58,15 @@ class CreditTradeViewSet(AuditableMixin, mixins.CreateModelMixin,
         user = self.request.user
         return CreditTradeService.get_organization_credit_trades(
             user.organization)
+
+    def list(self, request):
+        credit_trades = self.get_queryset().filter(
+            ~Q(status__status__in=["Approved"])
+        ).order_by(*self.ordering)
+
+        serializer = self.get_serializer(credit_trades, many=True)
+
+        return Response(serializer.data)
 
     def perform_create(self, serializer):
         credit_trade = serializer.save()


### PR DESCRIPTION
#286 

I found an issue where delete and update stopped working because of the recent changes to the queryset. This is to fix that issue

Changelog:
- "Approved" is no longer automatically filtered out
- List now filters out Approved
- Updated unit tests to accommodate the changes