### PR TITLE
Allow Multiple Roles for Users

### DIFF
--- a/backend/api/fixtures/test_users_multiple_roles.json
+++ b/backend/api/fixtures/test_users_multiple_roles.json
@@ -1,0 +1,42 @@
+[
+  {
+    "fields": {
+      "authorization_guid": "2c04e271-6fc2-4822-b231-7cd3dc7e9ec4",
+      "email": "gov_multi_role@test.com",
+      "username": "gov_multi_role",
+      "authorization_id": "gov_multi_role",
+      "display_name": "Multi Role",
+      "first_name": "Multi",
+      "last_name": "Role",
+      "organization": [
+        "Government Of British Columbia"
+      ]
+    },
+    "model": "api.user",
+    "pk": null
+  },
+  {
+    "fields": {
+      "role": [
+        "ProdlikeAnalyst"
+      ],
+      "user": [
+        "gov_multi_role"
+      ]
+    },
+    "model": "api.userrole",
+    "pk": null
+  },
+  {
+    "fields": {
+      "role": [
+        "ProdlikeDirector"
+      ],
+      "user": [
+        "gov_multi_role"
+      ]
+    },
+    "model": "api.userrole",
+    "pk": null
+  }
+]

--- a/backend/api/models/User.py
+++ b/backend/api/models/User.py
@@ -31,6 +31,7 @@ from auditable.models import Auditable
 from api.managers.UserManager import UserManager
 
 from .CreditTradeHistory import CreditTradeHistory
+from .Permission import Permission
 from .Role import Role
 from .UserRole import UserRole
 
@@ -89,6 +90,18 @@ class User(AbstractUser, Auditable):
 
     def __str__(self):
         return str(self.id)
+
+    @property
+    def permissions(self):
+        """
+        Permissions that the user has based on the roles applied
+        """
+        if self.roles is None:
+            return None
+
+        return Permission.objects.distinct().filter(
+            Q(role_permissions__role__in=self.roles)
+        ).order_by('id')
 
     @property
     def roles(self):

--- a/backend/api/models/User.py
+++ b/backend/api/models/User.py
@@ -96,9 +96,6 @@ class User(AbstractUser, Auditable):
         """
         Permissions that the user has based on the roles applied
         """
-        if self.roles is None:
-            return None
-
         return Permission.objects.distinct().filter(
             Q(role_permissions__role__in=self.roles)
         ).order_by('id')
@@ -125,9 +122,8 @@ class User(AbstractUser, Auditable):
         """
         Helper function to check if the user has the approrpiate permission
         """
-        if self.roles is None or \
-                not self.roles.filter(
-                        Q(role_permissions__permission__code=permission)):
+        if not self.roles.filter(
+                Q(role_permissions__permission__code=permission)):
             return False
 
         return True

--- a/backend/api/models/User.py
+++ b/backend/api/models/User.py
@@ -22,6 +22,7 @@
 """
 
 from django.db import models
+from django.db.models import Q
 from django.contrib.auth.models import AbstractUser
 from django.core.validators import RegexValidator
 import django.contrib.auth.validators
@@ -30,6 +31,7 @@ from auditable.models import Auditable
 from api.managers.UserManager import UserManager
 
 from .CreditTradeHistory import CreditTradeHistory
+from .Role import Role
 from .UserRole import UserRole
 
 
@@ -89,18 +91,11 @@ class User(AbstractUser, Auditable):
         return str(self.id)
 
     @property
-    def role(self):
+    def roles(self):
         """
-        Role applied to the User
+        Roles applied to the User
         """
-        user_role = UserRole.objects.select_related('role').filter(
-            user_id=self.id
-        ).first()
-
-        if user_role is None:
-            return None
-
-        return user_role.role
+        return Role.objects.filter(user_roles__user_id=self.id)
 
     def get_history(self, filters):
         """
@@ -117,11 +112,22 @@ class User(AbstractUser, Auditable):
         """
         Helper function to check if the user has the approrpiate permission
         """
-        if self.role is None or \
-                not self.role.permissions.filter(code=permission):
+        if self.roles is None or \
+                not self.roles.filter(
+                        Q(role_permissions__permission__code=permission)):
             return False
 
         return True
+
+    @property
+    def is_government_user(self):
+        """
+        Does this user have a government role?
+        """
+        if self.roles.filter(Q(is_government_role=True)):
+            return True
+
+        return False
 
     objects = UserManager()
 

--- a/backend/api/permissions/CreditTradeComment.py
+++ b/backend/api/permissions/CreditTradeComment.py
@@ -152,15 +152,15 @@ class CreditTradeCommentPermissions(permissions.BasePermission):
         if obj.create_user == request.user:
             return True
 
-        # And see but not edit those from their others in their own organization
+        # And see but not edit those from their others in their own
+        # organization
         if obj.create_user.organization == request.user.organization and \
                 request.method in permissions.SAFE_METHODS:
             return True
 
         # Government roles can always view comments
         # and can view or edit privileged comments with correct permission
-        if request.user.role is not None and request.user.role.is_government_role:
-
+        if request.user.roles and request.user.is_government_user:
             # read
             if request.method in permissions.SAFE_METHODS:
                 if obj.privileged_access:

--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -69,7 +69,7 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
         # if the user creating the proposal is not the initiator.
         # they should be a government user
         if data.get('initiator') != request.user.organization and \
