### PR TITLE
Moved .env file into backend and frontend folders

### DIFF
--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -13,7 +13,7 @@ from django.core.wsgi import get_wsgi_application
 from dotenv import load_dotenv
 
 try:
-    ENV = Path('..') / '.env'
+    ENV = '.env'
     load_dotenv(dotenv_path=ENV)
 except TypeError:
     pass  # path doesn't exist. no cause for alarm.

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -105,7 +105,7 @@ const config = {
   // from Node
   plugins: [
     new Dotenv({
-      path: '../.env'
+      path: '.env'
     }),
     new Webpack.HotModuleReplacementPlugin(),
     new Webpack.DefinePlugin({

--- a/frontend/webpack.docker.config.js
+++ b/frontend/webpack.docker.config.js
@@ -7,19 +7,18 @@ const buildPath = path.resolve(__dirname, 'public', 'build');
 const mainPath = path.resolve(__dirname, 'src', 'index.js');
 const tokenRenewalPath = path.resolve(__dirname, 'src', 'tokenRenewal.js');
 
-
 const config = {
-  entry: { bundle: [
-    // Polyfill for Object.assign on IE11, etc
-    'babel-polyfill',
-    mainPath
-  ],
+  entry: {
+    bundle: [
+      // Polyfill for Object.assign on IE11, etc
+      'babel-polyfill',
+      mainPath
+    ],
     tokenRenewal: [
       'babel-polyfill',
       tokenRenewalPath
     ]
-  }
-  ,
+  },
   output: {
     filename: "[name].js",
     publicPath: '/build/',


### PR DESCRIPTION
#620

Moved the .env files into backend and frontend folders as the pods won't have a way to go up one level.

Changelog:
- Moved where the backend is looking for the .env file into same level as manage.py
- Moved where the frontend is looking for the .env file into same level as package.json