### PR TITLE
Startup service checks

### DIFF
--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -6,6 +6,7 @@ programs=tfrs,security-scan-script
 
 [program:tfrs]
 startsecs=30
+startretries=20
 redirect_stderr=true
 directory=/app
 command=bash -c "python3 manage.py runserver 0.0.0.0:8000"
@@ -13,7 +14,8 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
 [program:security-scan-script]
-startsecs=5
+startsecs=10
+startretries=20
 redirect_stderr=true
 directory=/app
 command=bash -c "python3 manage.py runscript api.scripts.handle_security_scans"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,9 +67,12 @@ services:
             context: ./backend
         command: >
                 bash -c
-                "/wfi/wait-for-it.sh -t 14400 rabbit:5672 &&
+                "pip install -q -r requirements.txt &&
+                /wfi/wait-for-it.sh -t 14400 rabbit:5672 &&
                 /wfi/wait-for-it.sh -t 14400 db:5432 &&
-                pip install -q -r requirements.txt &&
+                /wfi/wait-for-it.sh -t 14400 minio:9000 &&
+                /wfi/wait-for-it.sh -t 14400 keycloak:8080 &&
+                /wfi/wait-for-it.sh -t 14400 mailslurper:8080 &&
                 python3 manage.py makemigrations &&
                 python3 manage.py migrate &&
                 python3 manage.py load_ops_data api/fixtures/development/dockerized.py &&
@@ -172,6 +175,13 @@ services:
       ports:
         - 9000:9000
       command: "server /export"
+    mailslurper:
+      build:
+        context: https://github.com/mailslurper/mailslurper.git
+      ports:
+        - 2500:2500
+        - 9090:8080
+        - 8085:8085
 volumes:
     node_modules:
     postgres_keycloak_data:


### PR DESCRIPTION
# Changelog
- Added a startup hook for the Django app to validate external service dependencies (Minio, Email, Keycloak, and AMQP) to validate configuration on startup and exit abnormally if a check fails.
- Corresponding changes to docker-compose environment