### PR TITLE
Prevent government users from seeing refused transfers

### DIFF
--- a/backend/api/services/CreditTradeService.py
+++ b/backend/api/services/CreditTradeService.py
@@ -28,13 +28,14 @@ class CreditTradeService(object):
         if organization == gov_org:
             # If organization == Government
             #  don't show "Cancelled" transactions
+            #  don't show "Refused" transactions
             #  don't show "Draft", "Submitted" transactions unless the
             #  initiator was government
             #  (Please note that government creating drafts and submitted is
             #  for testing only, in reality government will not do this)
             credit_trades = CreditTrade.objects.filter(
                 ~Q(status__status__in=["Cancelled"]) &
-                (~Q(status__status__in=["Draft", "Submitted"]) |
+                (~Q(status__status__in=["Draft", "Submitted", "Refused"]) |
                  Q(initiator=organization))
             )
         else:

--- a/backend/api/tests/test_credit_trade_operations.py
+++ b/backend/api/tests/test_credit_trade_operations.py
@@ -849,3 +849,48 @@ class TestCreditTradeOperations(BaseTestCase):
         # third entry should be recommended
         self.assertEqual(credit_trade['history'][2]['status']['id'],
                          self.statuses['recommended'].id)
+
+    def test_government_cannot_see_refused_trades(self):
+        """Verify that government users cannot see trades in status 'Refused'"""
+
+        ct = CreditTrade(
+            status=self.statuses['refused'],
+            type=self.credit_trade_types['buy'],
+            initiator=self.users['fs_user_1'].organization,
+            respondent=self.users['fs_user_2'].organization,
+            fair_market_value_per_credit=1,
+            number_of_credits=10
+        )
+        ct.save()
+
+        self.assertNotEqual(ct.id, 0)
+
+        with self.subTest("Initiator can see refused trade"):
+            response = self.clients['fs_user_1'].get('/api/credit_trades/{}'.format(ct.id))
+            self.assertTrue(status.is_success(response.status_code))
+
+        with self.subTest("Respondent can see refused trade"):
+            response = self.clients['fs_user_2'].get('/api/credit_trades/{}'.format(ct.id))
+            self.assertTrue(status.is_success(response.status_code))
+
+        with self.subTest("Third-party cannot see refused trade"):
+            response = self.clients['fs_user_3'].get('/api/credit_trades/{}'.format(ct.id))
+            self.assertFalse(status.is_success(response.status_code))
+
+        with self.subTest("Government analyst cannot see refused trade"):
+            response = self.clients['gov_analyst'].get('/api/credit_trades/{}'.format(ct.id))
+            self.assertFalse(status.is_success(response.status_code))
+
+            response = self.clients['gov_analyst'].get('/api/credit_trades')
+            self.assertTrue(status.is_success(response.status_code))
+            data = json.loads(response.content.decode('utf-8'))
+            self.assertFalse(any(trade['id'] == ct.id for trade in data))
+
+        with self.subTest("Government director cannot see refused trade"):
+            response = self.clients['gov_director'].get('/api/credit_trades/{}'.format(ct.id))
+            self.assertFalse(status.is_success(response.status_code))
+
+            response = self.clients['gov_director'].get('/api/credit_trades')
+            self.assertTrue(status.is_success(response.status_code))
+            data = json.loads(response.content.decode('utf-8'))
+            self.assertFalse(any(trade['id'] == ct.id for trade in data))


### PR DESCRIPTION
Prevent government users from seeing transfers in status "Refused".

Test case added.

Trello card 759