### PR TITLE
Added validation for the uploaded files

### DIFF
--- a/frontend/__tests__/utils/functions.js
+++ b/frontend/__tests__/utils/functions.js
@@ -1,4 +1,4 @@
-import { arrayMove } from '../../src/utils/functions';
+import { arrayMove, validateFiles } from '../../src/utils/functions';
 
 test('Array Move to actually function as expected', () => {
   const arr = [1, 2, 3, 4, 5];
@@ -7,4 +7,48 @@ test('Array Move to actually function as expected', () => {
   arrayMove(arr, 2, 1);
 
   expect(arr).toEqual([1, 3, 2, 4, 5]);
+});
+
+test('Validate Files should only return allowed file types', () => {
+  const files = [{
+    name: 'FILE_000.jpg',
+    type: 'image/jpg'
+  }, {
+    name: 'FILE_000.jpeg',
+    type: 'image/jpeg'
+  }, {
+    name: 'FILE_000.ppt',
+    type: ''
+  }, {
+    name: 'FILE_000.xls',
+    type: ''
+  }, {
+    name: 'FILE_000.pdf',
+    type: 'application/pdf'
+  }, {
+    name: 'FILE_000.exe',
+    type: 'application/octet-stream'
+  }, {
+    name: 'FILE_000.zip',
+    type: 'application/x-rar-compressed'
+  }];
+
+  const allowedFiles = validateFiles(files);
+
+  expect(allowedFiles).toEqual([{
+    name: 'FILE_000.jpg',
+    type: 'image/jpg'
+  }, {
+    name: 'FILE_000.jpeg',
+    type: 'image/jpeg'
+  }, {
+    name: 'FILE_000.ppt',
+    type: ''
+  }, {
+    name: 'FILE_000.xls',
+    type: ''
+  }, {
+    name: 'FILE_000.pdf',
+    type: 'application/pdf'
+  }]);
 });

--- a/frontend/src/secure_document_upload/CreditTransactionRequestAddContainer.js
+++ b/frontend/src/secure_document_upload/CreditTransactionRequestAddContainer.js
@@ -131,7 +131,7 @@ CreditTransactionRequestAddContainer.propTypes = {
   }).isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({
-      id: PropTypes.string.isRequired
+      type: PropTypes.string
     }).isRequired
   }).isRequired,
   validationErrors: PropTypes.shape()

--- a/frontend/src/secure_document_upload/components/CreditTransactionRequestFormDetails.js
+++ b/frontend/src/secure_document_upload/components/CreditTransactionRequestFormDetails.js
@@ -6,21 +6,25 @@ import PropTypes from 'prop-types';
 import Dropzone from 'react-dropzone';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
