### PR TITLE
Externalized Configuration

### DIFF
--- a/frontend/public/config/features.js
+++ b/frontend/public/config/features.js
@@ -1,0 +1,9 @@
+//defaults
+
+window.tfrs_config = {
+  "keycloak.enabled": false,
+  "keycloak.authority": "",
+  "keycloak.client_id": "tfrs-app",
+  "keycloak.callback_url": "",
+  "keycloak.post_logout_url": "",
+};

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -16,6 +16,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/config/features.js"></script>
     <script src="/build/bundle.js"></script>
     <script src="/assets/js/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.js"></script>

--- a/frontend/src/app/KeycloakAwareApp.js
+++ b/frontend/src/app/KeycloakAwareApp.js
@@ -1,6 +1,4 @@
 import StatusInterceptor from './components/StatusInterceptor';
-import CONFIG from '../config';
-import { getLoggedInUser } from '../actions/userActions';
 import { IntlProvider } from 'react-intl';
 import ReduxToastr from 'react-redux-toastr';
 import Navbar from './components/Navbar';

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,16 +1,22 @@
 /*
- Used to track feature configuration, injected via
-  Webpack (from environment variables or similar)
+ Used to track feature configuration
 */
+
+let get_config = (value, def) =>{
+  if (global.tfrs_config) {
+    return global.tfrs_config[value] || def;
+  }
+  return def;
+};
 
 
 let CONFIG = {
   KEYCLOAK: {
-    ENABLED: __INJECTED_CONFIG.KEYCLOAK.ENABLED,
-    AUTHORITY: __INJECTED_CONFIG.KEYCLOAK.AUTHORITY,
-    CLIENT_ID: __INJECTED_CONFIG.KEYCLOAK.CLIENT_ID,
-    CALLBACK_URL: __INJECTED_CONFIG.KEYCLOAK.CALLBACK_URL,
-    POST_LOGOUT_URL: __INJECTED_CONFIG.KEYCLOAK.POST_LOGOUT_URL
+    ENABLED: get_config("keycloak.enabled", false),
+    AUTHORITY: get_config("keycloak.authority","unconfigured"),
+    CLIENT_ID: get_config("keycloak.client_id", "unconfigured"),
+    CALLBACK_URL: get_config("keycloak.callback_url", "unconfigured"),
+    POST_LOGOUT_URL: get_config("keycloak.post_logout_url", "unconfigured")
   }
 };
 

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -31,8 +31,6 @@ import UserViewContainer from './users/UserViewContainer';
 import NotificationsContainer from './notifications/NotificationsContainer';
 import AuthCallback from './app/AuthCallback';
 import CONFIG from './config';
-import userManager from './store/oidc-usermanager';
-import {signUserOut} from "./actions/userActions";
 
 const Router = props => (
   <ConnectedRouter history={history} key={Math.random()}>

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -101,20 +101,9 @@ const config = {
     new Webpack.DefinePlugin({
       __LOGOUT_TEST_URL__: JSON.stringify('https://logontest.gov.bc.ca/clp-cgi/logoff.cgi'),
       __LOGOUT_URL__: JSON.stringify('https://logon.gov.bc.ca/clp-cgi/logoff.cgi'),
-      __VERSION__: JSON.stringify(packageJson.version),
-      __INJECTED_CONFIG: {
-        KEYCLOAK: {
-          ENABLED: process.env.KEYCLOAK_ENABLED &&
-            (process.env.KEYCLOAK_ENABLED.toLowerCase() === 'true'),
-          AUTHORITY: JSON.stringify(process.env.KEYCLOAK_AUTHORITY || 'unconfigured'),
-          CLIENT_ID: JSON.stringify(process.env.KEYCLOAK_CLIENT_ID || 'unconfigured'),
-          REALM: JSON.stringify(process.env.KEYCLOAK_REALM || 'unconfigured'),
-          ISSUE: JSON.stringify(process.env.KEYCLOAK_ISSUER || 'unconfigured'),
-          CALLBACK_URL: JSON.stringify(process.env.KEYCLOAK_CALLBACK_URL || 'unconfigured'),
-          POST_LOGOUT_URL: JSON.stringify(process.env.KEYCLOAK_POST_LOGOUT_URL || 'unconfigured')
-        }
+      __VERSION__: JSON.stringify(packageJson.version)
       }
-    })
+    )
   ]
 };
 

