### PR TITLE
Government reviewers can still add comments on received submissions

### DIFF
--- a/backend/api/permissions/DocumentComment.py
+++ b/backend/api/permissions/DocumentComment.py
@@ -34,16 +34,17 @@ class DocumentCommentPermissions(permissions.BasePermission):
         """
         Check whether the user should have authority to add a comment.
         Government Users with abilities to review the documents should
-        always have authority to add a comment.
+        always have authority to add a comment, unless it's archived.
         Fuel Suppliers with abilities to add or submit can add a comment
         if the document is either in draft or submitted status.
         """
         if user.is_government_user and \
-                user.has_perm('DOCUMENTS_GOVERNMENT_REVIEW'):
+                user.has_perm('DOCUMENTS_GOVERNMENT_REVIEW') and \
+                document.status.status in ['Received', 'Submitted']:
             return True
 
         if not user.is_government_user and not privileged and \
-                document.status.status != 'Received':
+                document.status.status in ['Draft', 'Submitted']:
             return True
 
         return False

--- a/backend/api/serializers/Document.py
+++ b/backend/api/serializers/Document.py
@@ -455,9 +455,17 @@ class DocumentUpdateSerializer(serializers.ModelSerializer):
             })
 
         if not DocumentService.validate_status(document.status, status):
+            if status.status == 'Draft':
+                raise serializers.ValidationError({
+                    'invalidStatus': "Error! The submission cannot be "
+                                     "rescinded because it has been marked "
+                                     "as received by a Government user."
+                                     "Please refresh your browser."
+                })
+
             raise serializers.ValidationError({
-                'invalidStatus': "Submission cannot be {} as it currently "
-                                 "has a status of {}.".format(
+                'invalidStatus': "Submission cannot be set to {} as it "
+                                 "currently has a status of {}.".format(
                                      status.status,
                                      document.status.status
                                  )

--- a/backend/api/serializers/Document.py
+++ b/backend/api/serializers/Document.py
@@ -457,9 +457,9 @@ class DocumentUpdateSerializer(serializers.ModelSerializer):
         if not DocumentService.validate_status(document.status, status):
             if status.status == 'Draft':
                 raise serializers.ValidationError({
-                    'invalidStatus': "Error! The submission cannot be "
-                                     "rescinded because it has been marked "
-                                     "as received by a Government user."
+                    'invalidStatus': "The submission cannot be rescinded "
+                                     "because it has been marked as received "
+                                     "by a Government user."
                                      "Please refresh your browser."
                 })
 

--- a/backend/api/tests/test_document_comments.py
+++ b/backend/api/tests/test_document_comments.py
@@ -164,4 +164,4 @@ class TestDocumentComments(BaseTestCase):
             data=json.dumps(payload)
         )
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/frontend/src/secure_file_submission/SecureFileSubmissionUtilityFunctions.js
+++ b/frontend/src/secure_file_submission/SecureFileSubmissionUtilityFunctions.js
@@ -1,5 +1,4 @@
 export default class SecureFileSubmissionUtilityFunctions {
-
   static canLinkCreditTransfer (loggedInUser, item) {
     if (!item.linkActions) {
       return false;
@@ -7,7 +6,6 @@ export default class SecureFileSubmissionUtilityFunctions {
 
     return item.linkActions.includes('ADD_LINK');
   }
-
 
   static canComment (loggedInUser, item) {
     if (!item.commentActions) {

--- a/frontend/src/secure_file_submission/components/SecureFileSubmissionDetails.js
+++ b/frontend/src/secure_file_submission/components/SecureFileSubmissionDetails.js
@@ -239,7 +239,6 @@ const SecureFileSubmissionDetails = props => (
         <SecureFileSubmissionComment comment={c} key={c.id} saveComment={props.saveComment}/>
       ))
       }
-      {!['Archived', 'Received'].includes(props.item.status.status) &&
       <div className="row">
         <div className="col-md-12">
           <SecureFileSubmissionCommentButtons
@@ -257,7 +256,6 @@ const SecureFileSubmissionDetails = props => (
           }
         </div>
       </div>
-      }
     </div>
 
     <div className="btn-container">


### PR DESCRIPTION
#952 #953 

Updated the flow so Government reviewers can still add comments on received submissions.
Also, updated the error message when trying to rescind a submission that's been received.

Changelog:
- Changed so that we check with the backend, instead of the front-end on whether to show the comment buttons
- Updated the check in the permission so that it checks whether the status is in the allowed statuses, instead of checking whether the status is forbidden
- During validation, we no longer check for the status directly. Instead, we check if the user is authorized to make that change (which checks the status internally)