### PR TITLE
Unit Testing Fix

### DIFF
--- a/backend/api/permissions/CreditTradeComment.py
+++ b/backend/api/permissions/CreditTradeComment.py
@@ -10,8 +10,7 @@ class CreditTradeCommentPermissions(permissions.BasePermission):
             return True
 
         # Need this information to make a decision
-        if not (request.data.has_key('privileged_access') and
-                request.data.has_key('credit_trade')):
+        if not (('privileged_access' in request.data) and ('credit_trade' in request.data)):
             return False
 
         credit_trade = request.data['credit_trade']


### PR DESCRIPTION
Python3 Compatibility Fix

Adjusted permission class to use `'key' in dict` format rather than
dict.has_key('key').

Confirmed working with Python 3.6.4