-                not request.user.role.is_government_role:
+                not request.user.is_government_user:
             raise serializers.ValidationError({
                 'invalidStatus': "You cannot create a proposal for another "
                                  "organization."
@@ -402,7 +402,7 @@ class CreditTrade2Serializer(serializers.ModelSerializer):
 
         # If the user doesn't have any roles assigned, treat as though the user
         # doesn't have available permissions
-        if request.user.role is None:
+        if request.user.roles is None:
             return []
 
         if cur_status == "Draft":
@@ -429,7 +429,7 @@ class CreditTrade2Serializer(serializers.ModelSerializer):
 
         # If the user doesn't have any roles assigned, treat as though the user
         # doesn't have available permissions
-        if request.user.role is None:
+        if request.user.roles is None:
             return []
 
         if request.user.has_perm('VIEW_PRIVILEGED_COMMENTS'):
@@ -449,8 +449,8 @@ class CreditTrade2Serializer(serializers.ModelSerializer):
 
         # if the user is not a government user we should limit what we show
         # so no recommended/not recommended
-        if (request.user.role is None or
-                not request.user.role.is_government_role):
+        if (request.user.roles is None or
+                not request.user.is_government_user):
             history = obj.get_history(["Accepted", "Completed", "Declined",
                                        "Refused", "Submitted"])
         else:

--- a/backend/api/serializers/Role.py
+++ b/backend/api/serializers/Role.py
@@ -28,15 +28,9 @@ from .Permission import PermissionSerializer
 
 
 class RoleSerializer(serializers.ModelSerializer):
-    permissions = PermissionSerializer(read_only=True, many=True)
-
+    """
+    Serializer for the Role used for displaying in the front-end
+    """
     class Meta:
         model = Role
-        fields = ('id', 'name', 'description', 'is_government_role',
-                  'permissions')
-
-
-class RoleMinSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Role
-        fields = ('id', 'name', 'description')
+        fields = ('id', 'name', 'description', 'is_government_role')

--- a/backend/api/serializers/User.py
+++ b/backend/api/serializers/User.py
@@ -29,25 +29,25 @@ from .Role import RoleSerializer, RoleMinSerializer
 
 
 class MemberSerializer(serializers.ModelSerializer):
-    role = RoleMinSerializer(read_only=True)
+    roles = RoleMinSerializer(many=True, read_only=True)
 
     class Meta:
         model = User
         fields = (
             'id', 'first_name', 'last_name', 'display_name', 'email', 'phone',
-            'role', 'is_active')
+            'roles', 'is_active')
 
 
 class UserSerializer(serializers.ModelSerializer):
     organization = OrganizationSerializer(read_only=True)
-    role = RoleSerializer(read_only=True)
+    roles = RoleSerializer(many=True, read_only=True)
 
     class Meta:
         model = User
         fields = (
             'id', 'first_name', 'last_name', 'email', 'authorization_id',
             'username', 'authorization_directory', 'display_name',
-            'organization', 'role')
+            'organization', 'roles')
 
 
 class UserMinSerializer(serializers.ModelSerializer):
@@ -66,19 +66,19 @@ class UserViewSerializer(serializers.ModelSerializer):
     """
     history = serializers.SerializerMethodField()
     organization = OrganizationMinSerializer(read_only=True)
-    role = RoleMinSerializer(read_only=True)
+    roles = RoleMinSerializer(many=True, read_only=True)
 
     class Meta:
         model = User
         fields = (
             'authorization_id', 'cell_phone', 'display_name', 'email',
             'first_name', 'history', 'id', 'is_active', 'last_name',
-            'organization', 'phone', 'role')
+            'organization', 'phone', 'roles')
 
     def get_history(self, obj):
         """
         Function to get the user's activity.
-        This should be restricted based on the user's role.
+        This should be restricted based on the user's roles.
         A government user won't see draft, submitted, refused.
         A regular user won't see recommended and not recommended.
         Regular users will only see histories related to their organization
@@ -88,8 +88,7 @@ class UserViewSerializer(serializers.ModelSerializer):
 
         # if the user is not a government user we should limit what we show
         # so no recommended/not recommended
