### PR TITLE
Negative values are no longer allowed for Fair Market Value Input

### DIFF
--- a/frontend/src/constants/langEnUs.js
+++ b/frontend/src/constants/langEnUs.js
@@ -49,3 +49,7 @@ export const TEXT_COMMENT_DIRTY = 'You are currently editing a comment. Save or 
                                   'performing other actions';
 export const TEXT_COMMENT_REQUIRED = 'Comment is required before a credit transaction can ' +
                                      'be recommended';
+
+export const TEXT_ERROR_MAX_DECIMALS = 'Cannot add more decimals.';
+export const TEXT_ERROR_MULTIPLE_DOTS = 'Multiple dots are not allowed.';
+export const TEXT_ERROR_NEGATIVE_VALUE = 'Negative values are not allowed.';


### PR DESCRIPTION
#631 

Negative symbol is no longer allowed in the FairMarketValueInput

Changelog:
- Prevent keypress of -
- Paste should also detect if there's a - in the clipboard
- Tooltip should be shown notifying the user negative values are not allowed