### PR TITLE
Caching Optimizations (ETags)

### DIFF
--- a/backend/api/viewsets/CreditTrade.py
+++ b/backend/api/viewsets/CreditTrade.py
@@ -23,6 +23,7 @@ from api.serializers import CreditTradeHistory2Serializer \
 
 from api.services.CreditTradeService import CreditTradeService
 
+import hashlib
 
 class CreditTradeViewSet(AuditableMixin, mixins.CreateModelMixin,
                          mixins.RetrieveModelMixin, mixins.UpdateModelMixin,
@@ -72,9 +73,35 @@ class CreditTradeViewSet(AuditableMixin, mixins.CreateModelMixin,
             ~Q(status__status__in=["Approved"])
         ).order_by(*self.ordering)
 
+        # For hash computation
+        most_recent_updated_credit_trade = self.get_queryset().exclude(
+            Q(update_timestamp=None))\
+            .order_by('-update_timestamp').first()
+
+        most_recent_created_credit_trade = self.get_queryset().exclude(
+            Q(create_timestamp=None)) \
+            .order_by('-create_timestamp').first()
+
+        digest = hashlib.sha256()
+        # you could use anything here (like perhaps the PID or startup time
+        digest.update(b'salt')
+        digest.update(most_recent_updated_credit_trade.update_timestamp.isoformat()
+                      .encode('utf-8') if most_recent_updated_credit_trade is not None else b'')
+        digest.update(most_recent_created_credit_trade.create_timestamp.isoformat()
+                      .encode('utf-8') if most_recent_created_credit_trade is not None else b'')
+        etag = 'W/"{}"'.format(digest.hexdigest())
+
+        # Browser has an up-to-date copy
+        if 'HTTP_IF_NONE_MATCH' in request.META and etag == request.META['HTTP_IF_NONE_MATCH']:
+            response = Response(status=status.HTTP_304_NOT_MODIFIED)
+            response['ETag'] = etag
+            return response
+
         serializer = self.get_serializer(credit_trades, many=True)
 
-        return Response(serializer.data)
+        response = Response(serializer.data)
+        response['ETag'] = etag
+        return response
 
     def perform_create(self, serializer):
         credit_trade = serializer.save()


### PR DESCRIPTION
Caching for `/api/credit_trades`

This call now returns `ETag` headers generated based on a hash of the single most recent `create_timestamp` and `update_timestamp` (if they exist). It will check the `If-None-Match` header supplied by the browser and avoid the expensive query and serialization if the result is expected not to have changed, returning instead a `304 Not Modified`.

Relevant test case created and verified.