### PR TITLE
Added Declined indicator in the breadcrumbs

### DIFF
--- a/backend/api/migrations/0012_credittradecomment_squashed_0014_auto_20180613_2324.py
+++ b/backend/api/migrations/0012_credittradecomment_squashed_0014_auto_20180613_2324.py
@@ -9,8 +9,6 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    replaces = [(b'api', '0012_credittradecomment'), (b'api', '0013_auto_20180613_2318'), (b'api', '0014_auto_20180613_2324')]
-
     dependencies = [
         ('api', '0011_auto_20180613_1848'),
     ]

--- a/frontend/src/credit_transfers/components/CreditTransferProgress.js
+++ b/frontend/src/credit_transfers/components/CreditTransferProgress.js
@@ -26,6 +26,17 @@ class CreditTransferProgress extends Component {
     );
   }
 
+  _addStepDeclined () {
+    return (
+      <div
+        className={`step ${(this.props.status.id === CREDIT_TRANSFER_STATUS.declinedForApproval.id) ? 'cancelled' : ''}`}
+        key={CREDIT_TRANSFER_STATUS.declinedForApproval.id}
+      >
+        <span>{CREDIT_TRANSFER_STATUS.declinedForApproval.description}</span>
+      </div>
+    );
+  }
+
   _addStepDraft () {
     return (
       <div
@@ -116,7 +127,11 @@ class CreditTransferProgress extends Component {
       view.push(this._addStepRecommended());
     }
 
-    view.push(this._addStepCompleted());
+    if (this.props.status.id === CREDIT_TRANSFER_STATUS.declinedForApproval.id) {
+      view.push(this._addStepDeclined());
+    } else {
+      view.push(this._addStepCompleted());
+    }
 
     return view;
   }


### PR DESCRIPTION
#385 

Declined functionality has already been applied. This just updates the breadcrumbs accordingly.

Changelog:
- Updated the breadcrumbs so it shows Declined instead of Approved (if the status was actually declined)
- Updated the migration so it doesn't try to migrate again.