### PR TITLE
Show only one "Return" button when user has both analyst and director role

### DIFF
--- a/frontend/src/app/components/Navbar.js
+++ b/frontend/src/app/components/Navbar.js
@@ -197,6 +197,7 @@ class Navbar extends Component {
           }
           <li>
             <NavLink
+              activeClassName="active"
               id="collapse-navbar-credit-transactions"
               to={CREDIT_TRANSACTIONS.LIST}
             >
@@ -220,6 +221,18 @@ class Navbar extends Component {
             </NavLink>
           </li>
           }
+          <li>
+            <NavLink
+              activeClassName="active"
+              id="navbar-notifications"
+              to={Routes.NOTIFICATIONS.LIST}
+            >
+                Notifications
+              {unreadCount > 0 &&
+                <span> ({unreadCount})</span>
+              }
+            </NavLink>
+          </li>
           <li>
             <NavLink id="navbar-settings" to={Routes.SETTINGS}>
               Settings

--- a/frontend/src/credit_transfers/components/CreditTransferFormButtons.js
+++ b/frontend/src/credit_transfers/components/CreditTransferFormButtons.js
@@ -169,6 +169,7 @@ const CreditTransferFormButtons = props => (
         </button>
       }
       {props.actions.includes(Lang.BTN_RETURN_TO_DRAFT) &&
+      !props.actions.includes(Lang.BTN_PULL_BACK) &&
         <button
           className="btn btn-warning"
           data-target="#confirmReturn"

--- a/frontend/styles/Navbar.scss
+++ b/frontend/styles/Navbar.scss
@@ -1,4 +1,4 @@
-.level2Navigation .container, #navbar {
+.level2Navigation .container {
   position: relative;
 
   a {
@@ -32,5 +32,11 @@
     .fa-layers-counter {
       font-size: 4rem;
     }
+  }
+}
+
+.navbar-nav {
+  .active {
+    background-color: rgba(255, 255, 255, 0.2);
   }
 }


### PR DESCRIPTION
#626 

Added condition to only show one button for returning the status to draft if the user has both analyst and director role.

Changelog:
- Added a check if Pull Back was already included