### PR TITLE
Persist destination in localStorage when navigating

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,7 @@ services:
             - RABBITMQ_DEFAULT_USER=rabbitmq
             - RABBITMQ_DEFAULT_PASS=rabbitmq
             - RABBITMQ_DEFAULT_VHOST=/tfrs
+            - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit log_levels [{connection,error}]
         ports:
             - 15672:15672
             - 5672:5672
@@ -132,6 +133,8 @@ services:
           DB_PASSWORD: keycloak
           KEYCLOAK_USER: admin
           KEYCLOAK_PASSWORD: admin
+          KEYCLOAK_LOGLEVEL: WARN
+          ROOT_LOGLEVEL: WARN
         ports:
           - 8888:8080
         depends_on:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17473,6 +17473,11 @@
         }
       }
     },
+    "redux-localstorage": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/redux-localstorage/-/redux-localstorage-0.4.1.tgz",
+      "integrity": "sha1-+vbXGcWBOXKU2BFHP/zt7gZckzw="
+    },
     "redux-logger": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "react-table": "^6.7.6",
     "react-text-mask": "^5.4.2",
     "redux": "^3.6.0",
+    "redux-localstorage": "^0.4.1",
     "redux-logger": "^3.0.1",
     "redux-oidc": "^3.0.0",
     "redux-socket.io": "^1.4.0",

