### PR TITLE
Fix users not receiving in-app notifications when a PVR is approved

### DIFF
--- a/backend/api/services/CreditTradeService.py
+++ b/backend/api/services/CreditTradeService.py
@@ -536,6 +536,9 @@ class CreditTradeService(object):
 
         notification_map[StatusChange('Approved')] = [
             ResultingNotification(
+                credit_trade.respondent,
+                NotificationType.PVR_APPROVED),
+            ResultingNotification(
                 government,
                 NotificationType.PVR_APPROVED),
         ]


### PR DESCRIPTION
#814 

Fixed the in-app notification not being sent to users when a PVR is approved

Changelog:
- Added a line to send the notification to users