### PR TITLE
Hide SMS settings

### DIFF
--- a/backend/api/keycloak_authentication.py
+++ b/backend/api/keycloak_authentication.py
@@ -92,7 +92,6 @@ class UserAuthentication(authentication.BaseAuthentication):
                                         issuer=settings.KEYCLOAK['ISSUER'])
                 break
             except InvalidTokenError as e:
-                print('token validation failed: {}'.format(e))
                 token_validation_errors.append(e)
 
         if not user_token:

--- a/frontend/src/settings/components/NotificationsCreditTransactionsTable.js
+++ b/frontend/src/settings/components/NotificationsCreditTransactionsTable.js
@@ -48,7 +48,8 @@ const NotificationsCreditTransactionsTable = (props) => {
     className: 'col-sms',
     Header: 'Receive SMS Notification',
     id: 'sms',
-    sortable: false
+    sortable: false,
+    show: false
   }, {
     accessor: item => (item.code),
     Cell: row => (

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -68,7 +68,8 @@ store.subscribe(() => {
     if (CONFIG.KEYCLOAK.ENABLED) {
       if (state.oidc.user &&
         !state.rootReducer.userRequest.isFetching &&
-        !state.rootReducer.userRequest.isAuthenticated) {
+        !state.rootReducer.userRequest.isAuthenticated &&
+        !state.rootReducer.userRequest.serverError) {
         store.dispatch(getLoggedInUser());
       }
     }


### PR DESCRIPTION
# Changelog

- Hide SMS settings column for demo
- Better authentication flow (friendly message) in the case where a user is logged into Keycloak but has no mapped user within TFRS

Trello card 979