### PR TITLE
Add Middleware to detect IE and add no-cache headers

### DIFF
--- a/backend/api/nocache.py
+++ b/backend/api/nocache.py
@@ -1,0 +1,31 @@
+import re
+
+from django.utils.cache import add_never_cache_headers
+
+
+class NoCacheMiddleware(object):
+    """Add No-cache headers to all responses if detect IE UA"""
+
+    IE_DETECTION_RE = [
+        re.compile('Trident/.*rv:(\d+\.\d*)'),
+        re.compile('MSIE')
+    ]
+
+    @staticmethod
+    def process_response(request, response):
+
+        if 'HTTP_USER_AGENT' not in request.META:
+            return response
+
+        user_agent = request.META['HTTP_USER_AGENT']
+        is_ie = False
+
+        for expr in NoCacheMiddleware.IE_DETECTION_RE:
+            if expr.search(user_agent):
+                is_ie = True
+                break
+
+        if is_ie:
+            add_never_cache_headers(response)
+
+        return response

--- a/backend/tfrs/settings.py
+++ b/backend/tfrs/settings.py
@@ -68,6 +68,7 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'api.nocache.NoCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
# Changelog
 - Possible workaround for IE caching 'features'

Trello card 1178