-        if (request.user.role is None or
-                not request.user.role.is_government_role):
+        if (request.user.roles is None or not request.user.is_government_user):
             if request.user.organization != obj.organization:
                 raise exceptions.PermissionDenied(
                     'You do not have sufficient authorization to use this '

--- a/backend/api/serializers/User.py
+++ b/backend/api/serializers/User.py
@@ -25,21 +25,17 @@ from rest_framework import exceptions, serializers
 
 from api.models.User import User
 from .Organization import OrganizationSerializer, OrganizationMinSerializer
-from .Role import RoleSerializer, RoleMinSerializer
-
-
-class MemberSerializer(serializers.ModelSerializer):
-    roles = RoleMinSerializer(many=True, read_only=True)
-
-    class Meta:
-        model = User
-        fields = (
-            'id', 'first_name', 'last_name', 'display_name', 'email', 'phone',
-            'roles', 'is_active')
+from .Permission import PermissionSerializer
+from .Role import RoleSerializer
 
 
 class UserSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the full details of the User and what permissions
+    the user has
+    """
     organization = OrganizationSerializer(read_only=True)
+    permissions = PermissionSerializer(many=True, read_only=True)
     roles = RoleSerializer(many=True, read_only=True)
 
     class Meta:
@@ -47,16 +43,21 @@ class UserSerializer(serializers.ModelSerializer):
         fields = (
             'id', 'first_name', 'last_name', 'email', 'authorization_id',
             'username', 'authorization_directory', 'display_name',
-            'organization', 'roles')
+            'organization', 'roles', 'is_government_user', 'permissions')
 
 
 class UserMinSerializer(serializers.ModelSerializer):
+    """
+    Serializer for display information for the User
+    """
     organization = OrganizationMinSerializer(read_only=True)
+    roles = RoleSerializer(many=True, read_only=True)
 
     class Meta:
         model = User
         fields = (
-            'id', 'first_name', 'last_name', 'display_name', 'organization')
+            'id', 'first_name', 'last_name', 'display_name', 'email', 'phone',
+            'roles', 'is_active', 'organization')
 
 
 class UserViewSerializer(serializers.ModelSerializer):
@@ -66,7 +67,7 @@ class UserViewSerializer(serializers.ModelSerializer):
     """
     history = serializers.SerializerMethodField()
     organization = OrganizationMinSerializer(read_only=True)
-    roles = RoleMinSerializer(many=True, read_only=True)
+    roles = RoleSerializer(many=True, read_only=True)
 
     class Meta:
         model = User

--- a/backend/api/tests/base_test_case.py
+++ b/backend/api/tests/base_test_case.py
@@ -57,7 +57,8 @@ class BaseTestCase(TestCase):
         'signing_authority_assertions.json',
         'test_prodlike_government_users_and_roles.json',
         'test_prodlike_government_users_and_roles_v0.3.1.json',
-        'test_users_and_organizations_v0.3.1.json'
+        'test_users_and_organizations_v0.3.1.json',
+        'test_users_multiple_roles.json'
     ]
 
     usernames = [
@@ -66,7 +67,8 @@ class BaseTestCase(TestCase):
         'fs_user_3',
         'gov_director',
         'gov_analyst',
-        'gov_admin'
+        'gov_admin',
+        'gov_multi_role'
     ]
 
     # For use in child classes

--- a/backend/api/tests/security/test_api_security_compliance_periods.py
+++ b/backend/api/tests/security/test_api_security_compliance_periods.py
@@ -45,27 +45,38 @@ class TestCompliancePeriodsAPI(BaseAPISecurityTestCase):
         url = "/api/compliance_periods"
 
         all_users = self.users
-        expected_results = defaultdict(lambda: {'status': status.HTTP_403_FORBIDDEN,
-                                                'reason': "Default response should be no access"})
+        expected_results = defaultdict(lambda: {
+            'status': status.HTTP_403_FORBIDDEN,
+            'reason': "Default response should be no access"})
 
