### PR TITLE
BDD - Minor Stability Update

### DIFF
--- a/functional-tests/src/test/groovy/pages/app/HistoricalDataEntryPage.groovy
+++ b/functional-tests/src/test/groovy/pages/app/HistoricalDataEntryPage.groovy
@@ -52,11 +52,11 @@ class HistoricalDataEntryPage extends BaseAppPage {
   }
 
   void setCreditsFrom(String respondentFrom) {
-    creditsFromDropdown.$('option', text:respondentFrom).click()
+    waitFor { creditsFromDropdown.$('option', text:respondentFrom).click() }
   }
 
   void setCreditsTo(String respondentTo) {
-    creditsToDropdown.$('option', text:respondentTo).click()
+    waitFor { creditsToDropdown.$('option', text:respondentTo).click() }
   }
 
   void setZeroDollarReason(String reason) {
@@ -64,7 +64,7 @@ class HistoricalDataEntryPage extends BaseAppPage {
   }
 
   void setCompliancePeriod(String period) {
-    compliancePeriodDropdown.$('option', text:period).click()
+    waitFor { compliancePeriodDropdown.$('option', text:period).click() }
   }
 
   void setNote(String note) {

--- a/functional-tests/src/test/groovy/pages/app/NewCreditTransactionPage.groovy
+++ b/functional-tests/src/test/groovy/pages/app/NewCreditTransactionPage.groovy
@@ -30,11 +30,11 @@ class NewCreditTransactionPage extends BaseAppPage {
   }
 
   void setRespondent(String respondent) {
-    respondentField.$('option', text:respondent).click()
+    waitFor { respondentField.$('option', text:respondent).click() }
   }
 
   void setCompliancePeriod(String period) {
-    compliancePeriodDropdown.$('option', text:period).click()
+    waitFor { compliancePeriodDropdown.$('option', text:period).click() }
   }
 
   void addComment(String comment) {

--- a/functional-tests/src/test/groovy/pages/app/NewCreditTransferPage.groovy
+++ b/functional-tests/src/test/groovy/pages/app/NewCreditTransferPage.groovy
@@ -20,7 +20,7 @@ class NewCreditTransferPage extends BaseAppPage {
   }
 
   void setTransactionType(String type) {
-    transactionTypeDropdown.$('option', text:type).click()
+    waitFor { transactionTypeDropdown.$('option', text:type).click() }
   }
 
   void setNumberOfCredits(int credits) {
@@ -28,7 +28,7 @@ class NewCreditTransferPage extends BaseAppPage {
   }
 
   void setRespondent(String respondent) {
-    respondentField.$('option', text:respondent).click()
+    waitFor { respondentField.$('option', text:respondent).click() }
   }
 
   void setPricePerCredit(int price) {


### PR DESCRIPTION
Minor update to hopefully improve stability based on some odd test failures and subsequent investigation.

After running some trials, it looks like there is a rare case where the expected content of a dropdown does not exist.  Possibly due to some rare loading race condition, or having to do with minuscule loading delays between focusing the dropdown, and when the dropdown content renders?

Adding waits around all dropdown selectors, which in the best case scenario will improve stability; worst case nothing will change.