### PR TITLE
Added a StatusInterceptor on a more generic level.

### DIFF
--- a/frontend/__tests__/app/components/__snapshots__/StatusInterceptor.js.snap
+++ b/frontend/__tests__/app/components/__snapshots__/StatusInterceptor.js.snap
@@ -55,7 +55,7 @@ exports[`StatusInterceptor should display the proper message for 500 errors 1`] 
     We're sorry.
   </p>
   <p>
-    It looks like our system is experiencing some technical difficulties.. We have been notified and will look into it. Please try again later.
+    It looks like our system is experiencing some technical difficulties. We have been notified and will look into it. Please try again later.
   </p>
 </div>
 `;
@@ -69,7 +69,7 @@ exports[`StatusInterceptor should display the proper message for 502 errors 1`] 
     We're sorry.
   </p>
   <p>
-    It looks like our system is experiencing some technical difficulties.. We have been notified and will look into it. Please try again later.
+    It looks like our system is experiencing some technical difficulties. We have been notified and will look into it. Please try again later.
   </p>
 </div>
 `;

--- a/frontend/src/admin/historical_data_entry/HistoricalDataEntryContainer.js
+++ b/frontend/src/admin/historical_data_entry/HistoricalDataEntryContainer.js
@@ -171,7 +171,10 @@ HistoricalDataEntryContainer.defaultProps = {
 
 HistoricalDataEntryContainer.propTypes = {
   addCreditTransfer: PropTypes.func.isRequired,
-  addErrors: PropTypes.shape({}),
+  addErrors: PropTypes.oneOfType([
+    PropTypes.shape({}),
+    PropTypes.string
+  ]),
   commitErrors: PropTypes.shape({}),
   commitMessage: PropTypes.string,
   compliancePeriods: PropTypes.arrayOf(PropTypes.shape()).isRequired,

--- a/frontend/src/admin/historical_data_entry/components/HistoricalDataEntryForm.js
+++ b/frontend/src/admin/historical_data_entry/components/HistoricalDataEntryForm.js
@@ -39,7 +39,10 @@ HistoricalDataEntryForm.propTypes = {
   actions: PropTypes.arrayOf(PropTypes.string).isRequired,
   compliancePeriods: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   editMode: PropTypes.bool,
-  errors: PropTypes.shape({}).isRequired,
+  errors: PropTypes.oneOfType([
+    PropTypes.shape({}),
+    PropTypes.string
+  ]).isRequired,
   fuelSuppliers: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   fields: PropTypes.shape({
     compliancePeriod: PropTypes.shape({

--- a/frontend/src/admin/historical_data_entry/components/HistoricalDataEntryPage.js
+++ b/frontend/src/admin/historical_data_entry/components/HistoricalDataEntryPage.js
@@ -74,7 +74,10 @@ const HistoricalDataEntryPage = (props) => {
 };
 
 HistoricalDataEntryPage.propTypes = {
-  addErrors: PropTypes.shape({}).isRequired,
+  addErrors: PropTypes.oneOfType([
+    PropTypes.shape({}),
+    PropTypes.string
+  ]).isRequired,
   commitErrors: PropTypes.shape({}).isRequired,
   commitMessage: PropTypes.string.isRequired,
   compliancePeriods: PropTypes.arrayOf(PropTypes.shape()).isRequired,

--- a/frontend/src/app/App.js
+++ b/frontend/src/app/App.js
@@ -12,14 +12,12 @@ import StatusInterceptor from './components/StatusInterceptor';
 
 const App = (props) => {
   let content;
-  if (!props.userRequest.isFetching && props.isAuthenticated) {
+  if (props.errorRequest.hasErrors && props.errorRequest.error.status) {
+    content = <StatusInterceptor statusCode={props.errorRequest.error.status} />;
+  } else if (!props.userRequest.isFetching && props.isAuthenticated) {
     content = props.children;
   } else if (!props.userRequest.isFetching) {
     content = <StatusInterceptor statusCode={props.userRequest.error.status} />;
-  }
-
-  if (props.errorRequest.hasErrors && props.errorRequest.error.status) {
-    content = <StatusInterceptor statusCode={props.errorRequest.error.status} />;
   }
 
   return (

--- a/frontend/src/app/App.js
+++ b/frontend/src/app/App.js
@@ -15,7 +15,11 @@ const App = (props) => {
   if (!props.userRequest.isFetching && props.isAuthenticated) {
     content = props.children;
   } else if (!props.userRequest.isFetching) {
-    content = (<StatusInterceptor statusCode={props.userRequest.error.status} />);
+    content = <StatusInterceptor statusCode={props.userRequest.error.status} />;
+  }
+
+  if (props.errorRequest.hasErrors && props.errorRequest.error.status) {
+    content = <StatusInterceptor statusCode={props.errorRequest.error.status} />;
   }
 
   return (
@@ -31,11 +35,26 @@ const App = (props) => {
   );
 };
 
+App.defaultProps = {
+  errorRequest: {
+    error: {
+    },
+    hasErrors: false
+  }
+};
+
 App.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired,
+  errorRequest: PropTypes.shape({
+    error: PropTypes.shape({
+      status: PropTypes.number,
+      statusText: PropTypes.string
+    }),
+    hasErrors: PropTypes.bool
+  }),
   loggedInUser: PropTypes.shape({
     displayName: PropTypes.string,
     organization: PropTypes.shape({
@@ -53,6 +72,10 @@ App.propTypes = {
 };
 
 export default withRouter(connect(state => ({
+  errorRequest: {
+    error: state.rootReducer.errorRequest.errorMessage,
+    hasErrors: state.rootReducer.errorRequest.hasErrors
+  },
   loggedInUser: state.rootReducer.userRequest.loggedInUser,
   isAuthenticated: state.rootReducer.userRequest.isAuthenticated,
   userRequest: {

--- a/frontend/src/app/components/Errors.js
+++ b/frontend/src/app/components/Errors.js
@@ -4,7 +4,16 @@ import PropTypes from 'prop-types';
 const Errors = props => (
   <div className="alert alert-danger">
     <h1>{props.title}</h1>
-    { Object.keys(props.errors).length > 0 &&
+    { typeof (props.errors) === 'string' &&
+      <p>{props.errors}</p>
+    }
+    { typeof (props.errors) === 'object' &&
+      Object.prototype.hasOwnProperty.call(props.errors, 'statusText') &&
+      <p>{props.errors.statusText}</p>
+    }
+    { typeof (props.errors) === 'object' &&
+      !Object.prototype.hasOwnProperty.call(props.errors, 'statusText') &&
+      Object.keys(props.errors).length > 0 &&
       Object.keys(props.errors).map(error => (
         <p key={error}>({error}) {props.errors[error]}</p>
       ))
@@ -17,7 +26,10 @@ Errors.defaultProps = {
 };
 
 Errors.propTypes = {
-  errors: PropTypes.shape({}).isRequired,
+  errors: PropTypes.oneOfType([
+    PropTypes.shape({}),
+    PropTypes.string
+  ]).isRequired,
   title: PropTypes.string
 };
 

--- a/frontend/src/app/components/StatusInterceptor.js
+++ b/frontend/src/app/components/StatusInterceptor.js
@@ -45,7 +45,7 @@ class StatusInterceptor extends Component {
     return (
       <div className="alert alert-danger error-alert" role="alert">
         <p>We&apos;re sorry.</p>
-        <p>It looks like our system is experiencing some technical difficulties.. We have been
+        <p>It looks like our system is experiencing some technical difficulties. We have been
           notified and will look into it. Please try again later.
         </p>
       </div>
@@ -56,7 +56,7 @@ class StatusInterceptor extends Component {
     return (
       <div className="alert alert-danger error-alert" role="alert">
         <p>We&apos;re sorry.</p>
-        <p>It looks like our system is experiencing some technical difficulties.. We have been
+        <p>It looks like our system is experiencing some technical difficulties. We have been
           notified and will look into it. Please try again later.
         </p>
       </div>

--- a/frontend/src/app/components/StatusInterceptor.js
+++ b/frontend/src/app/components/StatusInterceptor.js
@@ -32,6 +32,15 @@ class StatusInterceptor extends Component {
     );
   }
 
+  static render404Message () {
+    return (
+      <div className="alert alert-danger error-alert" role="alert">
+        <p>The requested page could not be found.</p>
+        <p>To trade this page for a valid one click <a href="/">here</a> or learn more about the Renewable and Low Carbon Fuel Requirements Regulation <a href="http://www.gov.bc.ca/lowcarbonfuels/" rel="noopener noreferrer" target="_blank">here</a></p>
+      </div>
+    );
+  }
+
   static render500Message () {
     return (
       <div className="alert alert-danger error-alert" role="alert">
@@ -69,6 +78,8 @@ class StatusInterceptor extends Component {
         return StatusInterceptor.render401Message();
       case 403:
         return StatusInterceptor.render403Message();
+      case 404:
+        return StatusInterceptor.render404Message();
       case 500:
         return StatusInterceptor.render500Message();
       case 502:

--- a/frontend/src/credit_transfers/CreditTransferViewContainer.js
+++ b/frontend/src/credit_transfers/CreditTransferViewContainer.js
@@ -254,6 +254,10 @@ class CreditTransferViewContainer extends Component {
   }
 }
 
+CreditTransferViewContainer.defaultProps = {
+  item: {}
+};
+
 CreditTransferViewContainer.propTypes = {
   addSigningAuthorityConfirmation: PropTypes.func.isRequired,
   deleteCreditTransfer: PropTypes.func.isRequired,
@@ -277,7 +281,7 @@ CreditTransferViewContainer.propTypes = {
       PropTypes.number
     ]),
     actions: PropTypes.arrayOf(PropTypes.shape({}))
-  }).isRequired,
+  }),
   loggedInUser: PropTypes.shape({
     displayName: PropTypes.string,
     organization: PropTypes.shape({

--- a/frontend/src/reducers/errorReducer.js
+++ b/frontend/src/reducers/errorReducer.js
@@ -1,0 +1,23 @@
+const errorRequest = (state = {
+  errorMessage: {},
+  hasErrors: false
+}, action) => {
+  switch (action.type) {
+    case 'ERROR':
+      return {
+        ...state,
+        errorMessage: action.errorMessage,
+        hasErrors: true
+      };
+    case '@@router/LOCATION_CHANGE':
+      return {
+        ...state,
+        errorMessage: {},
+        hasErrors: false
+      };
+    default:
+      return state;
+  }
+};
+
+export default errorRequest;

--- a/frontend/src/reducers/reducer.js
+++ b/frontend/src/reducers/reducer.js
@@ -8,6 +8,7 @@ import { creditTransfer, creditTransfers } from './creditTransferReducer';
 import { userRequest, usersRequest } from './userReducer';
 
 import { organizationRequest, organizations, fuelSuppliersRequest } from './organizationReducer';
+import errorRequest from './errorReducer';
 import compliancePeriods from './compliancePeriodReducer';
 import signingAuthorityAssertions from './signingAuthorityAssertionReducer';
 
@@ -104,6 +105,7 @@ const rootReducer = combineReducers({
   organizations,
   signingAuthorityAssertions,
   fuelSuppliersRequest,
+  errorRequest,
   routing
 });
 export default rootReducer;


### PR DESCRIPTION
#308 

Improved the error handling for inaccessible credit transfers and 500 errors better.

Changelog:
- Create 404 render
- Viewing a transaction ID that doesn't exist (or unauthorized for the logged in user should show a 404
- Fixed the error message display a single vertical line when a 500 error occurs
- Fixed various errors where it doesn't render anything when navigating away after receiving an error