-        expected_results[('gov_admin',)] = {'status': status.HTTP_200_OK,
-                                            'reason': 'should have read access'
-                                                      ' to compliance periods'}
+        expected_results[('gov_admin',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'should have read access to compliance periods'}
 
-        expected_results[('gov_analyst',)] = {'status': status.HTTP_200_OK,
-                                              'reason': 'should have read access to'
-                                                        ' compliance periods'}
+        expected_results[('gov_analyst',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'should have read access to compliance periods'}
 
-        expected_results[('gov_director',)] = {'status': status.HTTP_200_OK,
-                                               'reason': 'should have read access to'
-                                                         ' compliance periods'}
+        expected_results[('gov_director',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'should have read access to compliance periods'}
+
+        expected_results[('gov_multi_role',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'should have read access to compliance periods'}
+
         for user in all_users:
-            with self.subTest(user=user,
-                              expected_status=expected_results[(user,)]['status'],
-                              reason=expected_results[(user,)]['reason']):
+            with self.subTest(
+                user=user,
+                expected_status=expected_results[(user,)]['status'],
+                reason=expected_results[(user,)]['reason']
+            ):
                 response = self.clients[user].get(url)
                 logging.debug(response.content.decode('utf-8'))
-                self.assertEqual(response.status_code, expected_results[(user,)]['status'])
+
+                self.assertEqual(
+                    response.status_code,
+                    expected_results[(user,)]['status'])
 
     def test_get_by_id(self):
         """Test that getting another user directly is not a valid action
@@ -77,20 +88,25 @@ class TestCompliancePeriodsAPI(BaseAPISecurityTestCase):
 
         cp_that_exists = DataCreationUtilities.create_compliance_period()
 
-        expected_results = defaultdict(lambda: {'status': status.HTTP_403_FORBIDDEN,
-                                                'reason': "Default response should be no access"})
+        expected_results = defaultdict(lambda: {
+            'status': status.HTTP_403_FORBIDDEN,
+            'reason': "Default response should be no access"})
 
-        expected_results[('gov_admin',)] = {'status': status.HTTP_200_OK,
-                                            'reason': 'should have read access'
-                                                      ' to compliance periods'}
+        expected_results[('gov_admin',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'should have read access to compliance periods'}
 
-        expected_results[('gov_analyst',)] = {'status': status.HTTP_200_OK,
-                                              'reason': 'should have read access'
-                                                        ' to compliance periods'}
+        expected_results[('gov_analyst',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'should have read access to compliance periods'}
 
-        expected_results[('gov_director',)] = {'status': status.HTTP_200_OK,
-                                               'reason': 'should have read access'
-                                                         ' to compliance periods'}
+        expected_results[('gov_director',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'should have read access to compliance periods'}
+
+        expected_results[('gov_multi_role',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'should have read access to compliance periods'}
 
         for user in all_users:
             with self.subTest(user=user,
@@ -110,52 +126,75 @@ class TestCompliancePeriodsAPI(BaseAPISecurityTestCase):
 
         all_users = self.users
 
-        expected_results = defaultdict(lambda: {'status': status.HTTP_403_FORBIDDEN,
-                                                'reason': "Default response should be no access"})
+        expected_results = defaultdict(lambda: {
+            'status': status.HTTP_403_FORBIDDEN,
+            'reason': "Default response should be no access"})
 
-        expected_results[('gov_admin',)] = {'status': status.HTTP_201_CREATED,
-                                            'reason': 'Admin should have create access for'
-                                                      ' compliance periods'}
+        expected_results[('gov_admin',)] = {
+            'status': status.HTTP_201_CREATED,
+            'reason': 'Admin should have create access for compliance periods'}
 
-        expected_results[('gov_director',)] = {'status': status.HTTP_201_CREATED,
-                                               'reason': 'Director should have create access for'
-                                                         ' compliance periods'}
+        expected_results[('gov_director',)] = {
+            'status': status.HTTP_201_CREATED,
+            'reason': 'Director should have create access for compliance '
+                      'periods'}
 
-        for index, user in enumerate(all_users):
-            with self.subTest(user=user,
-                              expected_status=expected_results[(user,)]['status'],
-                              reason=expected_results[(user,)]['reason']):
+        expected_results[('gov_multi_role',)] = {
+            'status': status.HTTP_201_CREATED,
+            'reason': 'Multi Role should have create access for compliance '
+                      'periods'}
+
+        for _index, user in enumerate(all_users):
+            with self.subTest(
+                user=user,
+                expected_status=expected_results[(user,)]['status'],
+                reason=expected_results[(user,)]['reason']
+            ):
                 payload = {
                     'description': 'Posted CP {0!s}'.format(uuid.uuid4()),
                     'display_order': 1
                 }
 
-                response = self.clients[user].post(url,
-                                                   content_type='application/json',
-                                                   data=json.dumps(payload))
+                response = self.clients[user].post(
+                    url,
+                    content_type='application/json',
+                    data=json.dumps(payload))
 
                 logging.debug(response.content.decode('utf-8'))
-                self.assertEqual(response.status_code, expected_results[(user,)]['status'])
+                self.assertEqual(
+                    response.status_code,
+                    expected_results[(user,)]['status'])
 
     def test_delete(self):
-        """Test that deleting compliance periods is not a semantically valid action"""
+        """
+        Test that deleting compliance periods is not a semantically valid
+        action
+        """
 
         url = "/api/compliance_periods/{0!s}"
 
         all_users = self.users
 
-        expected_results = defaultdict(lambda: {'status': [status.HTTP_405_METHOD_NOT_ALLOWED,
-                                                           status.HTTP_403_FORBIDDEN],
-                                                'reason': "Default response should be no access"})
+        expected_results = defaultdict(lambda: {
+            'status': [
+                status.HTTP_405_METHOD_NOT_ALLOWED,
+                status.HTTP_403_FORBIDDEN
+            ],
+            'reason': "Default response should be no access"})
 
         for user in all_users:
-            with self.subTest(user=user,
-                              expected_statuses=expected_results[(user,)]['status'],
-                              reason=expected_results[(user,)]['reason']):
+            with self.subTest(
+                user=user,
+                expected_statuses=expected_results[(user,)]['status'],
+                reason=expected_results[(user,)]['reason']
+            ):
                 cp_that_exists = DataCreationUtilities.create_compliance_period()
-                response = self.clients[user].delete(url.format(cp_that_exists['id']))
+                response = self.clients[user].delete(
+                    url.format(cp_that_exists['id']))
                 logging.debug(response)
-                self.assertIn(response.status_code, expected_results[(user,)]['status'])
+                self.assertIn(
+                    response.status_code,
+                    expected_results[(user,)]['status'])
 
     def test_put(self):
         """
@@ -166,20 +205,30 @@ class TestCompliancePeriodsAPI(BaseAPISecurityTestCase):
 
         all_users = self.users
 
-        expected_results = defaultdict(lambda: {'status': status.HTTP_403_FORBIDDEN,
-                                                'reason': "Default response should be no access"})
+        expected_results = defaultdict(lambda: {
+            'status': status.HTTP_403_FORBIDDEN,
+            'reason': "Default response should be no access"})
 
-        expected_results[('gov_admin',)] = {'status': status.HTTP_200_OK,
-                                            'reason': 'Admin should have update access for'
-                                                      ' compliance periods'}
+        expected_results[('gov_admin',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'Admin should have update access for compliance periods'}
 
-        expected_results[('gov_director',)] = {'status': status.HTTP_200_OK,
-                                               'reason': 'Director should have update access for'
-                                                         ' compliance periods'}
-        for index, user in enumerate(all_users):
-            with self.subTest(user=user,
-                              expected_status=expected_results[(user,)]['status'],
-                              reason=expected_results[(user,)]['reason']):
+        expected_results[('gov_director',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'Director should have update access for compliance '
+                      ' periods'}
+
+        expected_results[('gov_multi_role',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'Multi Role should have update access for compliance '
+                      ' periods'}
+
+        for _index, user in enumerate(all_users):
+            with self.subTest(
+                user=user,
+                expected_status=expected_results[(user,)]['status'],
+                reason=expected_results[(user,)]['reason']
+            ):
                 cp_that_exists = DataCreationUtilities.create_compliance_period()
 
                 payload = {
@@ -195,7 +244,10 @@ class TestCompliancePeriodsAPI(BaseAPISecurityTestCase):
                 )
                 logging.debug(response)
 
-                self.assertEqual(response.status_code, expected_results[(user,)]['status'], "PUT")
+                self.assertEqual(
+                    response.status_code,
+                    expected_results[(user,)]['status'],
+                    "PUT")
 
                 payload = {
                     'description': 'Patched CP {0!s}'.format(uuid.uuid4())
@@ -209,4 +261,7 @@ class TestCompliancePeriodsAPI(BaseAPISecurityTestCase):
                 )
                 logging.debug(response)
 
-                self.assertEqual(response.status_code, expected_results[(user,)]['status'], "PATCH")
+                self.assertEqual(
+                    response.status_code,
+                    expected_results[(user,)]['status'],
+                    "PATCH")

--- a/backend/api/tests/security/test_api_security_organizations.py
+++ b/backend/api/tests/security/test_api_security_organizations.py
@@ -49,42 +49,64 @@ class TestOrganizationsAPI(BaseAPISecurityTestCase):
         url = "/api/organizations"
 
         all_users = self.users
-        expected_results = defaultdict(lambda: {'status': status.HTTP_403_FORBIDDEN,
-                                                'reason': "Default response should be no access"})
+        expected_results = defaultdict(lambda: {
+            'status': status.HTTP_403_FORBIDDEN,
+            'reason': "Default response should be no access"})
 
-        expected_results[('gov_director',)] = {'status': status.HTTP_200_OK,
-                                               'reason': 'Director should have read access to orgs'}
+        expected_results[('gov_director',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'Director should have read access to orgs'}
 
-        expected_results[('gov_analyst',)] = {'status': status.HTTP_200_OK,
-                                              'reason': 'Analyst should have read access to orgs'}
+        expected_results[('gov_analyst',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'Analyst should have read access to orgs'}
+
+        expected_results[('gov_multi_role',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'Multi Role should have read access to orgs'}
 
         for user in all_users:
-            with self.subTest(user=user,
-                              expected_status=expected_results[(user,)]['status'],
-                              reason=expected_results[(user,)]['reason']):
+            with self.subTest(
+                user=user,
+                expected_status=expected_results[(user,)]['status'],
+                reason=expected_results[(user,)]['reason']
+            ):
                 response = self.clients[user].get(url)
                 logging.debug(response.content.decode('utf-8'))
-                self.assertEqual(response.status_code, expected_results[(user,)]['status'])
+                self.assertEqual(
+                    response.status_code,
+                    expected_results[(user,)]['status'])
 
     def test_delete(self):
-        """Test that deleting organizations is not a semantically valid action"""
+        """
+        Test that deleting organizations is not a semantically valid action
+        """
 
         url = "/api/organizations/{0!s}"
 
         all_users = self.users
 
-        expected_results = defaultdict(lambda: {'status': [status.HTTP_405_METHOD_NOT_ALLOWED,
-                                                           status.HTTP_403_FORBIDDEN],
-                                                'reason': "Default response should be no access"})
+        expected_results = defaultdict(lambda: {
+            'status': [
+                status.HTTP_405_METHOD_NOT_ALLOWED,
+                status.HTTP_403_FORBIDDEN
+            ],
+            'reason': "Default response should be no access"})
 
         for user in all_users:
-            with self.subTest(user=user,
-                              expected_statuses=expected_results[(user,)]['status'],
-                              reason=expected_results[(user,)]['reason']):
+            with self.subTest(
+                user=user,
+                expected_statuses=expected_results[(user,)]['status'],
+                reason=expected_results[(user,)]['reason']
+            ):
                 org_that_exists = DataCreationUtilities.create_test_organization()
-                response = self.clients[user].delete(url.format(org_that_exists['id']))
+                response = self.clients[user].delete(
+                    url.format(org_that_exists['id']))
                 logging.debug(response)
-                self.assertIn(response.status_code, expected_results[(user,)]['status'])
+
+                self.assertIn(
+                    response.status_code,
+                    expected_results[(user,)]['status'])
 
     def test_post(self):
         """
@@ -96,16 +118,20 @@ class TestOrganizationsAPI(BaseAPISecurityTestCase):
 
         all_users = self.users
 
-        expected_results = defaultdict(lambda: {'status': status.HTTP_403_FORBIDDEN,
-                                                'reason': "Default response should be no access"})
+        expected_results = defaultdict(lambda: {
+            'status': status.HTTP_403_FORBIDDEN,
+            'reason': "Default response should be no access"})
 
-        expected_results[('gov_admin',)] = {'status': status.HTTP_201_CREATED,
-                                            'reason': 'Admin should have create access for orgs'}
+        expected_results[('gov_admin',)] = {
+            'status': status.HTTP_201_CREATED,
+            'reason': 'Admin should have create access for orgs'}
 
         for index, user in enumerate(all_users):
-            with self.subTest(user=user,
-                              expected_status=expected_results[(user,)]['status'],
-                              reason=expected_results[(user,)]['reason']):
+            with self.subTest(
+                user=user,
+                expected_status=expected_results[(user,)]['status'],
+                reason=expected_results[(user,)]['reason']
+            ):
                 payload = {
                     'status': OrganizationStatus.objects.get_by_natural_key('Active').id,
                     'type': OrganizationType.objects.get_by_natural_key('Part3FuelSupplier').id,
@@ -113,9 +139,10 @@ class TestOrganizationsAPI(BaseAPISecurityTestCase):
                     'actions_type': OrganizationActionsType.objects.get_by_natural_key('Buy And Sell').id
                 }
 
-                response = self.clients[user].post(url,
-                                                   content_type='application/json',
-                                                   data=json.dumps(payload))
+                response = self.clients[user].post(
+                    url,
+                    content_type='application/json',
+                    data=json.dumps(payload))
 
                 logging.debug(response.content.decode('utf-8'))
                 self.assertEqual(response.status_code, expected_results[(user,)]['status'])
@@ -130,16 +157,20 @@ class TestOrganizationsAPI(BaseAPISecurityTestCase):
 
         all_users = self.users
 
-        expected_results = defaultdict(lambda: {'status': status.HTTP_403_FORBIDDEN,
-                                                'reason': "Default response should be no access"})
+        expected_results = defaultdict(lambda: {
+            'status': status.HTTP_403_FORBIDDEN,
+            'reason': "Default response should be no access"})
 
-        expected_results[('gov_admin',)] = {'status': status.HTTP_200_OK,
-                                            'reason': 'Admin should have write access for orgs'}
+        expected_results[('gov_admin',)] = {
+            'status': status.HTTP_200_OK,
+            'reason': 'Admin should have write access for orgs'}
 
-        for index, user in enumerate(all_users):
-            with self.subTest(user=user,
-                              expected_status=expected_results[(user,)]['status'],
-                              reason=expected_results[(user,)]['reason']):
+        for _index, user in enumerate(all_users):
+            with self.subTest(
+                user=user,
+                expected_status=expected_results[(user,)]['status'],
+                reason=expected_results[(user,)]['reason']
+            ):
                 org_that_exists = DataCreationUtilities.create_test_organization()
 
                 payload = {
@@ -157,7 +188,10 @@ class TestOrganizationsAPI(BaseAPISecurityTestCase):
                 )
                 logging.debug(response)
 
-                self.assertEqual(response.status_code, expected_results[(user,)]['status'], "PUT")
+                self.assertEqual(
+                    response.status_code,
+                    expected_results[(user,)]['status'],
+                    "PUT")
 
                 payload = {
                     'name': 'Patched org {}'.format(str(uuid.uuid4())),
@@ -171,4 +205,7 @@ class TestOrganizationsAPI(BaseAPISecurityTestCase):
                 )
                 logging.debug(response)
 
-                self.assertEqual(response.status_code, expected_results[(user,)]['status'], "PATCH")
+                self.assertEqual(
+                    response.status_code,
+                    expected_results[(user,)]['status'],
+                    "PATCH")

--- a/backend/api/viewsets/Organization.py
+++ b/backend/api/viewsets/Organization.py
@@ -9,11 +9,11 @@ from api.models.Organization import Organization
 from api.models.OrganizationBalance import OrganizationBalance
 from api.models.OrganizationType import OrganizationType
 from api.models.User import User
-from api.serializers import MemberSerializer
 from api.serializers import OrganizationSerializer
 from api.serializers import OrganizationBalanceSerializer
 from api.serializers import OrganizationHistorySerializer
 from api.serializers import OrganizationMinSerializer
+from api.serializers import UserMinSerializer
 from api.permissions.OrganizationPermissions import OrganizationPermissions
 
 
@@ -35,7 +35,7 @@ class OrganizationViewSet(AuditableMixin, viewsets.GenericViewSet,
         'default': OrganizationSerializer,
         'history': OrganizationHistorySerializer,
         'fuel_suppliers': OrganizationMinSerializer,
-        'members': MemberSerializer
+        'members': UserMinSerializer
     }
 
     def get_serializer_class(self):

--- a/frontend/__tests__/utils/translate.js
+++ b/frontend/__tests__/utils/translate.js
@@ -1,0 +1,15 @@
+import roleName from '../../src/utils/translate';
+
+test('roleName should return the correct role description', () => {
+  let value = roleName({
+    id: 2
+  });
+
+  expect(value).toEqual('Government Analyst');
+
+  value = roleName({
+    id: 1
+  });
+
+  expect(value).toBeFalsy(); // since we don't have a record for 1 in the constants file
+});

--- a/frontend/src/app/components/Navbar.js
+++ b/frontend/src/app/components/Navbar.js
@@ -31,8 +31,7 @@ class Navbar extends Component {
     const SecondLevelNavigation = (
       <div className="level2Navigation">
         <div className="container">
-          {this.props.loggedInUser.roles &&
-          this.props.loggedInUser.isGovernmentUser &&
+          {this.props.loggedInUser.isGovernmentUser &&
           <NavLink
             activeClassName="active"
             id="navbar-organizations"
@@ -41,8 +40,7 @@ class Navbar extends Component {
             Fuel Suppliers
           </NavLink>
           }
-          {(!this.props.loggedInUser.roles ||
-          !this.props.loggedInUser.isGovernmentUser) &&
+          {!this.props.loggedInUser.isGovernmentUser &&
           [
             <a
               href={ORGANIZATIONS.BULLETIN}
@@ -77,8 +75,7 @@ class Navbar extends Component {
           >
             Credit Transactions
           </NavLink>
-          {this.props.loggedInUser.roles &&
-          this.props.loggedInUser.isGovernmentUser &&
+          {this.props.loggedInUser.isGovernmentUser &&
           <NavLink
             activeClassName="active"
             exact={false}
@@ -100,8 +97,7 @@ class Navbar extends Component {
       >
         <a id="navigation-anchor" href="#navigation-anchor"><span>Navigation Bar</span></a>
         <ul className="nav navbar-nav">
-          {this.props.loggedInUser.roles &&
-          this.props.loggedInUser.isGovernmentUser &&
+          {this.props.loggedInUser.isGovernmentUser &&
           <li>
             <NavLink
               id="collapse-navbar-organization"
@@ -111,8 +107,7 @@ class Navbar extends Component {
             </NavLink>
           </li>
           }
-          {(!this.props.loggedInUser.roles ||
-          !this.props.loggedInUser.isGovernmentUser) &&
+          {!this.props.loggedInUser.isGovernmentUser &&
           [
             <li key="bulletin">
               <a
@@ -150,8 +145,7 @@ class Navbar extends Component {
             Credit Transactions
             </NavLink>
           </li>
-          {this.props.loggedInUser.roles &&
-          this.props.loggedInUser.isGovernmentUser &&
+          {this.props.loggedInUser.isGovernmentUser &&
           <li>
             <NavLink
               id="collapse-navbar-administration"

--- a/frontend/src/app/components/Navbar.js
+++ b/frontend/src/app/components/Navbar.js
@@ -31,8 +31,8 @@ class Navbar extends Component {
     const SecondLevelNavigation = (
       <div className="level2Navigation">
         <div className="container">
-          {this.props.loggedInUser.role &&
-          this.props.loggedInUser.role.isGovernmentRole &&
+          {this.props.loggedInUser.roles &&
+          this.props.loggedInUser.isGovernmentUser &&
           <NavLink
             activeClassName="active"
             id="navbar-organizations"
@@ -41,8 +41,8 @@ class Navbar extends Component {
             Fuel Suppliers
           </NavLink>
           }
-          {(!this.props.loggedInUser.role ||
-          !this.props.loggedInUser.role.isGovernmentRole) &&
+          {(!this.props.loggedInUser.roles ||
+          !this.props.loggedInUser.isGovernmentUser) &&
           [
             <a
               href={ORGANIZATIONS.BULLETIN}
@@ -77,8 +77,8 @@ class Navbar extends Component {
           >
             Credit Transactions
           </NavLink>
-          {this.props.loggedInUser.role &&
-          this.props.loggedInUser.role.isGovernmentRole &&
+          {this.props.loggedInUser.roles &&
+          this.props.loggedInUser.isGovernmentUser &&
           <NavLink
             activeClassName="active"
             exact={false}
@@ -100,8 +100,8 @@ class Navbar extends Component {
       >
         <a id="navigation-anchor" href="#navigation-anchor"><span>Navigation Bar</span></a>
         <ul className="nav navbar-nav">
-          {this.props.loggedInUser.role &&
-          this.props.loggedInUser.role.isGovernmentRole &&
+          {this.props.loggedInUser.roles &&
+          this.props.loggedInUser.isGovernmentUser &&
           <li>
             <NavLink
               id="collapse-navbar-organization"
@@ -111,8 +111,8 @@ class Navbar extends Component {
             </NavLink>
           </li>
           }
-          {(!this.props.loggedInUser.role ||
-          !this.props.loggedInUser.role.isGovernmentRole) &&
+          {(!this.props.loggedInUser.roles ||
+          !this.props.loggedInUser.isGovernmentUser) &&
           [
             <li key="bulletin">
               <a
@@ -150,8 +150,8 @@ class Navbar extends Component {
             Credit Transactions
             </NavLink>
           </li>
-          {this.props.loggedInUser.role &&
-          this.props.loggedInUser.role.isGovernmentRole &&
+          {this.props.loggedInUser.roles &&
+          this.props.loggedInUser.isGovernmentUser &&
           <li>
             <NavLink
               id="collapse-navbar-administration"
@@ -268,14 +268,14 @@ class Navbar extends Component {
 Navbar.propTypes = {
   loggedInUser: PropTypes.shape({
     displayName: PropTypes.string,
+    isGovernmentUser: PropTypes.bool,
     organization: PropTypes.shape({
       name: PropTypes.string,
       id: PropTypes.number
     }),
-    role: PropTypes.shape({
-      id: PropTypes.number,
-      isGovernmentRole: PropTypes.bool
-    })
+    roles: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.number
+    }))
   }).isRequired,
   isAuthenticated: PropTypes.bool.isRequired
 };

--- a/frontend/src/credit_transfers/components/CreditTransactionsPage.js
+++ b/frontend/src/credit_transfers/components/CreditTransactionsPage.js
@@ -17,8 +17,8 @@ const CreditTransactionsPage = (props) => {
   return (
     <div className="page_credit_transactions">
       <div className="credit_balance">
-        {props.loggedInUser.role &&
-          !props.loggedInUser.role.isGovernmentRole &&
+        {props.loggedInUser.roles &&
+          !props.loggedInUser.isGovernmentUser &&
           <h3>
             Credit Balance: {
               numeral(props.loggedInUser.organization.organizationBalance.validatedCredits)
@@ -27,8 +27,8 @@ const CreditTransactionsPage = (props) => {
           </h3>
         }
         {!isFetching &&
-          props.loggedInUser.role &&
-          props.loggedInUser.role.isGovernmentRole &&
+          props.loggedInUser.roles &&
+          props.loggedInUser.isGovernmentUser &&
           [
             !props.organization &&
             <div key="all-organizations-credit-balance">
@@ -80,7 +80,7 @@ const CreditTransactionsPage = (props) => {
       <h1>{props.title}</h1>
       <div className="right-toolbar-container">
         <div className="actions-container">
-          {props.loggedInUser.role &&
+          {props.loggedInUser.roles &&
           props.loggedInUser.hasPermission(PERMISSIONS_CREDIT_TRANSACTIONS.PROPOSE) &&
             <button
               className="btn btn-primary"
@@ -117,6 +117,7 @@ CreditTransactionsPage.propTypes = {
   loggedInUser: PropTypes.shape({
     displayName: PropTypes.string,
     hasPermission: PropTypes.func,
+    isGovernmentUser: PropTypes.bool,
     organization: PropTypes.shape({
       id: PropTypes.number,
       name: PropTypes.string,
@@ -124,10 +125,9 @@ CreditTransactionsPage.propTypes = {
         validatedCredits: PropTypes.number
       })
     }),
-    role: PropTypes.shape({
-      id: PropTypes.number,
-      isGovernmentRole: PropTypes.bool
-    })
+    roles: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.number
+    }))
   }).isRequired,
   organization: PropTypes.oneOfType([
     PropTypes.bool,

--- a/frontend/src/credit_transfers/components/CreditTransferForm.js
+++ b/frontend/src/credit_transfers/components/CreditTransferForm.js
@@ -122,11 +122,7 @@ CreditTransferForm.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   id: PropTypes.number,
   loggedInUser: PropTypes.shape({
-    hasPermission: PropTypes.func,
-    role: PropTypes.shape({
-      id: PropTypes.number,
-      isGovernmentRole: PropTypes.bool
-    })
+    hasPermission: PropTypes.func
   }).isRequired,
   title: PropTypes.string,
   toggleCheck: PropTypes.func.isRequired,

--- a/frontend/src/organizations/components/OrganizationMembersTable.js
+++ b/frontend/src/organizations/components/OrganizationMembersTable.js
@@ -8,8 +8,8 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { Link } from 'react-router-dom';
 import 'react-table/react-table.css';
 
-import ROLES from '../../constants/roles';
 import USERS from '../../constants/routes/Users';
+import roleName from '../../utils/translate';
 
 const OrganizationMembersTable = (props) => {
   const columns = [{
@@ -17,14 +17,14 @@ const OrganizationMembersTable = (props) => {
     className: 'col-name',
     Header: 'Name',
     id: 'name',
-    minWidth: 200
+    minWidth: 150
   }, {
-    accessor: item => item.role &&
-      Object.values(ROLES).find(element => element.id === item.role.id).description,
+    accessor: item => item.roles &&
+      item.roles.map(role => roleName(role)).join(', '),
     className: 'col-role',
     Header: 'Role',
     id: 'role',
-    minWidth: 150
+    minWidth: 200
   }, {
     accessor: item => item.email,
     className: 'col-status-display',

--- a/frontend/src/reducers/userReducer.js
+++ b/frontend/src/reducers/userReducer.js
@@ -26,8 +26,8 @@ const userRequest = (state = {
         loggedInUser: {
           ...action.data,
           hasPermission: (permissionCode) => {
-            if (action.data.role) {
-              return action.data.role.permissions.findIndex(permission => (
+            if (action.data.permissions) {
+              return action.data.permissions.findIndex(permission => (
                 permission.code === permissionCode
               )) >= 0;
             }

--- a/frontend/src/users/components/UserDetails.js
+++ b/frontend/src/users/components/UserDetails.js
@@ -5,7 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Loading from '../../app/components/Loading';
-import ROLES from '../../constants/roles';
+import roleName from '../../utils/translate';
 
 import UserHistoryTable from './UserHistoryTable';
 
@@ -37,10 +37,9 @@ const UserDetails = props => (
         <div>Status:
           <strong> {props.user.details.isActive ? 'Active' : 'Inactive'}</strong>
         </div>
-        {props.user.details.role &&
+        {props.user.details.roles &&
           <div>Role:
-            <strong> {Object.values(ROLES).find(element => element.id ===
-            props.user.details.role.id).description}
+            <strong> {props.user.details.roles.map(role => roleName(role)).join(', ')}
             </strong>
           </div>
         }
@@ -70,9 +69,9 @@ UserDetails.propTypes = {
         name: PropTypes.string
       }),
       phone: PropTypes.string,
-      role: PropTypes.shape({
+      roles: PropTypes.arrayOf(PropTypes.shape({
         id: PropTypes.number
-      })
+      }))
     }),
     errors: PropTypes.shape({}),
     isFetching: PropTypes.bool.isRequired

--- a/frontend/src/utils/translate.js
+++ b/frontend/src/utils/translate.js
@@ -1,0 +1,22 @@
+import ROLES from '../constants/roles';
+/*
+ * This is for fetching the role description from our constants file as
+ * the front-end description might be different from the one coming from the
+ * backend
+ *
+ * @param Object containing the ID of the role we want to get the value of
+ *
+ * @return String Role Name
+ */
+const roleName = (role) => {
+  const roles = Object.values(ROLES);
+  const found = roles.findIndex(element => element.id === role.id);
+
+  if (found >= 0) {
+    return roles[found].description;
+  }
+
+  return false;
+};
+
+export default roleName;


### PR DESCRIPTION
#454 

You should now be able to assign multiple roles to a user without the app breaking.

Changelog:
- user now has a new property called 'roles' instead of 'role'
- Merged UserMinSerializer and MemberSerializer together (They looked too similar)
- RoleSerializer no longer loads permissions
- Merged RoleSerializer and RoleMinSerializer (other than one loads permissions. they're very similar)
- User now has a permissions property (to avoid duplicate permissions through multiple roles)
- The check to see if the user is a government user has been moved from the role and into the user as a property called 'isGovernmentUser'
- Added helper function in the front-end to get the role name 
- Added test for the helper function