### PR TITLE
Enable zero-reason rationale requirement for 'buy' type transfers

### DIFF
--- a/frontend/src/credit_transfers/components/CreditTransferFormDetails.js
+++ b/frontend/src/credit_transfers/components/CreditTransferFormDetails.js
@@ -11,7 +11,8 @@ import { CREDIT_TRANSFER_TYPES, ZERO_DOLLAR_REASON } from '../../constants/value
 class CreditTransferFormDetails extends Component {
   enableZeroReason () {
     return (
-      this.props.fields.tradeType.id === CREDIT_TRANSFER_TYPES.sell.id &&
+      (this.props.fields.tradeType.id === CREDIT_TRANSFER_TYPES.sell.id ||
+      this.props.fields.tradeType.id === CREDIT_TRANSFER_TYPES.buy.id) &&
       this.props.fields.fairMarketValuePerCredit !== null &&
       parseFloat(this.props.fields.fairMarketValuePerCredit) === 0
     );

--- a/frontend/src/credit_transfers/components/CreditTransferTextRepresentation.js
+++ b/frontend/src/credit_transfers/components/CreditTransferTextRepresentation.js
@@ -7,7 +7,6 @@ import * as NumberFormat from '../../constants/numeralFormats';
 import { CREDIT_TRANSFER_STATUS, CREDIT_TRANSFER_TYPES, ZERO_DOLLAR_REASON } from '../../constants/values';
 
 class CreditTransferTextRepresentation extends Component {
-
   constructor (props) {
     super(props);
 
@@ -53,6 +52,17 @@ class CreditTransferTextRepresentation extends Component {
         }
         {this.props.status.id !== CREDIT_TRANSFER_STATUS.refused.id &&
           <span>, effective <span className="value"> {this.tradeEffectiveDate}</span>.</span>
+        }
+        {this.props.zeroDollarReason != null &&
+        <div className="zero-reason">
+          <span>This credit transfer has zero-value per-credit because:
+            <span className="value">
+              {Object.values(ZERO_DOLLAR_REASON)
+                .find(zd => zd.id === this.props.zeroDollarReason.id)
+                .textRepresentationDescription}
+            </span>
+          </span>
+        </div>
         }
       </div>
     );


### PR DESCRIPTION
# Changelog

 - Adjust frontend components to support zero-reason rationales for 'buy' type trades.

Trello card 809