### PR TITLE
Credit Trade Hotfix

### DIFF
--- a/backend/api/viewsets/CreditTrade.py
+++ b/backend/api/viewsets/CreditTrade.py
@@ -103,7 +103,9 @@ class CreditTradeViewSet(AuditableMixin, mixins.CreateModelMixin,
         # you could use anything here (like perhaps the PID or startup time
         digest.update(b'salt')
         digest.update('user {}'.format(self.request.user.username).encode('utf-8'))
-        digest.update('org {}'.format(most_recent_updated_organization.name).encode('utf-8'))
+        if most_recent_updated_organization:
+            digest.update('org {}'.format(
+                most_recent_updated_organization.name).encode('utf-8'))
         digest.update(most_recent_updated_credit_trade.update_timestamp
                       .isoformat()
                       .encode('utf-8')


### PR DESCRIPTION
Seems like there's a bug in the caching if no organization has been updated.

One of the digest requires an updated_timestamp from the organizations table. The problem is if no organization has ever been updated then it'll run into a hard error.