--- a/frontend/src/app/AuthCallback.js
+++ b/frontend/src/app/AuthCallback.js
@@ -5,12 +5,25 @@ import history from '../app/History';
 import userManager from '../store/oidc-usermanager';
 
 class AuthCallback extends React.Component {
+
+  constructor() {
+    super();
+    this.success = this.success.bind(this);
+  }
+
+  success(user) {
+    const target = this.props.targetPath;
+    history.push(target);
+  }
+
+  error(e)  {}
+
   render() {
     return (
       <CallbackComponent
         userManager={userManager}
-        successCallback={this.props.success}
-        errorCallback={this.props.error}
+        successCallback={this.success}
+        errorCallback={this.error}
       >
         <div>Authentication complete. Redirecting.</div>
       </CallbackComponent>
@@ -20,23 +33,14 @@ class AuthCallback extends React.Component {
 
 const mapStateToProps = state => {
   return {
-    //todo: state.todos[0]
+    targetPath: state.targetPath.target
   }
-}
-
+};
 
 const mapDispatchToProps = dispatch => {
   return {
-    success: (user) => {
-      history.push('/');
-    }
-    ,
-    error: (e) => {
-      console.error(e);
-    }
   }
-}
-
+};
 
 export default connect(
   mapStateToProps,

--- a/frontend/src/app/KeycloakAwareApp.js
+++ b/frontend/src/app/KeycloakAwareApp.js
@@ -56,7 +56,6 @@ class KeycloakAwareApp extends React.Component {
         </IntlProvider>
       );
     } else if (this.props.keycloak.isFetching && this.props.location.pathname === '/authCallback') {
-      console.log('returning authcallback');
       return (this.props.children);
     }
     // we're not logged in and not in the process of logging in. trigger one.

--- a/frontend/src/app/components/Navbar.js
+++ b/frontend/src/app/components/Navbar.js
@@ -345,7 +345,6 @@ class Navbar extends Component {
                           <FontAwesomeIcon icon="sign-out-alt" /> Log Out
                         </MenuItem>
                         }
-
                       </DropdownButton>
                     }
                   </h5>

--- a/frontend/src/reducers/persistTargetPathReducer.js
+++ b/frontend/src/reducers/persistTargetPathReducer.js
@@ -1,0 +1,20 @@
+const persistTargetPathReducer = (state = {
+  target: '/'
+}, action) => {
+  switch (action.type) {
+    case 'redux-oidc/LOADING_USER':
+      if (action.currentRoute.location && !(action.currentRoute.location.pathname.match(/.*?authCallback/))) {
+        return {
+          ...state,
+          target: action.currentRoute.location.pathname
+        };
+      }
+      else {
+        return state;
+      }
+    default:
+      return state;
+  }
+};
+
+export {persistTargetPathReducer};

--- a/frontend/src/reducers/persistTargetPathReducer.js
+++ b/frontend/src/reducers/persistTargetPathReducer.js
@@ -3,7 +3,8 @@ const persistTargetPathReducer = (state = {
 }, action) => {
   switch (action.type) {
     case 'redux-oidc/LOADING_USER':
-      if (action.currentRoute.location && !(action.currentRoute.location.pathname.match(/.*?authCallback/))) {
+      if (action.currentRoute.location &&
+        !(action.currentRoute.location.pathname.match(/.*?authCallback/))) {
         return {
           ...state,
           target: action.currentRoute.location.pathname

--- a/frontend/src/store/authorizationInterceptor.js
+++ b/frontend/src/store/authorizationInterceptor.js
@@ -4,7 +4,6 @@ import CONFIG from '../config';
 
 function configureAxios () {
   if (CONFIG.KEYCLOAK) {
-    console.log('adding token to request');
 
     axios.interceptors.request.use((config) => {
       const loadconfig = async () => {

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -1,51 +1,57 @@
-import { createStore, applyMiddleware, combineReducers } from 'redux';
+import { createStore, compose, applyMiddleware, combineReducers } from 'redux';
 import { reducer as toastrReducer } from 'react-redux-toastr';
 import { routerReducer, routerMiddleware } from 'react-router-redux';
 import { createLogger } from 'redux-logger';
-import createSocketIoMiddleware from 'redux-socket.io';
 import io from 'socket.io-client';
 import thunk from 'redux-thunk';
 import rootReducer from '../reducers/reducer';
 import { getNotifications } from '../actions/notificationActions';
 import { SOCKETIO_URL } from '../constants/routes';
 
-import { createUserManager, loadUser, processSilentRenew, reducer as OIDCReducer } from 'redux-oidc';
+import createOidcMiddleware, { loadUser, processSilentRenew, reducer as OIDCReducer } from 'redux-oidc';
+import { persistTargetPathReducer } from '../reducers/persistTargetPathReducer';
+
 import userManager from './oidc-usermanager';
 import CONFIG from '../config';
 import { getLoggedInUser } from '../actions/userActions';
 
-const middleware = routerMiddleware(history);
+import persistState from 'redux-localstorage';
+import createSocketIoMiddleware from 'redux-socket.io';
 
-const loggerMiddleware = createLogger();
+const middleware = routerMiddleware(history);
+const oidcMiddleware = createOidcMiddleware(userManager);
 
 const socket = io(SOCKETIO_URL);
 const socketIoMiddleware = createSocketIoMiddleware(socket, 'socketio/');
 
-const store = process.env.NODE_ENV !== 'production' ? createStore(
-  combineReducers({
-    rootReducer,
-    routing: routerReducer,
-    toastr: toastrReducer,
-    oidc: OIDCReducer
-  }),
-  applyMiddleware(
-    thunk,
-    loggerMiddleware,
-    socketIoMiddleware,
-    middleware
-  )
-) : createStore(
-  combineReducers({
-    rootReducer,
-    routing: routerReducer,
-    toastr: toastrReducer,
-    oidc: OIDCReducer
-  }),
-  applyMiddleware(
-    thunk,
-    socketIoMiddleware,
-    middleware
-  )
+const enhancer = compose(persistState(['targetPath'], {key: 'tfrs-state'}));
+
+const combinedReducers = (state = {}, action) => {
+  const currentRoute = state.routing || {};
+  return {
+    toastr: toastrReducer(state.toastr, action),
+    oidc: OIDCReducer(state.oidc, action),
+    routing: routerReducer(state.routing, action),
+    targetPath: persistTargetPathReducer(state.targetPath, {...action, currentRoute}),
+    rootReducer: rootReducer(state.rootReducer, action),
+  };
+};
+
+let allMiddleware = [
+  thunk,
+  socketIoMiddleware,
+  oidcMiddleware,
+  middleware
+];
+
+if (process.env.NODE_ENV !== 'production') {
+  allMiddleware.push(createLogger());
+}
+
+const store = createStore(
+  combinedReducers,
+  applyMiddleware(...allMiddleware),
+  enhancer
 );
 
 let subscriptionProcessing = false;


### PR DESCRIPTION
# Changelog

- Added `targetPath` reducer that watches for **redux-oidc** action **LOAD_USER** and preserves current route in `state`.
- Added **redux-localstorage** dependency and modified store configuration to persist the state for reducer `targetPath`
- Streamlined configuration of `store` object
- minor adjustments to docker config to make it less verbose