### PR TITLE
Changed Modal Delete Message for Historical Data Entry

### DIFF
--- a/frontend/src/admin/historical_data_entry/components/HistoricalDataEntryPage.js
+++ b/frontend/src/admin/historical_data_entry/components/HistoricalDataEntryPage.js
@@ -60,7 +60,7 @@ const HistoricalDataEntryPage = (props) => {
         id="confirmDelete"
         title="Confirm Delete"
       >
-        Do you want to delete this credit transfer?
+        Do you want to delete this credit transaction?
       </Modal>
 
       <Modal


### PR DESCRIPTION
#833

Changed the message so it shows "credit transaction" instead of "credit transfer"

Changelog:
- Updated the modal delete