### PR TITLE
Different way to disabling snyk

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,8 +90,7 @@
     "production": "NODE_ENV=production webpack -p --config webpack.production.config.js",
     "build": "webpack",
     "test": "jest --coverage",
-    "snyk-protect": "snyk protect",
-    "prepare": "npm run snyk-protect"
+    "snyk-protect": "snyk protect"
   },
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
Apparently, prepare is a hook for npm. So that's why it was running it every time.