--- a/frontend/webpack.docker.config.js
+++ b/frontend/webpack.docker.config.js
@@ -69,19 +69,7 @@ const config = {
   devtool: 'source-map', // 'source-map', // debug
   plugins: [
     new Webpack.DefinePlugin({
-      __VERSION__: JSON.stringify(packageJson.version),
-      __INJECTED_CONFIG: {
-        KEYCLOAK: {
-          ENABLED: process.env.KEYCLOAK_ENABLED &&
-            (process.env.KEYCLOAK_ENABLED.toLowerCase() === 'true'),
-          AUTHORITY: JSON.stringify(process.env.KEYCLOAK_AUTHORITY || 'unconfigured'),
-          CLIENT_ID: JSON.stringify(process.env.KEYCLOAK_CLIENT_ID || 'unconfigured'),
-          REALM: JSON.stringify(process.env.KEYCLOAK_REALM || 'unconfigured'),
-          ISSUE: JSON.stringify(process.env.KEYCLOAK_ISSUER || 'unconfigured'),
-          CALLBACK_URL: JSON.stringify(process.env.KEYCLOAK_CALLBACK_URL || 'unconfigured'),
-          POST_LOGOUT_URL: JSON.stringify(process.env.KEYCLOAK_POST_LOGOUT_URL || 'unconfigured')
-        }
-      }
+      __VERSION__: JSON.stringify(packageJson.version)
     }),
     new Webpack.HotModuleReplacementPlugin()
   ]

--- a/frontend/webpack.production.config.js
+++ b/frontend/webpack.production.config.js
@@ -5,9 +5,6 @@ const path = require('path');
 const nodeModulesPath = path.resolve(__dirname, 'node_modules');
 const buildPath = path.resolve(__dirname, 'public', 'build');
 const mainPath = path.resolve(__dirname, 'src', 'index.js');
-// var plugins = require('webpack-load-plugins')();
-// plugins.ImageminPlugin = require('imagemin-webpack-plugin');
-// plugsin.imageminMozjpeg = require('imagemin-mozjpeg');
 
 const config = {
   mode: 'production',
@@ -56,7 +53,7 @@ const config = {
       }
     ]
   },
-  devServer: {
+    devServer: {
     historyApiFallback: true,
     headers: {
       'Access-Control-Allow-Origin': '*',
@@ -72,18 +69,6 @@ const config = {
       __LOGOUT_TEST_URL__: JSON.stringify('https://logontest.gov.bc.ca/clp-cgi/logoff.cgi'),
       __LOGOUT_URL__: JSON.stringify('https://logon.gov.bc.ca/clp-cgi/logoff.cgi'),
       __VERSION__: JSON.stringify(packageJson.version),
-      __INJECTED_CONFIG: {
-        KEYCLOAK: {
-          ENABLED: process.env.KEYCLOAK_ENABLED &&
-            (process.env.KEYCLOAK_ENABLED.toLowerCase() === 'true'),
-          AUTHORITY: JSON.stringify(process.env.KEYCLOAK_AUTHORITY || 'unconfigured'),
-          CLIENT_ID: JSON.stringify(process.env.KEYCLOAK_CLIENT_ID || 'unconfigured'),
-          REALM: JSON.stringify(process.env.KEYCLOAK_REALM || 'unconfigured'),
-          ISSUE: JSON.stringify(process.env.KEYCLOAK_ISSUER || 'unconfigured'),
-          CALLBACK_URL: JSON.stringify(process.env.KEYCLOAK_CALLBACK_URL || 'unconfigured'),
-          POST_LOGOUT_URL: JSON.stringify(process.env.KEYCLOAK_POST_LOGOUT_URL || 'unconfigured')
-        }
-      }
     })
   ]
 };


### PR DESCRIPTION
# Changelog 

Externalize feature configuration to a file, `public/features/config.js` to support OpenShift `configMap` deployment-time environment customisation via file injection.

This can't be accomplished via environment variables in our current deployment configurations since the application is built only once and deployed in several environments, served as a static bundle.