-import InputWithTooltip from '../../app/components/InputWithTooltip';
-import { CREDIT_TRANSFER_TYPES } from '../../constants/values';
+import { validateFiles } from '../../utils/functions';
 
 class CreditTransactionRequestFormDetails extends Component {
   constructor (props) {
     super(props);
 
-    this.onDrop = this.onDrop.bind(this);
-    this.removeFile = this.removeFile.bind(this);
+    this.rejectedFiles = [];
+
+    this._onDrop = this._onDrop.bind(this);
+    this._removeFile = this._removeFile.bind(this);
   }
 
-  onDrop (files) {
+  _onDrop (files) {
+    const acceptedFiles = validateFiles(files);
+    const rejectedFiles = files.filter(file => !acceptedFiles.includes(file));
+
     const attachedFiles = [
       ...this.props.fields.files,
-      ...files
+      ...acceptedFiles
     ];
 
     const newFiles = attachedFiles.filter((item, position, arr) => (
@@ -33,9 +37,14 @@ class CreditTransactionRequestFormDetails extends Component {
         value: newFiles
       }
     });
+
+    this.rejectedFiles = [
+      ...this.rejectedFiles,
+      ...rejectedFiles
+    ];
   }
 
-  removeFile (file) {
+  _removeFile (file) {
     const found = this.props.fields.files.findIndex(item => (item === file));
     this.props.fields.files.splice(found, 1);
 
@@ -151,7 +160,7 @@ class CreditTransactionRequestFormDetails extends Component {
                   <Dropzone
                     activeClassName="is-dragover"
                     className="dropzone"
-                    onDrop={this.onDrop}
+                    onDrop={this._onDrop}
                   >
                     <FontAwesomeIcon icon="cloud-upload-alt" size="2x" />
                     <div>
@@ -168,11 +177,28 @@ class CreditTransactionRequestFormDetails extends Component {
                   <ul>
                     {this.props.fields.files.map(file => (
                       <li key={file.name}>
-                        {file.name} - {file.size} bytes <button type="button" onClick={() => this.removeFile(file)}><FontAwesomeIcon icon="minus-circle" /></button>
+                        {file.name} - {file.size} bytes <button type="button" onClick={() => this._removeFile(file)}><FontAwesomeIcon icon="minus-circle" /></button>
                       </li>
                     ))}
                     {this.props.fields.files.length === 0 &&
                       <li>No files selected.</li>
+                    }
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            <div className="row">
+              <div className="form-group col-md-12 main-form files">
+                <div>Invalid Files/File Types (These files will not be uploaded):
+                  <ul>
+                    {this.rejectedFiles.map(file => (
+                      <li key={file.name}>
+                        {file.name} - {file.size} bytes
+                      </li>
+                    ))}
+                    {this.rejectedFiles.length === 0 &&
+                      <li>None</li>
                     }
                   </ul>
                 </div>

--- a/frontend/src/utils/functions.js
+++ b/frontend/src/utils/functions.js
@@ -38,7 +38,7 @@ const validateFiles = files => (
       case 'text/plain':
         return file.type;
       default:
-        if (file.name.endsWith('xls') || file.name.endsWith('ppt')) {
+        if (file.name.split('.').pop() === 'xls' || file.name.split('.').pop() === 'ppt') {
           return file;
         }
 

--- a/frontend/src/utils/functions.js
+++ b/frontend/src/utils/functions.js
@@ -22,4 +22,28 @@ const download = (url, params = {}) => (
   })
 );
 
-export { arrayMove, download };
+const validateFiles = files => (
+  files.filter((file) => {
+    switch (file.type) {
+      case 'application/msoutlook':
+      case 'application/pdf':
+      case 'application/vnd.openxmlformats-officedocument.presentationml.presentation':
+      case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+      case 'image/gif':
+      case 'image/jpg':
+      case 'image/jpeg':
+      case 'image/png':
+      case 'text/csv':
+      case 'text/plain':
+        return file.type;
+      default:
+        if (file.name.split('.').pop() === 'xls' || file.name.split('.').pop() === 'ppt') {
+          return file;
+        }
+
+        return false;
+    }
+  })
+);
+
+export { arrayMove, download, validateFiles };

--- a/frontend/src/utils/functions.js
+++ b/frontend/src/utils/functions.js
@@ -27,6 +27,7 @@ const validateFiles = files => (
     switch (file.type) {
       case 'application/msoutlook':
       case 'application/pdf':
+      case 'application/vnd.ms-excel':
       case 'application/vnd.openxmlformats-officedocument.presentationml.presentation':
       case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
       case 'image/gif':
@@ -37,7 +38,7 @@ const validateFiles = files => (
       case 'text/plain':
         return file.type;
       default:
-        if (file.name.split('.').pop() === 'xls' || file.name.split('.').pop() === 'ppt') {
+        if (file.name.endsWith('xls') || file.name.endsWith('ppt')) {
           return file;
         }
 


### PR DESCRIPTION
#785 

Validating the file types based on mime type. The "accept" property doesn't seem to be that reliable and looks a bit awkward to use. But mimetype checking is unreliable in general.

Changelog:
- New Invalid files section
- New validation function
- onDrop sorts the files into accepted and rejected files