### PR TITLE
Added a script to fix the effective dates for completed transactions

### DIFF
--- a/backend/api/scripts/update_effective_dates.py
+++ b/backend/api/scripts/update_effective_dates.py
@@ -1,0 +1,48 @@
+from api.models.CreditTrade import CreditTrade
+from api.models.CreditTradeHistory import CreditTradeHistory
+from api.models.CreditTradeStatus import CreditTradeStatus
+
+
+def run():
+    status_approved = CreditTradeStatus.objects \
+                                        .get(status="Approved")
+
+    status_completed = CreditTradeStatus.objects \
+                                        .get(status="Completed")
+
+    # Get all completed credit transfers
+    credit_trades = CreditTrade.objects.filter(
+        status_id=status_completed.id).order_by('-id')
+
+    for credit_trade in credit_trades:
+        '''
+        as we loop through the completed credit trades,
+        look at the history, and check what the last effective was
+        before it was completed
+        '''
+        credit_trade_history = CreditTradeHistory.objects.filter(
+            credit_trade_id=credit_trade.id,
+            status_id=status_approved.id
+        ).order_by('-update_timestamp', '-id').first()
+
+        if credit_trade_history:
+            credit_trade_history_complete = CreditTradeHistory.objects.filter(
+                credit_trade_id=credit_trade.id,
+                status_id=status_completed.id
+            ).order_by('-update_timestamp', '-id').first()
+
+            if credit_trade_history_complete.trade_effective_date != \
+               credit_trade_history.trade_effective_date and \
+               credit_trade_history.trade_effective_date is not None:
+                '''
+                Update the history that has a status completed
+                so it uses the that effective date
+                '''
+                credit_trade_history_complete.trade_effective_date = \
+                    credit_trade_history.trade_effective_date
+                credit_trade_history_complete.save()
+
+                # Update the credit trade
+                credit_trade.trade_effective_date = \
+                    credit_trade_history.trade_effective_date
+                credit_trade.save()


### PR DESCRIPTION
#354 

This is the script that we can run to fix the effective dates for PROD.

It looks back at the history and looks at the last effective fate before it was marked as completed.

To run the script you can execute:
`python manage.py runscript update_effective_dates`

You can add `--traceback` at the end to show more information if an error occurred.