### PR TITLE
Changed how the check goes and only run the checks when running servers

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -26,15 +26,17 @@ import sys
 from collections import namedtuple
 
 import pika
+from pika.exceptions import AMQPError
 from django.apps import AppConfig
 from django.db.models.signals import post_migrate
 from minio import Minio
 from minio.error import MinioError
-from pika.exceptions import AMQPError
 
 from api.services.KeycloakAPI import list_users, get_token
-from db_comments.db_actions import create_db_comments, create_db_comments_from_models
-from tfrs.settings import AMQP_CONNECTION_PARAMETERS, MINIO, DOCUMENTS_API, KEYCLOAK, EMAIL, TESTING
+from db_comments.db_actions import create_db_comments, \
+    create_db_comments_from_models
+from tfrs.settings import AMQP_CONNECTION_PARAMETERS, MINIO, DOCUMENTS_API, \
+    KEYCLOAK, EMAIL, TESTING, RUNSERVER
 
 
 class APIAppConfig(AppConfig):
@@ -48,12 +50,12 @@ class APIAppConfig(AppConfig):
         # register our interest in the post_migrate signal
         post_migrate.connect(post_migration_callback, sender=self)
 
-        if not TESTING:
+        if RUNSERVER:
             try:
                 check_external_services()
-            except RuntimeError as e:
+            except RuntimeError as error:
                 print('Startup checks failed. Not starting.')
-                print(e)
+                print(error)
                 exit(-1)  # Django doesn't seem to do this automatically.
 
 
@@ -67,7 +69,7 @@ def check_external_services():
         connection = pika.BlockingConnection(parameters)
         connection.channel()
         connection.close()
-    except AMQPError as e:
+    except AMQPError as _error:
         raise RuntimeError('AMQP connection failed')
 
     if DOCUMENTS_API['ENABLED']:
@@ -79,27 +81,27 @@ def check_external_services():
                           secret_key=MINIO['SECRET_KEY'],
                           secure=MINIO['USE_SSL'])
 
-            objects = minio.list_buckets()
-        except MinioError as e:
+            _objects = minio.list_buckets()
+        except MinioError as _error:
             raise RuntimeError('Minio connection failed')
 
     if KEYCLOAK['ENABLED']:
-        print ('Keycloak enabled. Checking connection')
+        print('Keycloak enabled. Checking connection')
 
         try:
             list_users(get_token())
-        except Exception as e:
+        except Exception as _error:
             raise RuntimeError('Keycloak connection failed')
 
     if EMAIL['ENABLED']:
-        print ('Email sending enabled. Checking connection')
+        print('Email sending enabled. Checking connection')
 
         try:
             with smtplib.SMTP(host=EMAIL['SMTP_SERVER_HOST'],
                               port=EMAIL['SMTP_SERVER_PORT']) as server:
                 server.noop()
-        except Exception as e:
-            print(e)
+        except Exception as error:
+            print(error)
             raise RuntimeError('SMTP Connection failed')
 
 
@@ -154,7 +156,9 @@ def post_migration_callback(sender, **kwargs):
 
 
 def get_all_model_classes():
-    """Get all the model classes in api.models. Easier than maintaining a list."""
+    """
+    Get all the model classes in api.models. Easier than maintaining a list.
+    """
 
     # Has to be a local import. Must be loaded late.
     import api.models
@@ -168,7 +172,7 @@ def get_all_model_classes():
             prefix='api.models.'
     ):
 
-        sub_module = ModuleInfo(module_finder,name,ispkg)
+        sub_module = ModuleInfo(module_finder, name, ispkg)
 
         if sub_module.name in sys.modules:
             # we're already loaded (probably as a dependency of another)

--- a/backend/tfrs/settings.py
+++ b/backend/tfrs/settings.py
@@ -36,13 +36,14 @@ SECRET_KEY = os.getenv(
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-#DEBUG = True
+# DEBUG = True
 DEBUG = os.getenv('DJANGO_DEBUG', 'True') == 'True'
 
 # SECURITY WARNING: never set this on in production
 BYPASS_AUTH = os.getenv('BYPASS_HEADER_AUTHENTICATION', False)
 
 TESTING = 'test' in sys.argv
+RUNSERVER = 'runserver' in sys.argv
 
 
 # ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
Instead of checking if we're running the test, we check if we're running the server.

The reason for this is for functions like migrate and collecstatic. 