### PR TITLE
Added tooltip for signing the proposal

### DIFF
--- a/frontend/__tests__/app/components/TooltipWhenDisabled.js
+++ b/frontend/__tests__/app/components/TooltipWhenDisabled.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import TooltipWhenDisabled from '../../../src/app/components/TooltipWhenDisabled';
+
+test('TooltipWhenDisabled should display properly', () => {
+  const component = renderer.create([
+    <TooltipWhenDisabled
+      disabled
+      key="tooltip"
+      title="Sample Title"
+    >
+      <button type="button">Test Button</button>
+    </TooltipWhenDisabled>
+  ]);
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/frontend/__tests__/app/components/__snapshots__/TooltipWhenDisabled.js.snap
+++ b/frontend/__tests__/app/components/__snapshots__/TooltipWhenDisabled.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TooltipWhenDisabled should display properly 1`] = `
+<div
+  className="overlay-trigger"
+  onBlur={[Function]}
+  onClick={null}
+  onFocus={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+>
+  <button
+    type="button"
+  >
+    Test Button
+  </button>
+</div>
+`;

--- a/frontend/src/app/components/TooltipWhenDisabled.js
+++ b/frontend/src/app/components/TooltipWhenDisabled.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+
+class TooltipWhenDisabled extends Component {
+  _renderDisabled () {
+    return (
+      <OverlayTrigger placement="right" overlay={this._tooltip()}>
+        <div className="overlay-trigger">
+          {this.props.children}
+        </div>
+      </OverlayTrigger>
+    );
+  }
+
+  _tooltip () {
+    return (
+      <Tooltip id="tooltip">
+        {this.props.title}
+      </Tooltip>
+    );
+  }
+
+  render () {
+    if (this.props.disabled) {
+      return this._renderDisabled();
+    }
+
+    return this.props.children;
+  }
+}
+
+TooltipWhenDisabled.defaultProps = {
+  disabled: true
+};
+
+TooltipWhenDisabled.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]).isRequired,
+  disabled: PropTypes.bool,
+  title: PropTypes.string.isRequired
+};
+
+export default TooltipWhenDisabled;

--- a/frontend/src/constants/routes.js
+++ b/frontend/src/constants/routes.js
@@ -9,7 +9,7 @@ export const NOTIFICATIONS = '/notifications';
 export const SETTINGS = '/settings';
 
 // API Routes
-export const BASE_URL = `${window.location.protocol}//${window.location.host}/api-business`;
+export const BASE_URL = `${window.location.protocol}//${window.location.host}/api`;
 
 export const ORGANIZATIONS_API = '/organizations';
 export const ORGANIZATION_ACTION_TYPES = '/organizationactionstypes';

--- a/frontend/src/constants/routes.js
+++ b/frontend/src/constants/routes.js
@@ -9,7 +9,7 @@ export const NOTIFICATIONS = '/notifications';
 export const SETTINGS = '/settings';
 
 // API Routes
-export const BASE_URL = `${window.location.protocol}//${window.location.host}/api`;
+export const BASE_URL = `${window.location.protocol}//${window.location.host}/api-business`;
 
 export const ORGANIZATIONS_API = '/organizations';
 export const ORGANIZATION_ACTION_TYPES = '/organizationactionstypes';

--- a/frontend/src/constants/values.js
+++ b/frontend/src/constants/values.js
@@ -27,11 +27,11 @@ export const CREDIT_TRANSFER_STATUS = {
   },
   recommendedForDecision: {
     id: 4,
-    description: 'Recommended'
+    description: 'Reviewed' /* Whether it's recommended or not, the user shouldn't need to know this */
   },
   notRecommended: {
     id: 5,
-    description: 'Not Recommended'
+    description: 'Reviewed' /* Whether it's recommended or not, the user shouldn't need to know this */
   },
   approved: {
     id: 6,

--- a/frontend/src/credit_transfers/CreditTransferAddContainer.js
+++ b/frontend/src/credit_transfers/CreditTransferAddContainer.js
@@ -20,7 +20,6 @@ import {
 import history from '../app/History';
 import * as Lang from '../constants/langEnUs';
 import CREDIT_TRANSACTIONS from '../constants/routes/CreditTransactions';
-import PERMISSIONS_CREDIT_TRANSACTIONS from '../constants/permissions/CreditTransactions';
 import { CREDIT_TRANSFER_STATUS } from '../constants/values';
 
 class CreditTransferAddContainer extends Component {
@@ -190,11 +189,7 @@ class CreditTransferAddContainer extends Component {
   }
 
   render () {
-    const buttonActions = [Lang.BTN_SAVE_DRAFT];
-
-    if (this.props.loggedInUser.hasPermission(PERMISSIONS_CREDIT_TRANSACTIONS.SIGN)) {
-      buttonActions.push(Lang.BTN_SIGN_1_2);
-    }
+    const buttonActions = [Lang.BTN_SAVE_DRAFT, Lang.BTN_SIGN_1_2];
 
     return ([
       <CreditTransferForm
@@ -247,7 +242,6 @@ CreditTransferAddContainer.propTypes = {
   invalidateCreditTransfers: PropTypes.func.isRequired,
   loggedInUser: PropTypes.shape({
     displayName: PropTypes.string,
-    hasPermission: PropTypes.func,
     organization: PropTypes.shape({
       name: PropTypes.string,
       id: PropTypes.number

--- a/frontend/src/credit_transfers/CreditTransferEditContainer.js
+++ b/frontend/src/credit_transfers/CreditTransferEditContainer.js
@@ -10,13 +10,14 @@ import { bindActionCreators } from 'redux';
 import CreditTransferForm from './components/CreditTransferForm';
 import ModalSubmitCreditTransfer from './components/ModalSubmitCreditTransfer';
 
-import { getFuelSuppliers } from '../actions/organizationActions';
 import {
   deleteCreditTransfer,
   getCreditTransfer,
   invalidateCreditTransfer,
   updateCreditTransfer
 } from '../actions/creditTransfersActions';
+import { getFuelSuppliers } from '../actions/organizationActions';
+import { getLoggedInUser } from '../actions/userActions';
 import {
   addSigningAuthorityConfirmation,
   prepareSigningAuthorityConfirmations
@@ -120,8 +121,6 @@ class CreditTransferEditContainer extends Component {
   _handleInputChange (event) {
     const { value, name } = event.target;
     const fieldState = { ...this.state.fields };
-
-    // console.log(typeof fieldState[name], value, name);
 
     if (typeof fieldState[name] === 'object') {
       this.changeObjectProp(parseInt(value, 10), name);
@@ -238,7 +237,7 @@ class CreditTransferEditContainer extends Component {
 
   render () {
     let availableActions = [];
-    const buttonActions = [Lang.BTN_SAVE_DRAFT];
+    const buttonActions = [Lang.BTN_SAVE_DRAFT, Lang.BTN_SIGN_1_2];
     const { isFetching, item } = this.props;
 
     if (!isFetching && item.actions) {
@@ -249,10 +248,6 @@ class CreditTransferEditContainer extends Component {
 
       if (availableActions.includes(Lang.BTN_SAVE_DRAFT)) {
         buttonActions.push(Lang.BTN_DELETE_DRAFT);
-      }
-
-      if (availableActions.includes(Lang.BTN_PROPOSE)) {
-        buttonActions.push(Lang.BTN_SIGN_1_2);
       }
     }
 
@@ -270,6 +265,7 @@ class CreditTransferEditContainer extends Component {
         handleSubmit={this._handleSubmit}
         id={item.id}
         key="creditTransferForm"
+        loggedInUser={this.props.loggedInUser}
         terms={this.state.terms}
         title="Edit Credit Transfer"
         toggleCheck={this._toggleCheck}
@@ -332,6 +328,13 @@ CreditTransferEditContainer.propTypes = {
     ]),
     actions: PropTypes.arrayOf(PropTypes.shape({}))
   }).isRequired,
+  loggedInUser: PropTypes.shape({
+    displayName: PropTypes.string,
+    organization: PropTypes.shape({
+      name: PropTypes.string,
+      id: PropTypes.number
+    })
+  }).isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({
       id: PropTypes.string.isRequired
@@ -345,7 +348,8 @@ const mapStateToProps = state => ({
   errors: state.rootReducer.creditTransfer.errors,
   fuelSuppliers: state.rootReducer.fuelSuppliersRequest.fuelSuppliers,
   isFetching: state.rootReducer.creditTransfer.isFetching,
-  item: state.rootReducer.creditTransfer.item
+  item: state.rootReducer.creditTransfer.item,
+  loggedInUser: state.rootReducer.userRequest.loggedInUser
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -353,6 +357,7 @@ const mapDispatchToProps = dispatch => ({
   deleteCreditTransfer: bindActionCreators(deleteCreditTransfer, dispatch),
   getCreditTransfer: bindActionCreators(getCreditTransfer, dispatch),
   getFuelSuppliers: bindActionCreators(getFuelSuppliers, dispatch),
+  getLoggedInUser: bindActionCreators(getLoggedInUser, dispatch),
   invalidateCreditTransfer: bindActionCreators(invalidateCreditTransfer, dispatch),
   prepareSigningAuthorityConfirmations: (creditTradeId, terms) =>
     prepareSigningAuthorityConfirmations(creditTradeId, terms),

--- a/frontend/src/credit_transfers/CreditTransferViewContainer.js
+++ b/frontend/src/credit_transfers/CreditTransferViewContainer.js
@@ -334,6 +334,7 @@ class CreditTransferViewContainer extends Component {
         id={item.id}
         isFetching={isFetching}
         key="creditTransferDetails"
+        loggedInUser={loggedInUser}
         note={item.note}
         numberOfCredits={item.numberOfCredits}
         rescinded={item.rescinded}
@@ -365,8 +366,14 @@ class CreditTransferViewContainer extends Component {
         action.action
       ));
 
+      if (item.status.id === CREDIT_TRANSFER_STATUS.draft.id) {
+        buttonActions.push(Lang.BTN_SIGN_1_2);
+
+        content.push(this._modalSubmit(item));
+      }
+
       if (item.respondent.id === loggedInUser.organization.id) {
-        if (availableActions.includes(Lang.BTN_ACCEPT)) {
+        if (item.status.id === CREDIT_TRANSFER_STATUS.proposed.id) {
           buttonActions.push(Lang.BTN_SIGN_2_2);
           content.push(this._modalAccept());
         }
@@ -392,12 +399,6 @@ class CreditTransferViewContainer extends Component {
         buttonActions.push(Lang.BTN_EDIT_DRAFT);
 
         content.push(this._modalDelete(item));
-      }
-
-      if (availableActions.includes(Lang.BTN_PROPOSE)) {
-        buttonActions.push(Lang.BTN_SIGN_1_2);
-
-        content.push(this._modalSubmit(item));
       }
 
       if (availableActions.includes(Lang.BTN_RECOMMEND_FOR_DECISION)) {

--- a/frontend/src/credit_transfers/components/CreditTransferDetails.js
+++ b/frontend/src/credit_transfers/components/CreditTransferDetails.js
@@ -13,7 +13,7 @@ import CreditTransferVisualRepresentation from './CreditTransferVisualRepresenta
 import { getCreditTransferType } from '../../actions/creditTransfersActions';
 import Errors from '../../app/components/Errors';
 import Loading from '../../app/components/Loading';
-import * as Lang from '../../constants/langEnUs';
+import PERMISSIONS_CREDIT_TRANSACTIONS from '../../constants/permissions/CreditTransactions';
 import CreditTransferCommentForm from './CreditTransferCommentForm';
 import CreditTransferComment from './CreditTransferComment';
 import CreditTransferCommentButtons from './CreditTransferCommentButtons';
@@ -73,9 +73,9 @@ const CreditTransferDetails = props => (
           privilegedAccess={props.willCreatePrivilegedComment}
         />
         }
+
         <form onSubmit={e => e.preventDefault()}>
-          {(props.buttonActions.includes(Lang.BTN_SIGN_1_2) ||
-          props.buttonActions.includes(Lang.BTN_SIGN_2_2)) &&
+          {(props.loggedInUser.hasPermission(PERMISSIONS_CREDIT_TRANSACTIONS.SIGN)) &&
           <CreditTransferTerms
             addToFields={props.addToFields}
             fields={props.fields}
@@ -89,9 +89,8 @@ const CreditTransferDetails = props => (
           />
           <CreditTransferFormButtons
             actions={props.buttonActions}
-            changeStatus={props.changeStatus}
             addComment={props.addComment}
-            isCommenting={props.isCommenting}
+            changeStatus={props.changeStatus}
             disabled={
               {
                 BTN_SIGN_1_2: props.fields.terms.findIndex(term => term.value === false) >= 0 ||
@@ -101,6 +100,12 @@ const CreditTransferDetails = props => (
               }
             }
             id={props.id}
+            isCommenting={props.isCommenting}
+            permissions={
+              {
+                BTN_SIGN_1_2: props.loggedInUser.hasPermission(PERMISSIONS_CREDIT_TRANSACTIONS.SIGN)
+              }
+            }
           />
         </form>
       </div>
@@ -159,6 +164,14 @@ CreditTransferDetails.propTypes = {
   ]),
   fields: PropTypes.shape({
     terms: PropTypes.array
+  }).isRequired,
+  loggedInUser: PropTypes.shape({
+    displayName: PropTypes.string,
+    hasPermission: PropTypes.func,
+    organization: PropTypes.shape({
+      name: PropTypes.string,
+      id: PropTypes.number
+    })
   }).isRequired,
   id: PropTypes.number,
   isFetching: PropTypes.bool.isRequired,

--- a/frontend/src/credit_transfers/components/CreditTransferForm.js
+++ b/frontend/src/credit_transfers/components/CreditTransferForm.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { CREDIT_TRANSFER_STATUS } from '../../constants/values';
 
 import Errors from '../../app/components/Errors';
-import * as Lang from '../../constants/langEnUs';
+import PERMISSIONS_CREDIT_TRANSACTIONS from '../../constants/permissions/CreditTransactions';
 import CreditTransferProgress from './CreditTransferProgress';
 import CreditTransferFormDetails from './CreditTransferFormDetails';
 import CreditTransferVisualRepresentation from './CreditTransferVisualRepresentation';
@@ -48,8 +48,7 @@ const CreditTransferForm = props => (
         handleInputChange={props.handleInputChange}
       />
 
-      {(props.buttonActions.includes(Lang.BTN_SIGN_1_2) ||
-        props.buttonActions.includes(Lang.BTN_SIGN_2_2)) &&
+      {(props.loggedInUser.hasPermission(PERMISSIONS_CREDIT_TRANSACTIONS.SIGN)) &&
         <CreditTransferTerms
           addToFields={props.addToFields}
           fields={props.fields}
@@ -64,6 +63,11 @@ const CreditTransferForm = props => (
           {
             BTN_SIGN_1_2: props.fields.terms.findIndex(term => term.value === false) >= 0 ||
             props.fields.terms.length === 0
+          }
+        }
+        permissions={
+          {
+            BTN_SIGN_1_2: props.loggedInUser.hasPermission(PERMISSIONS_CREDIT_TRANSACTIONS.SIGN)
           }
         }
         id={props.id}

--- a/frontend/src/credit_transfers/components/CreditTransferFormButtons.js
+++ b/frontend/src/credit_transfers/components/CreditTransferFormButtons.js
@@ -5,6 +5,7 @@ import * as Lang from '../../constants/langEnUs';
 import CREDIT_TRANSACTIONS from '../../constants/routes/CreditTransactions';
 import { CREDIT_TRANSFER_STATUS } from '../../constants/values';
 import history from '../../app/History';
+import TooltipWhenDisabled from '../../app/components/TooltipWhenDisabled';
 
 const CreditTransferFormButtons = props => (
   <div className="credit-transfer-actions">
@@ -45,15 +46,24 @@ const CreditTransferFormButtons = props => (
       </button>
       }
       {props.actions.includes(Lang.BTN_SIGN_1_2) &&
-      <button
-        className={`btn ${props.disabled.BTN_SIGN_1_2 ? 'btn-disabled' : 'btn-primary '}`}
-        data-target="#confirmSubmit"
-        data-toggle="modal"
+      <TooltipWhenDisabled
         disabled={props.disabled.BTN_SIGN_1_2}
-        type="button"
+        title={props.permissions.BTN_SIGN_1_2
+          ? 'Signing Authority Declaration needs to be accepted'
+          : 'You must be assigned the Signing Authority role in order to sign and send ' +
+          'a Credit Transfer Proposal to another fuel supplier'}
       >
-        {Lang.BTN_SIGN_1_2}
-      </button>
+        <button
+          className={`btn ${props.disabled.BTN_SIGN_1_2 ? 'btn-disabled' : 'btn-primary '}`}
+          data-placement="right"
+          data-target="#confirmSubmit"
+          data-toggle="modal"
+          disabled={props.disabled.BTN_SIGN_1_2}
+          type="button"
+        >
+          {Lang.BTN_SIGN_1_2}
+        </button>
+      </TooltipWhenDisabled>
       }
       {props.actions.includes(Lang.BTN_REFUSE) &&
       <button
@@ -66,15 +76,23 @@ const CreditTransferFormButtons = props => (
       </button>
       }
       {props.actions.includes(Lang.BTN_SIGN_2_2) &&
-      <button
-        className="btn btn-primary"
-        data-target="#confirmAccept"
-        data-toggle="modal"
+      <TooltipWhenDisabled
         disabled={props.disabled.BTN_SIGN_2_2}
-        type="button"
+        title={props.permissions.BTN_SIGN_2_2
+          ? 'Signing Authority Declaration needs to be accepted'
+          : 'You must be assigned the Signing Authority role in order to sign and send ' +
+          'a Credit Transfer Proposal to another fuel supplier'}
       >
-        {Lang.BTN_SIGN_2_2}
-      </button>
+        <button
+          className="btn btn-primary"
+          data-target="#confirmAccept"
+          data-toggle="modal"
+          disabled={props.disabled.BTN_SIGN_2_2}
+          type="button"
+        >
+          {Lang.BTN_SIGN_2_2}
+        </button>
+      </TooltipWhenDisabled>
       }
       {props.actions.includes(Lang.BTN_RESCIND) &&
       <button
@@ -131,22 +149,32 @@ const CreditTransferFormButtons = props => (
 );
 
 CreditTransferFormButtons.defaultProps = {
+  addComment: null,
   disabled: {
     BTN_SIGN_1_2: true,
     BTN_SIGN_2_2: true
+  },
+  isCommenting: false,
+  permissions: {
+    BTN_SIGN_1_2: false,
+    BTN_SIGN_2_2: false
   }
 };
 
 CreditTransferFormButtons.propTypes = {
   actions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  addComment: PropTypes.func,
   changeStatus: PropTypes.func.isRequired,
   disabled: PropTypes.shape({
     BTN_SIGN_1_2: PropTypes.bool,
     BTN_SIGN_2_2: PropTypes.bool
   }),
   id: PropTypes.number.isRequired,
-  addComment: PropTypes.func.isRequired,
-  isCommenting: PropTypes.bool.isRequired
+  isCommenting: PropTypes.bool,
+  permissions: PropTypes.shape({
+    BTN_SIGN_1_2: PropTypes.bool,
+    BTN_SIGN_2_2: PropTypes.bool
+  })
 };
 
 export default CreditTransferFormButtons;

--- a/frontend/src/credit_transfers/components/CreditTransferProgress.js
+++ b/frontend/src/credit_transfers/components/CreditTransferProgress.js
@@ -7,7 +7,7 @@ class CreditTransferProgress extends Component {
   static addStepRescinded () {
     return (
       <div
-        className="step cancelled"
+        className="step current"
         key={CREDIT_TRANSFER_STATUS.rescinded.id}
       >
         <span>{CREDIT_TRANSFER_STATUS.rescinded.description}</span>
@@ -44,7 +44,7 @@ class CreditTransferProgress extends Component {
   _addStepDeclined () {
     return (
       <div
-        className={`step ${(this.props.status.id === CREDIT_TRANSFER_STATUS.declinedForApproval.id) ? 'cancelled' : ''}`}
+        className={`step ${(this.props.status.id === CREDIT_TRANSFER_STATUS.declinedForApproval.id) ? 'current' : ''}`}
         key={CREDIT_TRANSFER_STATUS.declinedForApproval.id}
       >
         <span>{CREDIT_TRANSFER_STATUS.declinedForApproval.description}</span>
@@ -64,19 +64,6 @@ class CreditTransferProgress extends Component {
     );
   }
 
-  _addStepNotRecommended () {
-    return (
-      <div
-        className={`step ${(this.props.status.id === CREDIT_TRANSFER_STATUS.notRecommended.id &&
-          !this.props.rescinded)
-          ? 'cancelled' : ''}`}
-        key={CREDIT_TRANSFER_STATUS.notRecommended.id}
-      >
-        <span>{CREDIT_TRANSFER_STATUS.notRecommended.description}</span>
-      </div>
-    );
-  }
-
   _addStepProposed () {
     return (
       <div
@@ -90,10 +77,11 @@ class CreditTransferProgress extends Component {
     );
   }
 
-  _addStepRecommended () {
+  _addStepReviewed () {
     return (
       <div
-        className={`step ${(this.props.status.id === CREDIT_TRANSFER_STATUS.recommendedForDecision.id &&
+        className={`step ${((this.props.status.id === CREDIT_TRANSFER_STATUS.recommendedForDecision.id ||
+          this.props.status.id === CREDIT_TRANSFER_STATUS.notRecommended.id) &&
           !this.props.rescinded)
           ? 'current' : ''}`}
         key={CREDIT_TRANSFER_STATUS.recommendedForDecision.id}
@@ -108,7 +96,7 @@ class CreditTransferProgress extends Component {
       <div
         className={`step ${(this.props.status.id === CREDIT_TRANSFER_STATUS.refused.id &&
           !this.props.rescinded)
-          ? 'danger' : ''}`}
+          ? 'current' : ''}`}
         key={CREDIT_TRANSFER_STATUS.refused.id}
       >
         <span>{CREDIT_TRANSFER_STATUS.refused.description}</span>
@@ -145,11 +133,7 @@ class CreditTransferProgress extends Component {
       view.push(CreditTransferProgress.addStepRescinded());
     }
 
-    if (this.props.status.id === CREDIT_TRANSFER_STATUS.notRecommended.id) {
-      view.push(this._addStepNotRecommended());
-    } else {
-      view.push(this._addStepRecommended());
-    }
+    view.push(this._addStepReviewed());
 
     if ((this.props.status.id === CREDIT_TRANSFER_STATUS.notRecommended.id ||
       this.props.status.id === CREDIT_TRANSFER_STATUS.recommendedForDecision.id) &&
@@ -175,7 +159,7 @@ class CreditTransferProgress extends Component {
     }
 
     view.push(this._addStepDraft());
-    view.push(this._addStepRecommended());
+    view.push(this._addStepReviewed());
     view.push(this._addStepCompleted());
 
     return view;
@@ -188,7 +172,12 @@ class CreditTransferProgress extends Component {
     ].includes(this.props.type.id)) {
       return (
         <div className="credit-transfer-progress-bar">
-          <div className="arrow-steps clearfix">
+          <div
+            className={`arrow-steps clearfix
+              ${(this.props.status.id === CREDIT_TRANSFER_STATUS.refused.id ||
+                this.props.status.id === CREDIT_TRANSFER_STATUS.declinedForApproval.id ||
+                this.props.rescinded) ? 'negative' : ''}`}
+          >
             {this._renderCreditTransfer()}
           </div>
         </div>

--- a/frontend/src/reducers/userReducer.js
+++ b/frontend/src/reducers/userReducer.js
@@ -26,9 +26,9 @@ const userRequest = (state = {
           ...action.data,
           hasPermission: (permissionCode) => {
             if (action.data.role) {
-              return action.data.role.permissions.find(permission => (
+              return action.data.role.permissions.findIndex(permission => (
                 permission.code === permissionCode
-              ));
+              )) >= 0;
             }
 
             return false;

--- a/frontend/styles/CreditTransfers.scss
+++ b/frontend/styles/CreditTransfers.scss
@@ -85,6 +85,32 @@
       @include mobile {
         display: block;
       }
+
+      &.negative .step {
+        background-color: $light-red;
+
+        &:after {
+          border-left-color: $light-red;
+        }
+
+        &.current {
+          color: $white;
+          background-color: $red !important;
+
+          &:after {
+            border-left: 17px solid $red;
+          }
+
+          & ~ .step {
+            background-color: $border-grey;
+            color: $medium-font;
+
+            &:after {
+              border-left: 17px solid $border-grey;
+            }
+          }
+        }
+      }
     
       .step {
         font-size: 14px;
@@ -96,7 +122,7 @@
         padding: 8px 10px 8px 30px;
         float: left;
         position: relative;
-        background-color: $border-grey;
+        background-color: $light-blue;
         -webkit-user-select: none;
         -moz-user-select: none;
         -ms-user-select: none;
@@ -114,7 +140,7 @@
           height: 0;
           border-top: 19px solid transparent;
           border-bottom: 17px solid transparent;
-          border-left: 17px solid $border-grey;	
+          border-left: 17px solid $light-blue;	
           z-index: 2;
           transition: border-color 0.2s ease;
 
@@ -179,11 +205,11 @@
           }
 
           & ~ .step {
-            background-color: $light-red;
+            background-color: $border-grey;
             color: $medium-font;
 
             &:after {
-              border-left: 17px solid $light-red;
+              border-left: 17px solid $border-grey;
             }
           }
         }
@@ -197,21 +223,12 @@
           }
 
           & ~ .step {
-            background-color: $light-blue;
+            background-color: $border-grey;
             color: $medium-font;
 
             &:after {
-              border-left: 17px solid $light-blue;
+              border-left: 17px solid $border-grey;
             }
-          }
-        }
-
-        &.danger {
-          color: $white;
-          background-color: $red;
-
-          &:after {
-            border-left: 17px solid $red;
           }
         }
       }

--- a/frontend/styles/TooltipWhenDisabled.scss
+++ b/frontend/styles/TooltipWhenDisabled.scss
@@ -1,0 +1,7 @@
+.overlay-trigger {
+  display: inline-block;
+
+  button {
+    pointer-events: none;
+  }
+}

--- a/frontend/styles/index.scss
+++ b/frontend/styles/index.scss
@@ -1,14 +1,15 @@
 @import './App.scss';
-@import './mixins.scss';
-@import './variables.scss';
-@import './FuelSuppliers.scss';
+@import './ContactUs.scss';
+@import './CreditTransfers.scss';
 @import './Dashboard.scss';
+@import './FuelSuppliers.scss';
+@import './HistoricalDataEntry.scss';
+@import './mixins.scss';
 @import './Notifications.scss';
 @import './Opportunities.scss';
 @import './Organizations.scss';
-@import './CreditTransfers.scss';
-@import './HistoricalDataEntry.scss';
-@import './ContactUs.scss';
+@import './TooltipWhenDisabled.scss';
+@import './variables.scss';
 
 body {
   margin: 0;
@@ -82,7 +83,7 @@ h1 {
 }
 
 .btn-container {
-  .btn + .btn {
+  .btn + .btn, .btn + div {
     margin-left: 0.5rem;
   }
 }


### PR DESCRIPTION
#397 #398 #399

Added tooltips for the disabled Sign 1/2 and Sign 2/2 to give hints to the user on why it's disabled. Also, changed the breadcrumbs colouring.

Changelog:
- Sign 1/2 and Sign 2/2 should now be visible to Credit Trader roles
- Credit Traders will see a tooltip when hovering over the Sign 1/2 and Sign 2/2 buttons
- Reversed the colouring for the breadcrumbs
- Changed Recommended/Not Recommended to Reviewed
