### PR TITLE
Celery-based orphan cleanup

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -1,0 +1,8 @@
+from api.services.DocumentService import DocumentService
+from tfrs.celery import app as celery_app
+
+@celery_app.task
+def remove_orphans():
+    print('starting orphan removal')
+    DocumentService.remove_orphans()
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,7 @@
 coreapi==2.3.3
 cryptography==2.3.1
+celery==4.2.0
+django-celery-beat==1.4.0
 Django==1.11.18
 django-cors-headers==2.1.0
 django-debug-toolbar==1.5

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -2,10 +2,11 @@
 nodaemon=true
  
 [group:server]
-programs=tfrs,security-scan-script
+programs=tfrs,security-scan-script,celerybeat,celeryworker
 
 [program:tfrs]
 startsecs=30
+startretries=100
 redirect_stderr=true
 directory=/app
 command=bash -c "python3 manage.py runserver 0.0.0.0:8000"
@@ -20,4 +21,18 @@ command=bash -c "python3 manage.py runscript api.scripts.handle_security_scans"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
+[program:celerybeat]
+command=celery beat -A tfrs --loglevel=INFO
+startsecs=5
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+directory=/app
 
+[program:celeryworker]
+command=celery worker -A tfrs --loglevel=INFO -E
+startsecs=5
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+directory=/app

--- a/backend/tfrs/__init__.py
+++ b/backend/tfrs/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/backend/tfrs/celery.py
+++ b/backend/tfrs/celery.py
@@ -23,7 +23,7 @@ app.conf.update({
     'beat_schedule': {
         'minio-orphan-cleanup': {
             'task': 'api.tasks.remove_orphans',
-            'schedule': 30.0
+            'schedule': 3600.0
         }
     }
 })

--- a/backend/tfrs/celery.py
+++ b/backend/tfrs/celery.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import, unicode_literals
+import os
+from celery import Celery
+
+from tfrs.settings import AMQP
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tfrs.settings')
+
+app = Celery('tfrs', broker='amqp://{}:{}@{}:{}/{}'.format(
+    AMQP['USER'],
+    AMQP['PASSWORD'],
+    AMQP['HOST'],
+    AMQP['PORT'],
+    AMQP['VHOST']))
+
+app.conf.update({
+    'beat_scheduler': 'django_celery_beat.schedulers:DatabaseScheduler'
+})
+
+app.autodiscover_tasks()
+
+app.conf.update({
+    'beat_schedule': {
+        'minio-orphan-cleanup': {
+            'task': 'api.tasks.remove_orphans',
+            'schedule': 30.0
+        }
+    }
+})

--- a/backend/tfrs/settings.py
+++ b/backend/tfrs/settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django_extensions',
+    'django_celery_beat',
     'rest_framework',
     'tfrs',
     'api.app.APIAppConfig',


### PR DESCRIPTION
#Changelog
 - Added celery dependency for flexible scheduled tasks
 - Added minio orphan cleanup task

Some devops work is required to support the celery execution. I'm recommending we use supervisord as I've done in the docker installation to handle this in the openshift environments.