### PR TITLE
Tweaks and fixes for the frontend

### DIFF
--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -180,24 +180,51 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
                             "been `{}`.".format(self.instance.status.status)
             })
 
+        # if status is being modified, make sure the next state is valid
         if 'status' in request.data:
-            available_statuses = CreditTradeService.get_allowed_statuses(
-                self.instance, request)
-
-            allowed_statuses = list(
-                CreditTradeStatus.objects
-                .filter(status__in=available_statuses)
-                .only('id'))
-
             credit_trade_status = data.get('status')
-            is_rescinded = data.get('is_rescinded')
 
-            if (credit_trade_status not in allowed_statuses and not
-                    is_rescinded):
+            if data.get('is_rescinded') is False:
+                available_statuses = CreditTradeService.get_allowed_statuses(
+                    self.instance, request)
+
+                allowed_statuses = list(
+                    CreditTradeStatus.objects
+                    .filter(status__in=available_statuses)
+                    .only('id'))
+
+                if credit_trade_status not in allowed_statuses:
+                    raise serializers.ValidationError({
+                        'invalidStatus': "You do not have permission to set "
+                                         "the status to `{}`.".format(
+                                             credit_trade_status.status)
+                    })
+
+            if (credit_trade_status != self.instance.status and
+                    data.get('is_rescinded') is True):
                 raise serializers.ValidationError({
-                    'invalidStatus': "You do not have permission to set the "
-                                     "status to `{}`.".format(
-                                         credit_trade_status.status)
+                    'invalidStatus': "Cannot update status and rescind at the "
+                                     "same time."
+                })
+
+        if data.get('is_rescinded') is True:
+            if request.user.organization not in [
+                    self.instance.initiator, self.instance.respondent]:
+                raise serializers.ValidationError({
+                    'forbidden': "Cannot rescind unless organization is part "
+                                 "of the proposal."
+                })
+
+            if self.instance.status.status == 'Draft':
+                raise serializers.ValidationError({
+                    'forbidden': "Cannot rescind a draft"
+                })
+
+            if (self.instance.status.status == 'Submitted' and
+                    self.instance.respondent == request.user.organization):
+                raise serializers.ValidationError({
+                    'forbidden': "Cannot rescind a proposed trade when you're "
+                                 " the respondent"
                 })
 
         if (data.get('fair_market_value_per_credit') == 0 and

--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -28,6 +28,7 @@ from api.models.CreditTradeType import CreditTradeType
 from api.models.User import User
 from api.services.CreditTradeActions import CreditTradeActions
 from api.services.CreditTradeCommentActions import CreditTradeCommentActions
+from api.services.CreditTradeService import CreditTradeService
 
 from .CreditTradeComment import CreditTradeCommentSerializer
 from .CreditTradeHistory import CreditTradeHistoryReviewedSerializer
@@ -180,32 +181,8 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
             })
 
         if 'status' in request.data:
-            if self.instance.status.status == "Draft":
-                if request.user.has_perm('PROPOSE_CREDIT_TRANSFER'):
-                    available_statuses.append("Cancelled")
-                    available_statuses.append("Draft")
-
-            if request.user.has_perm('APPROVE_CREDIT_TRANSFER'):
-                available_statuses.append("Approved")
-
-            if request.user.has_perm('DECLINE_CREDIT_TRANSFER'):
-                available_statuses.append("Declined")
-
-            if request.user.has_perm('RECOMMEND_CREDIT_TRANSFER') and \
-               self.instance.status.status == "Accepted":
-                available_statuses.append("Recommended")
-                available_statuses.append("Not Recommended")
-
-            if request.user.has_perm('REFUSE_CREDIT_TRANSFER') and \
-               self.instance.respondent == request.user.organization:
-                available_statuses.append("Refused")
-
-            if request.user.has_perm('SIGN_CREDIT_TRANSFER'):
-                if self.instance.initiator == request.user.organization:
-                    available_statuses.append("Submitted")
-
-                if self.instance.respondent == request.user.organization:
-                    available_statuses.append("Accepted")
+            available_statuses = CreditTradeService.get_allowed_statuses(
+                self.instance, request)
 
             allowed_statuses = list(
                 CreditTradeStatus.objects

--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -213,8 +213,10 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
                 .only('id'))
 
             credit_trade_status = data.get('status')
