### PR TITLE
Fixed the user creation for BCeID by providing a default organization

### DIFF
--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -296,8 +296,8 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
     """
     def __init__(self, *args, **kwargs):
         """
-        This is to allow us to simulate a partial update.
-        This will need to be updated when we finally allow PATCH in our system.
+        This is to always ensure that we have a status for the credit
+        transfer
         """
         super(CreditTradeUpdateSerializer, self).__init__(*args, **kwargs)
         data = kwargs.get('data')

--- a/backend/api/serializers/UserCreationRequestSerializer.py
+++ b/backend/api/serializers/UserCreationRequestSerializer.py
@@ -5,12 +5,33 @@ from api.serializers import UserCreateSerializer
 
 
 class UserCreationRequestSerializer(serializers.Serializer):
+    """
+    Serializer for creating a user
+    """
     user = UserCreateSerializer(allow_null=False)
     email = serializers.EmailField(allow_null=False, allow_blank=False)
 
+    def __init__(self, *args, **kwargs):
+        """
+        This is to restrict non-government users from creating users
+        for other organizations
+        """
+        super(UserCreationRequestSerializer, self).__init__(*args, **kwargs)
+        data = kwargs.get('data')
+        request = self.context.get('request')
+
+        if not request.user.is_government_user:
+            user = data['user']
+            user['organization'] = request.user.organization.id
+
     def validate(self, data):
-        if UserCreationRequest.objects.filter(keycloak_email=data['email']).exists():
-            raise serializers.ValidationError('This SSO email is already associated with a user')
+        """
+        Validation to check that the email hasn't been used yet.
+        """
+        if UserCreationRequest.objects.filter(
+                keycloak_email=data['email']).exists():
+            raise serializers.ValidationError(
+                'This SSO email is already associated with a user')
 
         return data
 

--- a/frontend/src/app/History.js
+++ b/frontend/src/app/History.js
@@ -5,7 +5,6 @@ let config = {};
 /* global __BUILD_NUMBER__ */
 
 if (__BUILD_NUMBER__ && window.location.host === 'dev-lowcarbonfuels.pathfinder.gov.bc.ca') {
-  console.log(__BUILD_NUMBER__);
   config = {
     basename: `/${__BUILD_NUMBER__}`
   };

--- a/frontend/src/constants/notificationTypes.js
+++ b/frontend/src/constants/notificationTypes.js
@@ -16,7 +16,7 @@ const NOTIFICATION_TYPES = {
   PVR_CREATED: 'PVR Created',
   PVR_DECLINED: 'PVR Declined',
   PVR_INTERNAL_COMMENT: 'PVR Internal Comment Created Or Updated',
-  PVR_PULLED_BACK: 'PVR Pulled Back',
+  PVR_PULLED_BACK: 'PVR Recalled as draft',
   PVR_RECOMMENDED_FOR_APPROVAL: 'PVR Recommended For Approval',
   PVR_RETURNED_TO_ANALYST: 'PVR Returned to Analyst'
 };

--- a/frontend/src/constants/settings/notificationsGovernmentTransfers.js
+++ b/frontend/src/constants/settings/notificationsGovernmentTransfers.js
@@ -31,8 +31,8 @@ const GOVERNMENT_TRANSFER_NOTIFICATIONS = [{
 }, {
   id: 1,
   code: 'PVR_PULLED_BACK',
-  description: 'Returned to Analyst',
-  key: 'return_to_analyst',
+  description: 'Recalled as draft',
+  key: 'recalled_as_draft',
   recipients: ['government']
 }, {
   id: 1,


### PR DESCRIPTION
#649 

I've encountered issues creating a user as a fuel supplier user. This is to fix it.

Changelog:
- Added automatic fill for organization field when creating a user as a fuel supplier
- Changed the message `Pulled back` to `Recalled as draft`
- Minor code cleanup