### PR TITLE
UX Further Updates

### DIFF
--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -117,9 +117,10 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
                             reason='Other'):
                 if not will_create_a_comment:
                     raise serializers.ValidationError({
-                        'forbidden': "Cannot propose a trade with zero-reason "
-                                     "'Other' without creating an explanatory "
-                                     "comment'"
+                        'forbidden': "Please provide an explanation in the "
+                                     "comments as to why the Credit Transfer "
+                                     "Proposal has a fair market value of zero "
+                                     "dollars per credit."
                     })
 
         if credit_trade_status not in allowed_statuses:

--- a/frontend/src/constants/values.js
+++ b/frontend/src/constants/values.js
@@ -96,12 +96,12 @@ export const ZERO_DOLLAR_REASON = {
     id: 1,
     description: 'Affiliate',
     formButtonDescription: 'Transfer to Affiliated Organization',
-    textRepresentationDescription: 'it is a transfer of credits between affiliated organizations'
+    textRepresentationDescription: ' it is a transfer between affiliated organizations.'
   },
   other: {
     id: 2,
     description: 'Other',
     formButtonDescription: 'Other Reason',
-    textRepresentationDescription: 'a reason should be specified in the comments'
+    textRepresentationDescription: ' reason specified in comments.'
   }
 };

--- a/frontend/src/credit_transfers/CreditTransferViewContainer.js
+++ b/frontend/src/credit_transfers/CreditTransferViewContainer.js
@@ -358,11 +358,6 @@ class CreditTransferViewContainer extends Component {
         }}
         id="confirmDecline"
         key="confirmDecline"
-        canBypassExtraConfirm
-        extraConfirmText="You have not provided a comment explaining why you to decline to approve
-         this Credit Transfer Proposal"
-        showExtraConfirm={!this.state.hasCommented}
-        extraConfirmType="warning"
       >
         <div className="alert alert-warning">
           <p>

