### PR TITLE
Per-User Socket.IO channels

### DIFF
--- a/backend/api/notifications/notifications.py
+++ b/backend/api/notifications/notifications.py
@@ -22,7 +22,7 @@ from tfrs.settings import AMQP_CONNECTION_PARAMETERS, EMAIL
 subscription_cache = caches['notification_subscriptions']
 
 
-def send_amqp_notification():
+def send_amqp_notification(user):
     try:
         parameters = AMQP_CONNECTION_PARAMETERS
         connection = pika.BlockingConnection(parameters)
@@ -36,7 +36,8 @@ def send_amqp_notification():
         channel.basic_publish(exchange='notifications',
                               routing_key='global',
                               body=json.dumps({
-                                  'message': 'notification'
+                                  'audience': user.username,
+                                  'type': 'notification'
                               }),
                               properties=pika.BasicProperties(
                                   content_type='application/json',
@@ -296,7 +297,7 @@ class AMQPNotificationService:
                     is_warning=is_warning
                 )
                 notification.save()
-                send_amqp_notification()
+                send_amqp_notification(recipient)
 
                 if email_subscription in effective_subscriptions:
                     AMQPNotificationService.send_email_for_notification(notification)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,7 @@ services:
             - KEYCLOAK_ISSUER=http://localhost:8888/auth/realms/tfrs
             - KEYCLOAK_CALLBACK_URL=http://localhost:5001/authCallback
             - KEYCLOAK_POST_LOGOUT_URL=http://localhost:5001/
+            - KEYCLOAK_CERTS_URL=http://keycloak:8080/auth/realms/tfrs/protocol/openid-connect/certs
         volumes:
             - ./frontend:/app
             - node_modules:/app/node_modules

--- a/frontend/notifications.js
+++ b/frontend/notifications.js
@@ -1,4 +1,6 @@
 const amqp = require('amqp');
+const jwt = require('jsonwebtoken');
+const jwksClient = require('jwks-rsa');
 
 const vhost = process.env.RABBITMQ_VHOST || '/';
 
@@ -6,6 +8,66 @@ const user = process.env.RABBITMQ_USER || 'guest';
 const password = process.env.RABBITMQ_PASSWORD || 'guest';
 const amqpHost = process.env.RABBITMQ_HOST || 'localhost';
 const amqpPort = process.env.RABBITMQ_PORT || 5672;
+const jwksURI = process.env.KEYCLOAK_CERTS_URL || null;
+
+let client = jwksClient({jwksUri:jwksURI});
+
+function getSigningKey(header, callback) {
+  client.getSigningKey(header.kid, function (err, key) {
+    if (err) {
+      callback({error: 'certificate download failed'}, null);
+      return;
+    }
+    const signingKey = key.publicKey || key.rsaPublicKey;
+    callback(null, signingKey);
+  });
+}
+
+const setup = (io) => {
+
+  if (!jwksURI) {
+    console.log('No KEYCLOAK_CERTS_URL in environment,' +
+      ' cannot validate tokens and will not serve socket.io clients');
+    return;
+  }
+
+
+  io.on('connect', (socket) => {
+    socket.join('global');
+    let authenticated = false;
+    let roomName;
+
+    socket.on('action', function (action) {
+
+        switch (action.type) {
+          case 'socketio/AUTHENTICATE':
+            jwt.verify(action.token, getSigningKey, {}, (err, decoded) => {
+              if (err) {
+                console.log(`error verifying token ${err}`);
+                authenticated = false;
+              } else {
+                roomName = `user_${decoded.user_id}`;
+                socket.join(roomName);
+                authenticated = true;
+              }
+            });
+            break;
+          case 'socketio/DEAUTHENTICATE':
+            authenticated = false;
+            if (authenticated) {
+              socket.leave(roomName)
+            }
+            break;
+          default:
+            console.log('unknown action received ' + action.type);
+        }
+      }
+    );
+
+  });
+
+  connect(io);
+};
 
 const connect = (io) => {
   const connection = amqp.createConnection({
@@ -35,15 +97,35 @@ const connect = (io) => {
 
       /* we got a notification -- tell the connected clients */
       q.subscribe((message) => {
-        io.in('global').emit('action', {
-          type: 'SERVER_INITIATED_NOTIFICATION_RELOAD',
-          message: 'notification'
-        });
+
+        //by default our audience is everyone
+        let room = 'global';
+
+        if (message.audience && message.audience !== 'global') {
+          //this message is for someone in particular
+          room = `user_${message.audience}`;
+        }
+
+        if (!message.type) {
+          console.log('this message does not contain a type!');
+          return;
+        }
+
+        switch(message.type) {
+          case 'notification':
+            io.in(room).emit('action', {
+              type: 'SERVER_INITIATED_NOTIFICATION_RELOAD',
+              message: 'notification'
+            });
+            break;
+          default:
+            console.log(`unknown message type ${message.type}`);
+        }
       });
     });
   });
 };
 
 module.exports = {
-  connect
+  setup
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,8 @@
     "history": "^4.6.1",
     "http-proxy": "^1.17.0",
     "isomorphic-fetch": "^2.2.1",
+    "jsonwebtoken": "^8.5.0",
+    "jwks-rsa": "^1.4.0",
     "moment": "^2.23.0",
     "numeral": "^2.0.6",
     "oidc-client": "^1.6.1",

--- a/frontend/server-docker.js
+++ b/frontend/server-docker.js
@@ -7,6 +7,7 @@ const notifications = require('./notifications');
 
 const http = require('http');
 
+
 const devServerOptions = {
   contentBase: path.join(__dirname, 'public'),
   publicPath: '/build/',
@@ -39,12 +40,8 @@ const io = require('socket.io')(httpServer);
 
 httpServer.listen(4000);
 
-io.on('connect', (socket) => {
-  socket.join('global');
-  socket.emit('action', { type: 'SERVER_INITIATED_NOTIFICATION_RELOAD', message: 'connected' });
-});
+notifications.setup(io);
 
-notifications.connect(io);
 
 server.listen(3000, '0.0.0.0', () => {
   console.log('Starting server');

--- a/frontend/server-notifications.js
+++ b/frontend/server-notifications.js
@@ -10,9 +10,4 @@ const io = require('socket.io')(httpServer);
 
 httpServer.listen(3000);
 
-io.on('connect', (socket) => {
-  socket.join('global');
-  socket.emit('action', { type: 'SERVER_INITIATED_NOTIFICATION_RELOAD', message: 'connected' });
-});
-
-notifications.connect(io);
+notifications.setup(io);

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -30,16 +30,11 @@ if (!isProduction) {
   app.use(fallback('index.html', { root: publicPath }));
 }
 
-io.on('connect', (socket) => {
-  socket.join('global');
-  socket.emit('action', { type: 'SERVER_INITIATED_NOTIFICATION_RELOAD', message: 'connected' });
-});
-
 proxy.on('error', (e) => {
   console.log('Could not connect to proxy please try again');
 });
 
-notifications.connect(io);
+notifications.setup(io);
 
 server.listen(port, () => {
   console.log(`server running on Port ${port}`);

--- a/frontend/src/store/socketAuthentication.js
+++ b/frontend/src/store/socketAuthentication.js
@@ -1,0 +1,32 @@
+import {put, takeLatest, all} from 'redux-saga/effects';
+import userManager from './oidc-usermanager';
+
+function socketAuthenticate(dispatch) {
+
+  userManager.getUser().then(user => {
+
+    if (!user || !user.id_token)
+      return;
+
+    dispatch(
+      {
+        type: "socketio/AUTHENTICATE",
+        token: user.id_token
+      }
+    );
+  });
+}
+
+
+function* socketDeauthenticate() {3
+  yield put({
+    type: "socketio/DEAUTHENTICATE",
+  });
+}
+
+export default function* socketAuthenticationSaga(store) {
+  yield all([
+    takeLatest('redux-oidc/USER_FOUND', socketAuthenticate, store.dispatch),
+    takeLatest('redux-oidc/USER_EXPIRED', socketDeauthenticate)
+  ]);
+}

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -18,6 +18,7 @@ import CONFIG from '../config';
 import sessionTimeoutSaga from './sessionTimeout';
 import authenticationStateSaga from './authenticationState';
 import notificationsSaga from './notificationTrigger';
+import socketAuthenticationSaga from "./socketAuthentication";
 
 const middleware = routerMiddleware(history);
 const sagaMiddleware = createSagaMiddleware();
@@ -58,5 +59,6 @@ const store = createStore(
 sagaMiddleware.run(sessionTimeoutSaga);
 sagaMiddleware.run(notificationsSaga, store);
 sagaMiddleware.run(authenticationStateSaga, store);
+sagaMiddleware.run(socketAuthenticationSaga, store);
 
 export default store;

--- a/frontend/webpack.production.config.js
+++ b/frontend/webpack.production.config.js
@@ -35,8 +35,7 @@ const config = {
         loader: 'babel-loader',
         exclude: [nodeModulesPath],
         query: {
-          presets: ['react', 'env'],
-          plugins: ['transform-object-rest-spread']
+          presets: ['react', 'env']
         }
       },
       {

--- a/frontend/webpack.production.config.js
+++ b/frontend/webpack.production.config.js
@@ -35,7 +35,8 @@ const config = {
         loader: 'babel-loader',
         exclude: [nodeModulesPath],
         query: {
-          presets: ['react', 'env']
+          presets: ['react', 'env'],
+          plugins: ['transform-object-rest-spread']
         }
       },
       {


### PR DESCRIPTION
# Changelog
 - This card addresses a long-standing technical debt issue. Previously, there was a single global socket.io channel and when notifications were triggered, a reload notice would distributed to all connected users.
 - This PR introduces authentication to the socket.io channel, including full JWT verification
 - notifications are now sent to specific user channels
 - Now that this channel is secure, it could easily be extended to include things like, for example, clamav scan results in realtime
 - The docker environment is suitably updated.
 - ***IMPORTANT*** the `notifications-server` pod will need `KEYCLOAK_CERTS_URL` environment defined (to match Django)


 