+            is_rescinded = data.get('is_rescinded')
 
-            if credit_trade_status not in allowed_statuses:
+            if (credit_trade_status not in allowed_statuses and not
+                    is_rescinded):
                 raise serializers.ValidationError({
                     'invalidStatus': "You do not have permission to set the "
                                      "status to `{}`.".format(
@@ -405,6 +407,13 @@ class CreditTrade2Serializer(serializers.ModelSerializer):
         return serializer.data
 
     def get_reviewed(self, obj):
+        request = self.context.get('request')
+
+        # only show this to government users
+        if (request.user.role is None or
+                not request.user.role.is_government_role):
+            return {}
+
         serializer = CreditTradeHistoryReviewedSerializer(obj.reviewed)
 
         return serializer.data

--- a/frontend/src/app/components/Footer.js
+++ b/frontend/src/app/components/Footer.js
@@ -42,7 +42,14 @@ const Footer = props => (
               </li>
             </ul>
             <div id="footer-about-version" className="inline">
-              v{__VERSION__}
+              <a
+                href="https://github.com/bcgov/tfrs/releases/latest"
+                key="credit-market-report"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                v{__VERSION__}
+              </a>
             </div>
           </div>
         </div>

--- a/frontend/src/constants/langEnUs.js
+++ b/frontend/src/constants/langEnUs.js
@@ -2,7 +2,7 @@
 export const BTN_ACCEPT = 'Accept';
 export const BTN_APPROVE = 'Approve';
 export const BTN_ADD_TO_QUEUE = 'Add to Queue';
-export const BTN_APP_CANCEL = 'Cancel';
+export const BTN_APP_CANCEL = 'Back';
 export const BTN_COMMIT = 'Commit';
 export const BTN_CT_CANCEL = 'Cancel';
 export const BTN_DECLINE_FOR_APPROVAL = 'Decline to Approve';

--- a/frontend/src/constants/routes.js
+++ b/frontend/src/constants/routes.js
@@ -9,7 +9,7 @@ export const NOTIFICATIONS = '/notifications';
 export const SETTINGS = '/settings';
 
 // API Routes
-export const BASE_URL = `${window.location.protocol}//${window.location.host}/api-business`;
+export const BASE_URL = `${window.location.protocol}//${window.location.host}/api`;
 
 export const ORGANIZATIONS_API = '/organizations';
 export const ORGANIZATION_ACTION_TYPES = '/organizationactionstypes';

--- a/frontend/src/constants/routes.js
+++ b/frontend/src/constants/routes.js
@@ -9,7 +9,7 @@ export const NOTIFICATIONS = '/notifications';
 export const SETTINGS = '/settings';
 
 // API Routes
-export const BASE_URL = `${window.location.protocol}//${window.location.host}/api`;
+export const BASE_URL = `${window.location.protocol}//${window.location.host}/api-business`;
 
 export const ORGANIZATIONS_API = '/organizations';
 export const ORGANIZATION_ACTION_TYPES = '/organizationactionstypes';

--- a/frontend/src/credit_transfers/components/CreditTransferDetails.js
+++ b/frontend/src/credit_transfers/components/CreditTransferDetails.js
@@ -95,6 +95,7 @@ const CreditTransferDetails = props => (
           {(props.tradeType.id === CREDIT_TRANSFER_TYPES.sell.id ||
           props.tradeType.id === CREDIT_TRANSFER_TYPES.buy.id) &&
           props.status.id !== CREDIT_TRANSFER_STATUS.draft.id &&
+          (props.signatures.length > 0 || props.reviewed.user) &&
             <CreditTransferSigningHistory
               reviewed={props.reviewed}
               signatures={props.signatures}
@@ -116,7 +117,10 @@ const CreditTransferDetails = props => (
             isCommenting={props.isCommenting}
             permissions={
               {
-                BTN_SIGN_1_2: props.loggedInUser.hasPermission(PERMISSIONS_CREDIT_TRANSACTIONS.SIGN)
+                BTN_SIGN_1_2:
+                props.loggedInUser.hasPermission(PERMISSIONS_CREDIT_TRANSACTIONS.SIGN),
+                BTN_SIGN_2_2:
+                props.loggedInUser.hasPermission(PERMISSIONS_CREDIT_TRANSACTIONS.SIGN)
               }
             }
           />

--- a/frontend/src/credit_transfers/components/CreditTransferForm.js
+++ b/frontend/src/credit_transfers/components/CreditTransferForm.js
@@ -69,7 +69,10 @@ const CreditTransferForm = props => (
         }
         permissions={
           {
-            BTN_SIGN_1_2: props.loggedInUser.hasPermission(PERMISSIONS_CREDIT_TRANSACTIONS.SIGN)
+            BTN_SIGN_1_2:
+            props.loggedInUser.hasPermission(PERMISSIONS_CREDIT_TRANSACTIONS.SIGN),
+            BTN_SIGN_2_2:
+            props.loggedInUser.hasPermission(PERMISSIONS_CREDIT_TRANSACTIONS.SIGN)
           }
         }
         id={props.id}

--- a/frontend/src/credit_transfers/components/CreditTransferFormButtons.js
+++ b/frontend/src/credit_transfers/components/CreditTransferFormButtons.js
@@ -93,7 +93,7 @@ const CreditTransferFormButtons = props => (
         title={props.isCommenting ? Lang.TEXT_COMMENT_DIRTY : (props.permissions.BTN_SIGN_2_2
           ? 'Signing Authority Declaration needs to be accepted'
           : 'You must be assigned the Signing Authority role in order to sign and send ' +
-          'a Credit Transfer Proposal to another fuel supplier')}
+          'a Credit Transfer Proposal to the Low Carbon Fuels Branch')}
       >
         <button
           className="btn btn-primary"

--- a/frontend/styles/CreditTransfers.scss
+++ b/frontend/styles/CreditTransfers.scss
@@ -279,6 +279,7 @@
 
   .terms-header {
     margin-bottom: 15px;
+    margin-top: 15px;
   }
 
   .well {

--- a/frontend/styles/TooltipWhenDisabled.scss
+++ b/frontend/styles/TooltipWhenDisabled.scss
@@ -4,10 +4,4 @@
   button {
     pointer-events: none;
   }
-  .btn:last-child {
-    margin-left: 0.5em;
-  }
-  .btn:first-child {
-    margin-left: 0.5em;
-  }
 }

--- a/frontend/styles/index.scss
+++ b/frontend/styles/index.scss
@@ -116,8 +116,13 @@ h1 {
 }
 
 .btn-container {
-  .btn + .btn, .btn + div {
+  .btn + .btn, .btn + div, div + div {
     margin-left: 0.5rem;
+    margin-right: 0.3rem;
+  }
+
+  div:last-child {
+    margin-right: 0;
   }
 }
 


### PR DESCRIPTION
#420 #421 #422 #423 #424 #426

This should fix a lot of the frontend issues we've encountered during the demo. And one fix on the backend.

Changelog:
- Fixed backend issue throwing a permission error when rescinding
- Renamed Cancel to Back
- Signing History should be hidden when no one has signed it (applicable to old proposals)
- Updated the tooltip for Sign 2/2
- Reviewed and Recommended line in Signing History is now hidden from Fuel Supplier users
- Version number at the bottom should now link to latest release in github