### PR TITLE
Added metatag to force IE to use latest rendering method

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- CSS  -->


### PR DESCRIPTION
IE (even IE11) seems to be rendering the site using IE7 mode. This is causing the site not to load anything. So we have to force it to use whatever latest version it has.
