### PR TITLE
Added 2 test fuel suppliers and 2 test users

### DIFF
--- a/backend/api/fixtures/test_organization_for_basic_bceid.json
+++ b/backend/api/fixtures/test_organization_for_basic_bceid.json
@@ -1,0 +1,22 @@
+[
+  {
+    "fields": {
+      "name": "TFRS Fantastic Fuels",
+      "actions_type": 1,
+      "status": 1,
+      "type_id": 2
+    },
+    "model": "api.organization",
+    "pk": null
+  },
+  {
+    "fields": {
+      "name": "TFRS IMBeing Green",
+      "actions_type": 1,
+      "status": 1,
+      "type_id": 2
+    },
+    "model": "api.organization",
+    "pk": null
+  }
+]

--- a/backend/api/fixtures/test_users_basic_bceid.json
+++ b/backend/api/fixtures/test_users_basic_bceid.json
@@ -1,0 +1,26 @@
+[
+  {
+    "fields": {
+        "email": "justin.lepitzki@gmail.com",
+        "username": "business_justin.lepitzki",
+        "authorization_id": "justin.lepitzki",
+        "first_name": "Justin",
+        "last_name": "Lepitzki",
+        "organization": ["TFRS Fantastic Fuels"]
+    },
+    "model": "api.user",
+    "pk": null
+  },
+  {
+    "fields": {
+        "email": "jll7@sfu.ca",
+        "username": "business_justin.wakelam",
+        "authorization_id": "justin.wakelam",
+        "first_name": "Justin",
+        "last_name": "Wakelam",
+        "organization": ["TFRS IMBeing Green"]
+    },
+    "model": "api.user",
+    "pk": null
+  }
+]

--- a/backend/api/managers/OrganizationManager.py
+++ b/backend/api/managers/OrganizationManager.py
@@ -1,0 +1,29 @@
+"""
+    REST API Documentation for the NRS TFRS Credit Trading Application
+
+    The Transportation Fuels Reporting System is being designed to streamline
+    compliance reporting for transportation fuel suppliers in accordance with
+    the Renewable & Low Carbon Fuel Requirements Regulation.
+
+    OpenAPI spec version: v1
+
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+from django.db import models
+
+
+class OrganizationManager(models.Manager):
+    def get_by_natural_key(self, name):
+        return self.get(name=name)

--- a/backend/api/models/Organization.py
+++ b/backend/api/models/Organization.py
@@ -26,6 +26,8 @@ from .OrganizationActionsType import OrganizationActionsType
 from .OrganizationBalance import OrganizationBalance
 from .OrganizationStatus import OrganizationStatus
 
+from api.managers.OrganizationManager import OrganizationManager
+
 from auditable.models import Auditable
 
 
@@ -44,6 +46,7 @@ class Organization(Auditable):
         related_name='organizations',
         blank=True, null=True,
         on_delete=models.PROTECT)
+    objects = OrganizationManager()
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
#330

Added fixtures to setup test basic accounts and test fuel suppliers.

Changelog:
- Added users fixture
- Added fuel suppliers fixture
- Added OrganizationManager so we don't have to know what the primary keys are for the new organizations before we can apply the fixture