--- a/frontend/src/credit_transfers/components/CreditTransferDetails.js
+++ b/frontend/src/credit_transfers/components/CreditTransferDetails.js
@@ -43,6 +43,8 @@ const CreditTransferDetails = props => (
               creditsFrom={props.creditsFrom}
               creditsTo={props.creditsTo}
               fairMarketValuePerCredit={props.fairMarketValuePerCredit}
+              history={props.history}
+              isRescinded={props.isRescinded}
               numberOfCredits={props.numberOfCredits}
               status={props.status}
               totalValue={props.totalValue}

--- a/frontend/src/credit_transfers/components/CreditTransferFormDetails.js
+++ b/frontend/src/credit_transfers/components/CreditTransferFormDetails.js
@@ -96,7 +96,9 @@ class CreditTransferFormDetails extends Component {
           <span> effective on Director&apos;s approval</span>
           {this.enableZeroReason() &&
           <div className="zero-reason-form">
-            <span>This trade has a value of zero dollars because:</span>
+            <span>
+              This credit transfer has a fair market value of zero dollars per credit because:
+            </span>
             <br />
             <div className="form-group">
               <div className="btn-group zero-reason" role="group" id="zero-dollar-reason">

--- a/frontend/src/credit_transfers/components/CreditTransferSigningHistory.js
+++ b/frontend/src/credit_transfers/components/CreditTransferSigningHistory.js
@@ -70,11 +70,22 @@ class CreditTransferSigningHistory extends Component {
       <div>
         <h3 className="signing-authority-header" key="header">Transaction History</h3>
         {this.props.history.length > 0 &&
-        this.props.history.map((history) => {
+        this.props.history.map((history, index, arr) => {
           let action;
           if (history.isRescinded) {
             action = CreditTransferSigningHistory.renderRescinded();
           } else {
+            if ([ // if the next history entry is also recommended/not recommended, don't show it
+              CREDIT_TRANSFER_STATUS.notRecommended.id,
+              CREDIT_TRANSFER_STATUS.recommendedForDecision.id
+            ].includes(history.status.id) &&
+            (index + 1) < arr.length && [
+              CREDIT_TRANSFER_STATUS.notRecommended.id,
+              CREDIT_TRANSFER_STATUS.recommendedForDecision.id
+            ].includes(arr[index + 1].status.id)) {
+              return false;
+            }
+
             switch (history.status.id) {
               case CREDIT_TRANSFER_STATUS.accepted.id:
                 action = this._renderAccepted(history);

--- a/frontend/src/credit_transfers/components/CreditTransferTextRepresentation.js
+++ b/frontend/src/credit_transfers/components/CreditTransferTextRepresentation.js
@@ -47,12 +47,7 @@ class CreditTransferTextRepresentation extends Component {
         <span className="value"> {this.numberOfCredits} </span> credit{(this.props.numberOfCredits > 1) && 's'} from
         <span className="value"> {this.creditsFrom} </span>
         for <span className="value"> {this.totalValue}</span>
-        {this.props.status.id === CREDIT_TRANSFER_STATUS.refused.id &&
-          <span>. <span className="value"> {this.creditsTo} </span> refused the proposal.</span>
-        }
-        {this.props.status.id !== CREDIT_TRANSFER_STATUS.refused.id &&
-          <span>, effective <span className="value"> {this.tradeEffectiveDate}</span>.</span>
-        }
+        {this._statusText()}
         {this.props.zeroDollarReason != null &&
         <div className="zero-reason">
           <span>This credit transfer has zero-value per-credit because:
@@ -123,12 +118,7 @@ class CreditTransferTextRepresentation extends Component {
         <span className="value"> {this.creditsTo} </span>
         for <span className="value"> {this.fairMarketValuePerCredit} </span> per credit
         for a total value of <span className="value"> {this.totalValue}</span>
-        {this.props.status.id === CREDIT_TRANSFER_STATUS.refused.id &&
-          <span>. <span className="value"> {this.creditsTo} </span> refused the proposal.</span>
-        }
-        {this.props.status.id !== CREDIT_TRANSFER_STATUS.refused.id &&
-          <span>, effective <span className="value"> {this.tradeEffectiveDate}</span>.</span>
-        }
+        {this._statusText()}
         {this.props.zeroDollarReason != null &&
           <div className="zero-reason">
             <span>This credit transfer has zero-value per-credit because:
@@ -161,7 +151,24 @@ class CreditTransferTextRepresentation extends Component {
     );
   }
 
+  _rescindedBy () {
+    const rescindedBy = this.props.history.find(history => (history.isRescinded));
+
+    if (rescindedBy) {
+      return [
+        <span key="rescinded-by" className="value"> ${rescindedBy.user.organization.name} </span>,
+        <span key="rescinded-by-text">rescinded the proposal.</span>
+      ];
+    }
+
+    return false;
+  }
+
   _sellAction () {
+    if (this.props.isRescinded) {
+      return ' proposed to sell ';
+    }
+
     switch (this.props.status.id) {
       case CREDIT_TRANSFER_STATUS.approved.id:
       case CREDIT_TRANSFER_STATUS.completed.id:
@@ -171,6 +178,21 @@ class CreditTransferTextRepresentation extends Component {
       default:
         return ' is proposing to sell ';
     }
+  }
+
+  _statusText () {
+    if (this.props.isRescinded) {
+      return <span>. {this._rescindedBy()}</span>;
+    }
+
+    if (this.props.status.id === CREDIT_TRANSFER_STATUS.refused.id) {
+      return <span>. <span className="value"> {this.props.creditsFrom.name} </span> refused the proposal.</span>;
+    }
+
+    if (this.props.status.id === CREDIT_TRANSFER_STATUS.declinedForApproval.id) {
+      return <span>. The proposal was declined.</span>;
+    }
+    return <span>, effective <span className="value"> {this.tradeEffectiveDate}</span>.</span>;
   }
 
   render () {
@@ -206,6 +228,8 @@ CreditTransferTextRepresentation.defaultProps = {
   creditsTo: {
     name: 'To'
   },
+  history: [],
+  isRescinded: false,
   tradeEffectiveDate: '',
   zeroDollarReason: null
 };
@@ -227,6 +251,21 @@ CreditTransferTextRepresentation.propTypes = {
     PropTypes.string,
     PropTypes.number
   ]).isRequired,
+  history: PropTypes.arrayOf(PropTypes.shape({
+    creditTradeUpdateTime: PropTypes.string,
+    isRescinded: PropTypes.bool,
+    status: PropTypes.shape({
+      id: PropTypes.number,
+      status: PropTypes.string
+    }),
+    user: PropTypes.shape({
+      displayName: PropTypes.string,
+      firstName: PropTypes.string,
+      id: PropTypes.number,
+      lastName: PropTypes.string
+    })
+  })),
+  isRescinded: PropTypes.bool,
   numberOfCredits: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number


### PR DESCRIPTION
#607 #608 #609 #610 #611

Further changes to the front-end

Changelog:
- Updated Zero-dollar reason validation message
- Updated text for zero-dollar reason
- Removed additional warning message when declining
- Signing History should no longer show multiple "recommended" entries
- Additional text added when a transaction is rescinded, refused or declined