### PR TITLE
Change director decline warning

### DIFF
--- a/frontend/src/app/components/Modal.js
+++ b/frontend/src/app/components/Modal.js
@@ -61,7 +61,7 @@ const Modal = props => (
             type="button"
             className="btn btn-primary"
             data-dismiss="modal"
-            disabled={!((!props.showExtraConfirm) || props.canBypass)}
+            disabled={!((!props.showExtraConfirm) || props.canBypassExtraConfirm)}
             onClick={props.handleSubmit}
           >
             {props.confirmLabel}

--- a/frontend/src/credit_transfers/CreditTransferViewContainer.js
+++ b/frontend/src/credit_transfers/CreditTransferViewContainer.js
@@ -353,6 +353,31 @@ class CreditTransferViewContainer extends Component {
         showExtraConfirm={!this.state.hasCommented}
         extraConfirmType="warning"
       >
+        <div className="alert alert-warning">
+          <p>
+            Under section 11.11 (3) of the Regulation, the Director may decline to approve a
+            proposed transfer if the Director:
+          </p>
+          <dl>
+            <dt>(a)</dt>
+            <dd>
+              considers the intent of the transfer is to avoid compliance with the Act or
+              Regulation, or
+            </dd>
+            <dt>(b)</dt>
+            <dd>
+              is not satisfied that the transferor or transferee will be able to comply with the
+              low carbon fuel requirement (section 6 of the Act)
+            </dd>
+          </dl>
+          <p>
+            This statutory decision is appealable, and you are strongly encouraged to add a comment
+            that provides an explanation as to why the proposed transfer is being declined. The
+            comment will be visible to both Part 3 fuel suppliers involved in the proposed
+            transfer.
+          </p>
+        </div>
+
         Are you sure you want to decline to approve this credit
         {[CREDIT_TRANSFER_TYPES.buy.id, CREDIT_TRANSFER_TYPES.sell.id].indexOf(item.type.id) >= 0
           ? ' transfer proposal' : ' transaction'}?


### PR DESCRIPTION
Per Trello card 765 the messaging for directors choosing to decline a credit transfer proposal is now much more verbose.