### PR TITLE
Disabling snyk to help the pipeline run faster

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -106,5 +106,5 @@
       }
     }
   },
-  "snyk": true
+  "snyk": false
 }


### PR DESCRIPTION
Disabling snyk for now as it seems to be draining the resources when the pipeline runs