### PR TITLE
Removed sort by fuel suppliers in credit transactions. Applied the so…

### DIFF
--- a/frontend/src/admin/historical_data_entry/components/HistoricalDataTable.js
+++ b/frontend/src/admin/historical_data_entry/components/HistoricalDataTable.js
@@ -145,6 +145,10 @@ const HistoricalDataTable = (props) => {
     <ReactTable
       data={props.items}
       defaultPageSize={5}
+      defaultSorted={[{
+        id: 'id',
+        desc: true
+      }]}
       filterable={filterable}
       defaultFilterMethod={filterMethod}
       columns={columns}

--- a/frontend/src/credit_transfers/components/CreditTransferTable.js
+++ b/frontend/src/credit_transfers/components/CreditTransferTable.js
@@ -93,8 +93,6 @@ const CreditTransferTable = (props) => {
     id: 'fairMarketValuePerCredit',
     minWidth: 100
   }, {
-    id: 'status',
-    Header: 'Status',
     accessor: item => (Object.entries(CREDIT_TRANSFER_STATUS).find(([, value]) =>
       (value.id === item.status.id))[1].description),
     className: 'col-status',
@@ -135,11 +133,8 @@ const CreditTransferTable = (props) => {
       data={props.items}
       defaultPageSize={15}
       defaultSorted={[{
-        id: 'creditsFrom',
-        desc: false
-      }, {
-        id: 'creditsTo',
-        desc: false
+        id: 'id',
+        desc: true
       }]}
       filterable={filterable}
       pageSizeOptions={[5, 10, 15, 20, 25, 50, 100]}

--- a/frontend/src/organizations/components/OrganizationsTable.js
+++ b/frontend/src/organizations/components/OrganizationsTable.js
@@ -74,6 +74,10 @@ const OrganizationsTable = (props) => {
     <ReactTable
       data={props.items}
       defaultPageSize={15}
+      defaultSorted={[{
+        id: 'name',
+        desc: false
+      }]}
       filterable={filterable}
       pageSizeOptions={[5, 10, 15, 20, 25, 50, 100]}
       defaultFilterMethod={filterMethod}


### PR DESCRIPTION
#364

Completely misunderstood the issue. Sorting should be applied to Fuel Suppliers **Tab**, not Credit Transactions

Changelog:
- Removed default sorting of Fuel Suppliers in Credit Transactions
- Added default sorting to Fuel Suppliers
- Added default sorting to Credit Transactions (ID Desc)
  - This is so that we have an inidicator on the table on how it's being sorted
- Added default sorting to Historical Data Entry (ID Desc)
  - This is so that we have an inidicator on the table on how it's being sorted
