### PR TITLE
Fixed pluralization for credits when it's over 999

### DIFF
--- a/frontend/src/credit_transfers/components/CreditTransferTextRepresentation.js
+++ b/frontend/src/credit_transfers/components/CreditTransferTextRepresentation.js
@@ -36,7 +36,7 @@ class CreditTransferTextRepresentation extends Component {
     return (
       <div className="text-representation">
         <span className="value">{this.creditsTo}</span> {this._buyAction()}
-        <span className="value"> {this.numberOfCredits} </span> credit{(this.numberOfCredits > 1) && 's'} from
+        <span className="value"> {this.numberOfCredits} </span> credit{(this.props.numberOfCredits > 1) && 's'} from
         <span className="value"> {this.creditsFrom} </span>
         for <span className="value"> {this.totalValue} </span>
         effective on <span className="value"> {this.tradeEffectiveDate}</span>.
@@ -48,7 +48,7 @@ class CreditTransferTextRepresentation extends Component {
     return (
       <div className="text-representation">
         A credit transfer of
-        <span className="value"> {this.numberOfCredits} </span> credit{(this.numberOfCredits > 1) && 's'} for
+        <span className="value"> {this.numberOfCredits} </span> credit{(this.props.numberOfCredits > 1) && 's'} for
         <span className="value"> {this.creditsTo} </span>
         has been <span className="value lowercase"> {this.tradeStatus} </span>
         effective on <span className="value"> {this.tradeEffectiveDate}</span>.
@@ -61,7 +61,7 @@ class CreditTransferTextRepresentation extends Component {
       <div className="text-representation">
         An <span className="value">award</span> of
         <span className="value"> {this.numberOfCredits} </span>
-        credit{(this.numberOfCredits > 1) && 's'} earned by
+        credit{(this.props.numberOfCredits > 1) && 's'} earned by
         <span className="value"> {this.creditsTo} </span> for the completion of a
         Part 3 Agreement has been <span className="value lowercase"> {this.tradeStatus}</span>,
         effective on <span className="value"> {this.tradeEffectiveDate}</span>.
@@ -74,7 +74,7 @@ class CreditTransferTextRepresentation extends Component {
       <div className="text-representation">
         A <span className="value">reduction</span> of
         <span className="value"> {this.numberOfCredits} </span>
-        credit{(this.numberOfCredits > 1) && 's'} earned by
+        credit{(this.props.numberOfCredits > 1) && 's'} earned by
         <span className="value"> {this.creditsFrom} </span>
         has been <span className="value lowercase"> {this.tradeStatus}</span>,
         effective on <span className="value"> {this.tradeEffectiveDate}</span>.
@@ -86,7 +86,7 @@ class CreditTransferTextRepresentation extends Component {
     return (
       <div className="text-representation">
         <span className="value">{this.creditsFrom}</span> {this._sellAction()}
-        <span className="value"> {this.numberOfCredits} </span> credit{(this.numberOfCredits > 1) && 's'} to
+        <span className="value"> {this.numberOfCredits} </span> credit{(this.props.numberOfCredits > 1) && 's'} to
         <span className="value"> {this.creditsTo} </span>
         for <span className="value"> {this.fairMarketValuePerCredit} </span> per credit
         for a total value of <span className="value"> {this.totalValue}</span>,
@@ -100,7 +100,7 @@ class CreditTransferTextRepresentation extends Component {
       <div className="text-representation">
         A <span className="value">validation</span> of
         <span className="value"> {this.numberOfCredits} </span>
-        credit{(this.numberOfCredits > 1) && 's'} earned by
+        credit{(this.props.numberOfCredits > 1) && 's'} earned by
         <span className="value"> {this.creditsTo} </span>
         has been <span className="value lowercase"> {this.tradeStatus}</span>,
         effective on <span className="value"> {this.tradeEffectiveDate}</span>.

--- a/frontend/src/credit_transfers/components/CreditTransferVisualRepresentation.js
+++ b/frontend/src/credit_transfers/components/CreditTransferVisualRepresentation.js
@@ -20,7 +20,7 @@ class CreditTransferVisualRepresentation extends Component {
         </div>
         <div className="col-sm-4 col-md-5">
           <div className="arrow">
-            <div>{numeral(this.props.numberOfCredits).format(NumberFormat.INT)} credit{this.props.numberOfCredits > 2 && 's'}</div>
+            <div>{numeral(this.props.numberOfCredits).format(NumberFormat.INT)} credit{this.props.numberOfCredits > 1 && 's'}</div>
             <FontAwesomeIcon icon="arrow-alt-circle-up" size="4x" />
             <div>{getCreditTransferType(this.props.tradeType.id)}</div>
           </div>


### PR DESCRIPTION
#324 

The issue was being caused by the comma when it's over 999 number of credits. So the fix is simply to do a check against numeric version of number of credits instead.

Changelog:
- Changed the condition to look into this.props.numberOfCredits, instead of this.numberOfCredits (which is a string)
- Updated condition in Visual Representation so pluralization occurs when the number of credits is over 1 (instead of 2)