### PR TITLE
Historical entry note public

### DIFF
--- a/backend/api/authentication.py
+++ b/backend/api/authentication.py
@@ -1,4 +1,5 @@
 import uuid
+from django.conf import settings
 from django.db.models import Q
 from rest_framework import authentication
 from rest_framework import exceptions
@@ -6,10 +7,13 @@ from api.models.User import User
 from api.models.Organization import Organization
 from api.models.OrganizationType import OrganizationType
 from api.utils import get_firstname_lastname
-from django.conf import settings
 
 
 class UserAuthentication(authentication.BaseAuthentication):
+    """
+    Class that handles whether the user is suppoed to be authenticated
+    or rejected.
+    """
     def authenticate(self, request):
 
         # Bypass auth env variable

--- a/backend/api/permissions/CreditTradeComment.py
+++ b/backend/api/permissions/CreditTradeComment.py
@@ -65,6 +65,7 @@ class CreditTradeCommentPermissions(permissions.BasePermission):
     action_mapping[(_Relationship.GovernmentAnalyst, 'Accepted', True, True)] = True
     action_mapping[(_Relationship.GovernmentAnalyst, 'Recommended', True, True)] = True
     action_mapping[(_Relationship.GovernmentAnalyst, 'Not Recommended', True, True)] = True
+    action_mapping[(_Relationship.GovernmentAnalyst, 'Draft', False, False)] = True
     action_mapping[(_Relationship.GovernmentAnalyst, 'Draft', False, True)] = True
     action_mapping[(_Relationship.GovernmentAnalyst, 'Approved', False, True)] = True
 

--- a/backend/api/permissions/CreditTradeComment.py
+++ b/backend/api/permissions/CreditTradeComment.py
@@ -67,7 +67,7 @@ class CreditTradeCommentPermissions(permissions.BasePermission):
     action_mapping[(_Relationship.GovernmentAnalyst, 'Not Recommended', True, True)] = True
     action_mapping[(_Relationship.GovernmentAnalyst, 'Draft', False, False)] = True
     action_mapping[(_Relationship.GovernmentAnalyst, 'Draft', False, True)] = True
-    action_mapping[(_Relationship.GovernmentAnalyst, 'Approved', False, True)] = True
+    action_mapping[(_Relationship.GovernmentAnalyst, 'Approved', False, False)] = True
 
     action_mapping[(_Relationship.GovernmentDirector, 'Recommended', False, False)] = True
     action_mapping[(_Relationship.GovernmentDirector, 'Not Recommended', False, False)] = True

--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -354,15 +354,14 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
                 data.get('fair_market_value_per_credit') > 0 and \
                 data.get('zero_reason') is not None:
             raise serializers.ValidationError(
-                {'zeroDollarReason': 'Zero dollar reason supplied but this '
-                                     'trade has a non-zero value-per-credit'})
+                {'zeroDollarReason': "Zero dollar reason supplied but this "
+                                     "trade has a non-zero value-per-credit"})
 
         if data.get('fair_market_value_per_credit') == 0 and \
                 data.get('zero_reason') is None:
             allowed_types = list(CreditTradeType.objects.filter(the_type__in=[
                 "Credit Validation", "Credit Retirement", "Part 3 Award"
-            ]).only('id')
-                                 )
+            ]).only('id'))
 
             credit_trade_type = data.get('type')
 

--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -22,7 +22,6 @@
 """
 from datetime import datetime
 
-from django.forms.models import model_to_dict
 from rest_framework import serializers
 
 from api.models.CreditTrade import CreditTrade
@@ -99,24 +98,28 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
             available_statuses.append('Submitted')
 
         allowed_statuses = list(
-            CreditTradeStatus.objects
-                .filter(status__in=available_statuses)
-                .only('id'))
+            CreditTradeStatus.objects.filter(
+                status__in=available_statuses).only('id'))
 
         credit_trade_status = data.get('status')
 
-        will_create_a_comment = True if 'comment' in data \
-                                        and data['comment'] is not None \
-                                        and len(data['comment'].strip()) > 0 else False
+        will_create_a_comment = (True if 'comment' in data and
+                                 data['comment'] is not None and
+                                 len(data['comment'].strip()) > 0
+                                 else False)
 
-        if credit_trade_status.id == CreditTradeStatus.objects.get(status='Submitted').id:
+        if credit_trade_status.id == \
+                CreditTradeStatus.objects.get(status='Submitted').id:
             zero_reason = data.get('zero_reason')
 
-            if zero_reason is not None and zero_reason in CreditTradeZeroReason.objects.filter(reason='Other'):
+            if zero_reason is not None and \
+                    zero_reason in CreditTradeZeroReason.objects.filter(
+                            reason='Other'):
                 if not will_create_a_comment:
                     raise serializers.ValidationError({
-                        'forbidden': "Cannot propose a trade with zero-reason 'Other' without"
-                                     " creating an explanatory comment'"
+                        'forbidden': "Cannot propose a trade with zero-reason "
+                                     "'Other' without creating an explanatory "
+                                     "comment'"
                     })
 
         if credit_trade_status not in allowed_statuses:
@@ -132,9 +135,12 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
 
             allowed_types = list(
                 CreditTradeType.objects.filter(
-                    the_type__in=["Credit Validation", "Credit Retirement", "Part 3 Award"]).only(
-                    'id'
-                )
+                    the_type__in=[
+                        "Credit Validation",
+                        "Credit Retirement",
+                        "Part 3 Award"
+                    ]
+                ).only('id')
             )
 
             if credit_trade_type not in allowed_types:
@@ -148,16 +154,15 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
                 data.get('fair_market_value_per_credit') > 0 and \
                 data.get('zero_reason') is not None:
             raise serializers.ValidationError(
-                {'zeroDollarReason': 'Zero dollar reason supplied but this trade has a '
-                                     'non-zero value-per-credit'})
+                {'zeroDollarReason': "Zero dollar reason supplied but this "
+                                     "trade has a non-zero value-per-credit"})
 
         # If the initiator is 'selling', make sure that the organization
         # has enough credits
         sell_type = CreditTradeType.objects.get(the_type="Sell")
         draft_propose_statuses = list(
-            CreditTradeStatus.objects
-                .filter(status__in=["Draft", "Submitted"])
-                .only('id'))
+            CreditTradeStatus.objects.filter(
+                status__in=["Draft", "Submitted"]).only('id'))
 
         if credit_trade_type == sell_type and \
                 data.get('initiator') == request.user.organization and \
@@ -170,7 +175,7 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError({
                     'insufficientCredits': "{} does not have enough credits "
                                            "for the proposal.".format(
-                        request.user.organization.name)
+                                               request.user.organization.name)
                 })
 
         return data
@@ -207,7 +212,8 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
                   'create_user', 'update_user',
                   'compliance_period', 'is_rescinded', 'comment')
 
-    comment = serializers.CharField(max_length=4000, allow_null=True, allow_blank=True, required=False)
+    comment = serializers.CharField(
+        max_length=4000, allow_null=True, allow_blank=True, required=False)
 
 
 class CreditTradeListSerializer(serializers.ModelSerializer):
@@ -251,7 +257,7 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
             })
 
         if self.instance.status.status in [
-            "Cancelled", "Completed", "Declined", "Refused"
+                "Cancelled", "Completed", "Declined", "Refused"
         ]:
             raise serializers.ValidationError({
                 'readOnly': "Cannot update a transaction that's already "
@@ -289,15 +295,14 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
                     self.instance, request)
 
                 allowed_statuses = list(
-                    CreditTradeStatus.objects
-                        .filter(status__in=available_statuses)
-                        .only('id'))
+                    CreditTradeStatus.objects.filter(
+                        status__in=available_statuses).only('id'))
 
                 if credit_trade_status not in allowed_statuses:
                     raise serializers.ValidationError({
                         'invalidStatus': "You do not have permission to set "
                                          "the status to `{}`.".format(
-                            credit_trade_status.status)
+                                             credit_trade_status.status)
                     })
 
             if (credit_trade_status != self.instance.status and
@@ -314,13 +319,15 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
             if credit_trade_status.status == 'Submitted':
                 zero_reason = data.get('zero_reason')
                 if zero_reason is not None and zero_reason.reason == 'Other':
-                    if not (will_create_a_comment or CreditTradeComment.objects.filter(
+                    if not (will_create_a_comment or
+                            CreditTradeComment.objects.filter(
                                 credit_trade_id=self.instance.id,
                                 create_user__organization=request.user.organization
                             ).exists()):
                         raise serializers.ValidationError({
-                            'forbidden': "Cannot propose a trade with zero-reason 'Other' without"
-                                         " creating an explanatory comment'"
+                            'forbidden': "Cannot propose a trade with "
+                                         "zero-reason 'Other' without "
+                                         "creating an explanatory comment"
                         })
 
         if data.get('is_rescinded') is True:
@@ -347,10 +354,11 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
                 data.get('fair_market_value_per_credit') > 0 and \
                 data.get('zero_reason') is not None:
             raise serializers.ValidationError(
-                {'zeroDollarReason': 'Zero dollar reason supplied but this trade has a '
-                                     'non-zero value-per-credit'})
+                {'zeroDollarReason': 'Zero dollar reason supplied but this '
+                                     'trade has a non-zero value-per-credit'})
 
-        if data.get('fair_market_value_per_credit') == 0 and data.get('zero_reason') is None:
+        if data.get('fair_market_value_per_credit') == 0 and \
+                data.get('zero_reason') is None:
             allowed_types = list(CreditTradeType.objects.filter(the_type__in=[
                 "Credit Validation", "Credit Retirement", "Part 3 Award"
             ]).only('id')
@@ -393,16 +401,19 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
 
         previous_state = CreditTrade.objects.get(id=self.instance.id)
 
-        if 'comment' in data and data['comment'] is not None and len(data['comment'].strip()) > 0:
+        if 'comment' in data and data['comment'] is not None and \
+                len(data['comment'].strip()) > 0:
             if 'ADD_COMMENT' not in CreditTradeCommentActions.\
                     available_comment_actions(request, previous_state):
-                raise serializers.ValidationError('Cannot add a comment in this state')
+                raise serializers.ValidationError(
+                    "Cannot add a comment in this state")
 
         accepted_status = CreditTradeStatus.objects.get(status="Accepted")
         draft_propose_statuses = list(
-            CreditTradeStatus.objects
-                .filter(status__in=["Draft", "Submitted"])
-                .only('id'))
+            CreditTradeStatus.objects.filter(
+                status__in=["Draft", "Submitted"]
+            ).only('id')
+        )
 
         if (self.instance.initiator == request.user.organization and
                 credit_trade_status in draft_propose_statuses and
@@ -414,7 +425,7 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError({
                     'insufficientCredits': "{} does not have enough credits "
                                            "for the proposal.".format(
-                        request.user.organization.name)
+                                               request.user.organization.name)
                 })
 
         return data
@@ -451,7 +462,8 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
                   'create_user', 'update_user',
                   'compliance_period', 'is_rescinded', 'comment')
 
-    comment = serializers.CharField(max_length=4000, allow_null=True, allow_blank=True, required=False)
+    comment = serializers.CharField(
+        max_length=4000, allow_null=True, allow_blank=True, required=False)
 
 
 class CreditTradeApproveSerializer(serializers.ModelSerializer):
@@ -469,7 +481,7 @@ class CreditTradeApproveSerializer(serializers.ModelSerializer):
             })
 
         if self.instance.status.status in [
-            "Approved", "Cancelled", "Completed", "Declined"
+                "Approved", "Cancelled", "Completed", "Declined"
         ]:
             raise serializers.ValidationError({
                 'readOnly': "Cannot approve a transaction that's already "
@@ -539,13 +551,13 @@ class CreditTrade2Serializer(serializers.ModelSerializer):
         if cur_status == "Draft":
             return CreditTradeActions.draft(request, obj)
 
-        elif cur_status == "Submitted":
+        if cur_status == "Submitted":
             return CreditTradeActions.submitted(request, obj)
 
-        elif cur_status == "Accepted":
+        if cur_status == "Accepted":
             return CreditTradeActions.accepted(request)
 
-        elif cur_status == "Recommended" or cur_status == "Not Recommended":
+        if cur_status in ["Recommended", "Not Recommended"]:
             return CreditTradeActions.reviewed(request, obj)
 
         return []
@@ -556,6 +568,9 @@ class CreditTrade2Serializer(serializers.ModelSerializer):
         return CreditTradeCommentActions.available_comment_actions(request, obj)
 
     def get_comments(self, obj):
+        """
+        Returns all the attached comments for the credit trade
+        """
         request = self.context.get('request')
 
         # If the user doesn't have any roles assigned, treat as though the user
@@ -575,6 +590,9 @@ class CreditTrade2Serializer(serializers.ModelSerializer):
         return serializer.data
 
     def get_history(self, obj):
+        """
+        Returns all the previous status changes for the credit trade
+        """
         from .CreditTradeHistory import CreditTradeHistoryReviewedSerializer
         request = self.context.get('request')
 
@@ -619,7 +637,7 @@ class CreditTrade2Serializer(serializers.ModelSerializer):
 
         if (obj.status.status == 'Recommended' or
                 obj.status.status == 'Not Recommended') and \
-            (not request.user.is_government_user):
+                not request.user.is_government_user:
             recommended = CreditTradeStatus.objects.get(status="Recommended")
 
             return {

--- a/backend/api/serializers/CreditTradeComment.py
+++ b/backend/api/serializers/CreditTradeComment.py
@@ -66,7 +66,7 @@ class CreditTradeCommentUpdateSerializer(serializers.ModelSerializer):
             'update_user')
 
         read_only_fields = ('id', 'create_timestamp', 'create_user',
-                            'credit_trade', 'privileged_access')
+                            'credit_trade')
 
 
 class CreditTradeCommentCreateSerializer(serializers.ModelSerializer):

--- a/backend/api/tests/test_credit_trade_comments.py
+++ b/backend/api/tests/test_credit_trade_comments.py
@@ -315,7 +315,7 @@ class TestAPIComments(BaseTestCase, CreditTradeRelationshipMixin, CreditTradeFlo
                 'status': status.HTTP_201_CREATED,
                 'reason': 'Analyst can comment in Not Recommended'
             }
-        expected_results[('Approved', False, 'gov_analyst', True)] = \
+        expected_results[('Approved', False, 'gov_analyst', False)] = \
             {
                 'status': status.HTTP_201_CREATED,
                 'reason': 'Director can comment in Not Recommended'

--- a/backend/api/viewsets/CreditTradeComments.py
+++ b/backend/api/viewsets/CreditTradeComments.py
@@ -55,8 +55,8 @@ class CreditTradeCommentsViewSet(AuditableMixin,
     def get_serializer_class(self):
         if self.action in list(self.serializer_classes.keys()):
             return self.serializer_classes[self.action]
-        else:
-            return self.serializer_classes['default']
+
+        return self.serializer_classes['default']
 
     def perform_create(self, serializer):
         comment = serializer.save()

--- a/frontend/src/admin/historical_data_entry/HistoricalDataEntryContainer.js
+++ b/frontend/src/admin/historical_data_entry/HistoricalDataEntryContainer.js
@@ -93,17 +93,17 @@ class HistoricalDataEntryContainer extends Component {
     }
   }
 
-  _handleSubmit (event, status) {
+  _handleSubmit (event) {
     event.preventDefault();
 
     const data = this.props.prepareCreditTransfer(this.state.fields);
     const { comment } = this.state.fields;
 
-    this.props.addCreditTransfer(data).then((response) => {
-      if (comment !== '') {
-        this._saveComment(response.data.id, comment);
-      }
+    if (comment !== '') {
+      data.comment = comment;
+    }
 
+    this.props.addCreditTransfer(data).then((response) => {
       this.props.invalidateCreditTransfers();
       this.loadData();
       this.resetState();
@@ -116,17 +116,6 @@ class HistoricalDataEntryContainer extends Component {
     this.props.processApprovedCreditTransfers().then(() => {
       this.loadData();
     });
-  }
-
-  _saveComment (id, comment) {
-    // API data structure
-    const data = {
-      creditTrade: id,
-      comment,
-      privilegedAccess: true
-    };
-
-    return this.props.addCommentToCreditTransfer(data);
   }
 
   _selectIdForModal (id) {

--- a/frontend/src/admin/historical_data_entry/HistoricalDataEntryContainer.js
+++ b/frontend/src/admin/historical_data_entry/HistoricalDataEntryContainer.js
@@ -99,7 +99,7 @@ class HistoricalDataEntryContainer extends Component {
     const data = this.props.prepareCreditTransfer(this.state.fields);
     const { comment } = this.state.fields;
 
-    if (comment !== '') {
+    if (comment.length > 0) {
       data.comment = comment;
     }
 

--- a/frontend/src/admin/historical_data_entry/HistoricalDataEntryEditContainer.js
+++ b/frontend/src/admin/historical_data_entry/HistoricalDataEntryEditContainer.js
@@ -75,7 +75,9 @@ class HistoricalDataEntryEditContainer extends Component {
   _handleSubmit (event) {
     event.preventDefault();
 
-    this.state.submitted = true;
+    this.setState({
+      submitted: true
+    });
 
     const data = this.props.prepareCreditTransfer(this.state.fields);
     const { id } = this.props.item;
@@ -133,29 +135,21 @@ class HistoricalDataEntryEditContainer extends Component {
   }
 
   loadPropsToFieldState (props) {
-    if (Object.keys(props.item).length !== 0) {
+    if (Object.keys(props.item).length !== 0 && !this.state.submitted) {
       const { item } = props;
 
-      let fieldState = {};
-
-      if (this.state.submitted) {
-        fieldState = {
-          ...this.state.fields
-        };
-      } else {
-        fieldState = {
-          // we only allow one comment per entry in the Historical Data Entry
-          comment: (item.comments.length > 0) ? item.comments[0].comment : '',
-          compliancePeriod: (item.compliancePeriod) ? item.compliancePeriod : { id: 0 },
-          creditsFrom: item.creditsFrom,
-          creditsTo: item.creditsTo,
-          fairMarketValuePerCredit: item.fairMarketValuePerCredit,
-          numberOfCredits: item.numberOfCredits.toString(),
-          tradeEffectiveDate: (item.tradeEffectiveDate) ? item.tradeEffectiveDate.toString() : '',
-          transferType: item.type.id.toString(),
-          zeroDollarReason: (item.zeroReason) ? item.zeroReason.id.toString() : ''
-        };
-      }
+      const fieldState = {
+        // we only allow one comment per entry in the Historical Data Entry
+        comment: (item.comments.length > 0) ? item.comments[0].comment : '',
+        compliancePeriod: (item.compliancePeriod) ? item.compliancePeriod : { id: 0 },
+        creditsFrom: item.creditsFrom,
+        creditsTo: item.creditsTo,
+        fairMarketValuePerCredit: item.fairMarketValuePerCredit,
+        numberOfCredits: item.numberOfCredits.toString(),
+        tradeEffectiveDate: (item.tradeEffectiveDate) ? item.tradeEffectiveDate.toString() : '',
+        transferType: item.type.id.toString(),
+        zeroDollarReason: (item.zeroReason) ? item.zeroReason.id.toString() : ''
+      };
 
       this.setState({
         fields: fieldState,

--- a/frontend/src/admin/historical_data_entry/HistoricalDataEntryEditContainer.js
+++ b/frontend/src/admin/historical_data_entry/HistoricalDataEntryEditContainer.js
@@ -96,7 +96,7 @@ class HistoricalDataEntryEditContainer extends Component {
     const data = {
       creditTrade: this.props.item.id,
       comment,
-      privilegedAccess: true
+      privilegedAccess: false
     };
 
     if (item.comments.length > 0) {

--- a/frontend/src/admin/historical_data_entry/components/HistoricalDataEntryForm.js
+++ b/frontend/src/admin/historical_data_entry/components/HistoricalDataEntryForm.js
@@ -13,8 +13,7 @@ const HistoricalDataEntryForm = props => (
       <Errors errors={props.errors} />
     }
     <form
-      onSubmit={(event, status) =>
-        props.handleSubmit(event, '')}
+      onSubmit={event => props.handleSubmit(event)}
     >
       <HistoricalDataEntryFormDetails
         actions={props.actions}

--- a/frontend/src/credit_transfers/CreditTransferAddContainer.js
+++ b/frontend/src/credit_transfers/CreditTransferAddContainer.js
@@ -26,6 +26,7 @@ import {
 } from '../actions/signingAuthorityConfirmationsActions';
 import history from '../app/History';
 import * as Lang from '../constants/langEnUs';
+import COMMENTS from '../constants/permissions/Comments';
 import CREDIT_TRANSACTIONS from '../constants/routes/CreditTransactions';
 import { CREDIT_TRANSFER_STATUS, CREDIT_TRANSFER_TYPES } from '../constants/values';
 import toastr from '../utils/toastr';
@@ -45,14 +46,17 @@ class CreditTransferAddContainer extends Component {
             id: CREDIT_TRANSFER_TYPES.part3Award.id
           },
           zeroDollarReason: { id: null, name: '' }
-        }
+        },
+        isCommenting: false,
+        isCreatingPrivilegedComment: false,
+        hasCommented: false
       };
     } else {
       this.state = {
-        comment: null,
         creditsFrom: {},
         creditsTo: {},
         fields: {
+          comment: null,
           fairMarketValuePerCredit: '',
           initiator: {},
           note: '',
@@ -68,6 +72,7 @@ class CreditTransferAddContainer extends Component {
       };
     }
 
+    this._addComment = this._addComment.bind(this);
     this._addToFields = this._addToFields.bind(this);
     this._changeStatus = this._changeStatus.bind(this);
     this._handleInputChange = this._handleInputChange.bind(this);
@@ -91,6 +96,13 @@ class CreditTransferAddContainer extends Component {
     });
   }
 
+  _addComment (privileged = false) {
+    this.setState({
+      isCommenting: true,
+      isCreatingPrivilegedComment: privileged
+    });
+  }
+
   _addToFields (value) {
     const fieldState = { ...this.state.fields };
     fieldState.terms.push(value);
@@ -110,7 +122,7 @@ class CreditTransferAddContainer extends Component {
       fairMarketValuePerCredit: parseFloat(this.state.fields.fairMarketValuePerCredit).toFixed(2),
       initiator: this.state.fields.initiator.id,
       note: this.state.fields.note,
-      comment: this.state.comment,
+      comment: this.state.fields.comment,
       numberOfCredits: parseInt(this.state.fields.numberOfCredits, 10),
       respondent: this.state.fields.respondent.id,
       status: status.id,
@@ -142,9 +154,11 @@ class CreditTransferAddContainer extends Component {
   }
 
   _governmentTransferSubmit (status) {
+    const { comment } = this.state.fields;
+    const { isCreatingPrivilegedComment } = this.state;
+
     // API data structure
     const data = {
-      comment: this.state.fields.comment,
       compliancePeriod: this.state.fields.compliancePeriod.id,
       initiator: this.state.fields.initiator.id,
       numberOfCredits: parseInt(this.state.fields.numberOfCredits, 10),
@@ -155,9 +169,21 @@ class CreditTransferAddContainer extends Component {
     };
 
     this.props.addCreditTransfer(data).then((response) => {
+      this._saveComment(response.data.id, comment, isCreatingPrivilegedComment);
+
       this.props.invalidateCreditTransfers();
       history.push(CREDIT_TRANSACTIONS.HIGHLIGHT.replace(':id', response.data.id));
       toastr.creditTransactionSuccess(status.id, data);
+    });
+  }
+
+  _handleCommentChanged (comment) {
+    const fieldState = { ...this.state.fields };
+
+    fieldState.comment = comment;
+
+    this.setState({
+      fields: fieldState
     });
   }
 
@@ -189,10 +215,19 @@ class CreditTransferAddContainer extends Component {
     return false;
   }
 
-  _handleCommentChanged (comment) {
-    this.setState({
-      comment
-    });
+  _saveComment (id, comment, privileged = false) {
+    // API data structure
+    const data = {
+      creditTrade: id,
+      comment,
+      privilegedAccess: privileged
+    };
+
+    if (comment.length > 0) {
+      return this.props.addCommentToCreditTransfer(data);
+    }
+
+    return false;
   }
 
   _renderCreditTransfer () {
@@ -241,11 +276,18 @@ class CreditTransferAddContainer extends Component {
     return ([
       <GovernmentTransferForm
         actions={buttonActions}
+        addComment={this._addComment}
+        canComment
+        canCreatePrivilegedComment={this.props.loggedInUser.hasPermission(COMMENTS.EDIT_PRIVILEGED)}
         errors={this.props.errors}
         fields={this.state.fields}
         fuelSuppliers={this.props.fuelSuppliers}
+        handleCommentChanged={this._handleCommentChanged}
         handleInputChange={this._handleInputChange}
         handleSubmit={this._handleSubmit}
+        hasCommented={this.state.hasCommented}
+        isCommenting={this.state.isCommenting}
+        isCreatingPrivilegedComment={this.state.isCreatingPrivilegedComment}
         key="creditTransferForm"
         title="New Credit Transaction"
       />,
@@ -349,6 +391,7 @@ CreditTransferAddContainer.propTypes = {
   invalidateCreditTransfers: PropTypes.func.isRequired,
   loggedInUser: PropTypes.shape({
     displayName: PropTypes.string,
+    hasPermission: PropTypes.func,
     isGovernmentUser: PropTypes.bool,
     organization: PropTypes.shape({
       name: PropTypes.string,

--- a/frontend/src/credit_transfers/CreditTransferEditContainer.js
+++ b/frontend/src/credit_transfers/CreditTransferEditContainer.js
@@ -29,6 +29,7 @@ import {
 } from '../actions/signingAuthorityConfirmationsActions';
 import history from '../app/History';
 import * as Lang from '../constants/langEnUs';
+import COMMENTS from '../constants/permissions/Comments';
 import CREDIT_TRANSACTIONS from '../constants/routes/CreditTransactions';
 import { CREDIT_TRANSFER_STATUS, CREDIT_TRANSFER_TYPES } from '../constants/values';
 import toastr from '../utils/toastr';
@@ -49,6 +50,9 @@ class CreditTransferEditContainer extends Component {
           },
           zeroDollarReason: { id: null, name: '' }
         },
+        isCommenting: false,
+        isCreatingPrivilegedComment: false,
+        hasCommented: false,
         submitted: false
       };
     } else {
@@ -73,6 +77,7 @@ class CreditTransferEditContainer extends Component {
       };
     }
 
+    this._addComment = this._addComment.bind(this);
     this._addToFields = this._addToFields.bind(this);
     this._changeStatus = this._changeStatus.bind(this);
     this._deleteCreditTransfer = this._deleteCreditTransfer.bind(this);
@@ -114,6 +119,13 @@ class CreditTransferEditContainer extends Component {
     }
   }
 
+  _addComment (privileged = false) {
+    this.setState({
+      isCommenting: true,
+      isCreatingPrivilegedComment: privileged
+    });
+  }
+
   _addToFields (value) {
     const fieldState = { ...this.state.fields };
     fieldState.terms.push(value);
@@ -133,7 +145,7 @@ class CreditTransferEditContainer extends Component {
       fairMarketValuePerCredit: parseFloat(this.state.fields.fairMarketValuePerCredit).toFixed(2),
       initiator: this.state.fields.initiator.id,
       note: this.state.fields.note,
-      comment: this.state.comment,
+      comment: this.state.fields.comment,
       numberOfCredits: parseInt(this.state.fields.numberOfCredits, 10),
       respondent: this.state.fields.respondent.id,
       status: status.id,
@@ -180,6 +192,7 @@ class CreditTransferEditContainer extends Component {
   _governmentTransferSubmit (status) {
     const { id } = this.props.item;
     const { comment } = this.state.fields;
+    const { isCreatingPrivilegedComment } = this.state;
 
     // API data structure
     const data = {
@@ -191,7 +204,7 @@ class CreditTransferEditContainer extends Component {
     };
 
     this.props.updateCreditTransfer(id, data).then((response) => {
-      this._saveComment(comment);
+      this._saveComment(comment, isCreatingPrivilegedComment);
 
       history.push(CREDIT_TRANSACTIONS.HIGHLIGHT.replace(':id', id));
       toastr.creditTransactionSuccess(status.id, this.props.item);
@@ -227,7 +240,9 @@ class CreditTransferEditContainer extends Component {
   _handleSubmit (event, status) {
     event.preventDefault();
 
-    this.state.submitted = true;
+    this.setState({
+      submitted: true
+    });
 
     // Government Transfer Submit
     if ([CREDIT_TRANSFER_TYPES.buy.id, CREDIT_TRANSFER_TYPES.sell.id]
@@ -241,8 +256,12 @@ class CreditTransferEditContainer extends Component {
   }
 
   _handleCommentChanged (comment) {
+    const fieldState = { ...this.state.fields };
+
+    fieldState.comment = comment;
+
     this.setState({
-      comment
+      fields: fieldState
     });
   }
 
@@ -319,11 +338,18 @@ class CreditTransferEditContainer extends Component {
     return ([
       <GovernmentTransferForm
         actions={buttonActions}
+        addComment={this._addComment}
+        canComment
+        canCreatePrivilegedComment={this.props.loggedInUser.hasPermission(COMMENTS.EDIT_PRIVILEGED)}
         errors={this.props.errors}
         fields={this.state.fields}
         fuelSuppliers={this.props.fuelSuppliers}
+        handleCommentChanged={this._handleCommentChanged}
         handleInputChange={this._handleInputChange}
         handleSubmit={this._handleSubmit}
+        hasCommented={this.state.hasCommented}
+        isCommenting={this.state.isCommenting}
+        isCreatingPrivilegedComment={this.state.isCreatingPrivilegedComment}
         key="creditTransferForm"
         title="Edit Credit Transaction"
       />,
@@ -346,13 +372,13 @@ class CreditTransferEditContainer extends Component {
     ]);
   }
 
-  _saveComment (comment) {
+  _saveComment (comment, privileged = false) {
     const { item } = this.props;
     // API data structure
     const data = {
-      creditTrade: this.props.item.id,
+      creditTrade: item.id,
       comment,
-      privilegedAccess: true
+      privilegedAccess: privileged
     };
 
     if (item.comments.length > 0) {
@@ -360,18 +386,16 @@ class CreditTransferEditContainer extends Component {
       return this.props.updateCommentOnCreditTransfer(item.comments[0].id, data);
     }
 
-    return this.props.addCommentToCreditTransfer(data);
+    if (comment.length > 0) {
+      return this.props.addCommentToCreditTransfer(data);
+    }
+
+    return false;
   }
 
   _setCreditTransferState (item) {
-    let fieldState = {};
-
-    if (this.state.submitted) {
-      fieldState = {
-        ...this.state.fields
-      };
-    } else {
-      fieldState = {
+    if (!this.state.submitted) {
+      const fieldState = {
         initiator: item.initiator,
         fairMarketValuePerCredit: item.fairMarketValuePerCredit,
         note: '',
@@ -382,37 +406,37 @@ class CreditTransferEditContainer extends Component {
         tradeType: item.type,
         zeroDollarReason: item.zeroReason
       };
-    }
 
-    this.setState({
-      fields: fieldState,
-      creditsFrom: item.creditsFrom,
-      creditsTo: item.creditsTo,
-      totalValue: item.totalValue
-    });
+      this.setState({
+        fields: fieldState,
+        creditsFrom: item.creditsFrom,
+        creditsTo: item.creditsTo,
+        totalValue: item.totalValue
+      });
+    }
   }
 
   _setGovernmentTransferState (item) {
-    let fieldState = {};
-
-    if (this.state.submitted) {
-      fieldState = {
-        ...this.state.fields
-      };
-    } else {
-      fieldState = {
+    if (!this.state.submitted) {
+      const fieldState = {
         comment: (item.comments.length > 0) ? item.comments[0].comment : '',
-        compliancePeriod: (item.compliancePeriod) ? item.compliancePeriod : { id: 0 },
+        compliancePeriod: item.compliancePeriod ? item.compliancePeriod : { id: 0 },
         numberOfCredits: item.numberOfCredits.toString(),
         respondent: item.respondent,
         tradeType: item.type,
         zeroDollarReason: item.zeroReason
       };
-    }
 
-    this.setState({
-      fields: fieldState
-    });
+      if (item.comments.length > 0) {
+        this.setState({
+          isCreatingPrivilegedComment: item.comments[0].privilegedAccess
+        });
+      }
+
+      this.setState({
+        fields: fieldState
+      });
+    }
   }
 
   _toggleCheck (key) {
@@ -539,6 +563,7 @@ CreditTransferEditContainer.propTypes = {
   }).isRequired,
   loggedInUser: PropTypes.shape({
     displayName: PropTypes.string,
+    hasPermission: PropTypes.func,
     isGovernmentUser: PropTypes.bool,
     organization: PropTypes.shape({
       name: PropTypes.string,
@@ -557,7 +582,6 @@ CreditTransferEditContainer.propTypes = {
 
 const mapStateToProps = state => ({
   errors: state.rootReducer.creditTransfer.errors,
-  fields: state.rootReducer.creditTransfer.fields,
   fuelSuppliers: state.rootReducer.fuelSuppliersRequest.fuelSuppliers,
   isFetching: state.rootReducer.creditTransfer.isFetching,
   item: state.rootReducer.creditTransfer.item,

--- a/frontend/src/credit_transfers/components/CreditTransferCommentButtons.js
+++ b/frontend/src/credit_transfers/components/CreditTransferCommentButtons.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import * as Lang from "../../constants/langEnUs";
+import * as Lang from '../../constants/langEnUs';
 
 const CreditTransferCommentButtons = props => (
   <div className="btn-container">

--- a/frontend/src/credit_transfers/components/CreditTransferFormDetails.js
+++ b/frontend/src/credit_transfers/components/CreditTransferFormDetails.js
@@ -125,10 +125,6 @@ CreditTransferFormDetails.defaultProps = {
   children: null
 };
 
-CreditTransferFormDetails.defaultProps = {
-  children: null
-};
-
 CreditTransferFormDetails.propTypes = {
   fuelSuppliers: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   fields: PropTypes.shape({

--- a/frontend/src/credit_transfers/components/GovernmentTransferForm.js
+++ b/frontend/src/credit_transfers/components/GovernmentTransferForm.js
@@ -13,6 +13,8 @@ import TooltipWhenDisabled from '../../app/components/TooltipWhenDisabled';
 import GovernmentTransferFormDetails from './GovernmentTransferFormDetails';
 import history from '../../app/History';
 import * as Lang from '../../constants/langEnUs';
+import CreditTransferCommentButtons from './CreditTransferCommentButtons';
+import CreditTransferCommentForm from './CreditTransferCommentForm';
 
 class GovernmentTransferForm extends Component {
   componentDidMount () {
@@ -32,55 +34,72 @@ class GovernmentTransferForm extends Component {
             fuelSuppliers={this.props.fuelSuppliers}
             fields={this.props.fields}
             handleInputChange={this.props.handleInputChange}
-          />
+          >
+            <CreditTransferCommentButtons
+              canComment={this.props.canComment}
+              isCommenting={false}
+              addComment={this.props.addComment}
+              canCreatePrivilegedComment={this.props.canCreatePrivilegedComment}
+            />
+            <CreditTransferCommentForm
+              comment={this.props.fields.comment}
+              isCommentingOnUnsavedCreditTransfer={this.props.id === 0}
+              isCreatingPrivilegedComment={this.props.isCreatingPrivilegedComment}
+              isEditingExistingComment={this.props.fields.comment.length > 0}
+              handleCommentChanged={this.props.handleCommentChanged}
+              embedded
+            />
+          </GovernmentTransferFormDetails>
 
           {Object.keys(this.props.errors).length > 0 &&
             <Errors errors={this.props.errors} />
           }
 
-          <div className="btn-container">
-            <button
-              className="btn btn-default"
-              onClick={() => history.goBack()}
-              type="button"
-            >
-              {Lang.BTN_APP_CANCEL}
-            </button>
-            {this.props.actions.includes(Lang.BTN_DELETE_DRAFT) &&
-            <button
-              className="btn btn-danger"
-              data-target="#confirmDelete"
-              data-toggle="modal"
-              type="button"
-            >
-              {Lang.BTN_DELETE_DRAFT}
-            </button>
-            }
-            {this.props.actions.includes(Lang.BTN_SAVE_DRAFT) &&
-            <button
-              className="btn btn-default"
-              type="submit"
-            >
-              {Lang.BTN_SAVE_DRAFT}
-            </button>
-            }
-            {this.props.actions.includes(Lang.BTN_RECOMMEND_FOR_DECISION) &&
-            <TooltipWhenDisabled
-              disabled={this.props.fields.comment.length === 0}
-              title={Lang.TEXT_COMMENT_REQUIRED}
-            >
+          <div className="credit-transfer-actions">
+            <div className="btn-container">
               <button
-                className={`btn ${this.props.fields.comment.length === 0
-                  ? 'btn-disabled' : 'btn-primary '}`}
-                data-target="#confirmRecommend"
-                data-toggle="modal"
-                disabled={this.props.fields.comment.length === 0}
+                className="btn btn-default"
+                onClick={() => history.goBack()}
                 type="button"
               >
-                {Lang.BTN_RECOMMEND_FOR_DECISION}
+                {Lang.BTN_APP_CANCEL}
               </button>
-            </TooltipWhenDisabled>
-            }
+              {this.props.actions.includes(Lang.BTN_DELETE_DRAFT) &&
+              <button
+                className="btn btn-danger"
+                data-target="#confirmDelete"
+                data-toggle="modal"
+                type="button"
+              >
+                {Lang.BTN_DELETE_DRAFT}
+              </button>
+              }
+              {this.props.actions.includes(Lang.BTN_SAVE_DRAFT) &&
+              <button
+                className="btn btn-default"
+                type="submit"
+              >
+                {Lang.BTN_SAVE_DRAFT}
+              </button>
+              }
+              {this.props.actions.includes(Lang.BTN_RECOMMEND_FOR_DECISION) &&
+              <TooltipWhenDisabled
+                disabled={this.props.fields.comment.length === 0}
+                title={Lang.TEXT_COMMENT_REQUIRED}
+              >
+                <button
+                  className={`btn ${this.props.fields.comment.length === 0
+                    ? 'btn-disabled' : 'btn-primary '}`}
+                  data-target="#confirmRecommend"
+                  data-toggle="modal"
+                  disabled={this.props.fields.comment.length === 0}
+                  type="button"
+                >
+                  {Lang.BTN_RECOMMEND_FOR_DECISION}
+                </button>
+              </TooltipWhenDisabled>
+              }
+            </div>
           </div>
         </form>
       </div>
@@ -89,12 +108,16 @@ class GovernmentTransferForm extends Component {
 }
 
 GovernmentTransferForm.defaultProps = {
+  handleCommentChanged: null,
   id: 0,
   title: 'New Credit Transaction'
 };
 
 GovernmentTransferForm.propTypes = {
   actions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  addComment: PropTypes.func.isRequired,
+  canComment: PropTypes.bool.isRequired,
+  canCreatePrivilegedComment: PropTypes.bool.isRequired,
   compliancePeriods: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   errors: PropTypes.shape({}).isRequired,
   fields: PropTypes.shape({
@@ -102,9 +125,12 @@ GovernmentTransferForm.propTypes = {
   }).isRequired,
   fuelSuppliers: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   getCompliancePeriods: PropTypes.func.isRequired,
+  handleCommentChanged: PropTypes.func,
   handleInputChange: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   id: PropTypes.number,
+  isCreatingPrivilegedComment: PropTypes.bool.isRequired,
+  isCommenting: PropTypes.bool.isRequired,
   title: PropTypes.string
 };
 

--- a/frontend/src/credit_transfers/components/GovernmentTransferFormDetails.js
+++ b/frontend/src/credit_transfers/components/GovernmentTransferFormDetails.js
@@ -85,23 +85,22 @@ const GovernmentTransferFormDetails = props => (
 
       <div className="row">
         <div className="form-group col-md-12">
-          <label htmlFor="comment">Note:
-            <textarea
-              className="form-control"
-              rows="5"
-              id="comment"
-              name="comment"
-              value={props.fields.comment}
-              onChange={props.handleInputChange}
-            />
-          </label>
+          {props.children}
         </div>
       </div>
     </div>
   </div>
 );
 
+GovernmentTransferFormDetails.defaultProps = {
+  children: null
+};
+
 GovernmentTransferFormDetails.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]),
   compliancePeriods: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   fuelSuppliers: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   fields: PropTypes.shape({

--- a/frontend/src/reducers/creditTransferReducer.js
+++ b/frontend/src/reducers/creditTransferReducer.js
@@ -54,8 +54,7 @@ const creditTransfer = (state = {
         ...state,
         didInvalidate: true,
         isFetching: false,
-        errors: action.errorMessage,
-        fields: action.data
+        errors: action.errorMessage
       };
     case ActionTypes.INVALIDATE_CREDIT_TRANSFER:
       return {

--- a/frontend/styles/CreditTransactions.scss
+++ b/frontend/styles/CreditTransactions.scss
@@ -1,6 +1,8 @@
 .credit-transaction {
-  .btn-container {
-    text-align: right;
+  .credit-transfer-actions {
+    .btn-container {
+      text-align: right;
+    }  
   }
 
   .main-form {
@@ -18,6 +20,11 @@
       .btn {
         margin-right: 0;
       }
+    }
+
+    .note {
+      margin: 0;
+      padding: 0;
     }
   }
 }


### PR DESCRIPTION
#535 #538

Changed so that "notes" are no longer internal comments.

Changelog:
- Changed comments automatically added by historical data entry to be external
- Minor code changes to satisfy pep8
- Credit Transaction notes now look more like the commenting system allowing the user to pick between internal or public comment