### PR TITLE
Fix milestone evidence missing and Link Credit Transactions

### DIFF
--- a/frontend/src/actions/documentUploads.js
+++ b/frontend/src/actions/documentUploads.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import CreditTransferActionTypes from '../constants/actionTypes/CreditTransfers';
+import CreditTransferReducerTypes from '../constants/reducerTypes/CreditTransfers';
 import ActionTypes from '../constants/actionTypes/DocumentUploads';
 import ReducerTypes from '../constants/reducerTypes/DocumentUploads';
 import * as Routes from '../constants/routes';
@@ -341,7 +343,6 @@ const unlinkDocument = (id, data) => (dispatch) => {
     });
 };
 
-
 const removeDocumentLinkRequest = () => ({
   name: ReducerTypes.REMOVE_DOCUMENT_LINK,
   type: ActionTypes.REMOVE_DOCUMENT_LINK
@@ -359,6 +360,40 @@ const removeDocumentLinkError = error => ({
   errorMessage: error
 });
 
+/*
+ * Get Linkable Credit Transactions
+ */
+const getLinkableCreditTransactions = id => (dispatch) => {
+  dispatch(getCreditTransfersRequest());
+
+  return axios
+    .get(`${Routes.BASE_URL}${Routes.SECURE_DOCUMENT_UPLOAD.API}/${id}/linkable_credit_transactions`)
+    .then((response) => {
+      dispatch(getCreditTransfersSuccess(response.data));
+      return Promise.resolve(response);
+    }).catch((error) => {
+      dispatch(getCreditTransfersError(error.response));
+      return Promise.reject(error);
+    });
+};
+
+const getCreditTransfersRequest = () => ({
+  name: CreditTransferReducerTypes.GET_CREDIT_TRANSFERS_REQUEST,
+  type: CreditTransferActionTypes.GET_CREDIT_TRANSFERS
+});
+
+const getCreditTransfersSuccess = creditTransfers => ({
+  name: CreditTransferReducerTypes.RECEIVE_CREDIT_TRANSFERS_REQUEST,
+  type: CreditTransferActionTypes.RECEIVE_CREDIT_TRANSFERS,
+  data: creditTransfers,
+  receivedAt: Date.now()
+});
+
+const getCreditTransfersError = error => ({
+  name: CreditTransferReducerTypes.ERROR_CREDIT_TRANSFERS_REQUEST,
+  type: CreditTransferActionTypes.ERROR,
+  errorMessage: error
+});
 
 export {
   addCommentToDocument,
@@ -368,6 +403,7 @@ export {
   getDocumentUpload,
   getDocumentUploads,
   getDocumentUploadURL,
+  getLinkableCreditTransactions,
   updateCommentOnDocument,
   uploadDocument,
   updateDocumentUpload,

--- a/frontend/src/app/components/Modal.js
+++ b/frontend/src/app/components/Modal.js
@@ -57,6 +57,7 @@ const Modal = props => (
           >
             {props.cancelLabel}
           </button>
+          {props.showConfirmButton &&
           <button
             id="modal-yes"
             type="button"
@@ -67,6 +68,7 @@ const Modal = props => (
           >
             {props.confirmLabel}
           </button>
+          }
         </div>
       </div>
     </div>
@@ -77,6 +79,7 @@ Modal.defaultProps = {
   cancelLabel: Lang.BTN_NO,
   confirmLabel: Lang.BTN_YES,
   handleSubmit: null,
+  showConfirmButton: true,
   showExtraConfirm: false,
   canBypassExtraConfirm: true,
   extraConfirmType: 'info',
@@ -86,19 +89,20 @@ Modal.defaultProps = {
 
 Modal.propTypes = {
   cancelLabel: PropTypes.string,
+  canBypassExtraConfirm: PropTypes.bool,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]).isRequired,
   confirmLabel: PropTypes.string,
-  showExtraConfirm: PropTypes.bool,
   extraConfirmText: PropTypes.string,
   extraConfirmType: PropTypes.oneOf([
     'info', 'warning', 'error'
   ]),
-  canBypassExtraConfirm: PropTypes.bool,
   handleSubmit: PropTypes.func,
   id: PropTypes.string.isRequired,
+  showConfirmButton: PropTypes.bool,
+  showExtraConfirm: PropTypes.bool,
   title: PropTypes.string
 };
 

--- a/frontend/src/secure_file_submission/SecureFileSubmissionDetailContainer.js
+++ b/frontend/src/secure_file_submission/SecureFileSubmissionDetailContainer.js
@@ -17,6 +17,7 @@ import Modal from '../app/components/Modal';
 import history from '../app/History';
 import SecureFileSubmissionDetails from './components/SecureFileSubmissionDetails';
 import SECURE_DOCUMENT_UPLOAD from '../constants/routes/SecureDocumentUpload';
+import * as Lang from '../constants/langEnUs';
 import toastr from '../utils/toastr';
 import LinkedCreditTransferSelection from './components/LinkedCreditTransferSelection';
 import { getCreditTransfers } from '../actions/creditTransfersActions';
@@ -297,9 +298,22 @@ class SecureFileSubmissionDetailContainer extends Component {
         >
           Are you sure you want to securely submit these files to the
           Government of British Columbia?
+        </Modal>,
+        <Modal
+          cancelLabel={Lang.BTN_CANCEL_LINK_CREDIT_TRANSACTION}
+          id="linkCreditTransfer"
+          key="linkCreditTransfer"
+          showConfirmButton={false}
+          title="Link Credit Transaction"
+        >
+          <LinkedCreditTransferSelection
+            creditTransfers={this.props.creditTransfers.items}
+            establishLink={this._establishLink}
+          />
         </Modal>
       ]);
     }
+
     return <Loading />;
   }
 
@@ -312,13 +326,6 @@ class SecureFileSubmissionDetailContainer extends Component {
       if (this.props.creditTransfers.isFetching) {
         return <Loading />;
       }
-
-      return (
-        <LinkedCreditTransferSelection
-          creditTransfers={this.props.creditTransfers.items}
-          cancelLink={this._cancelLink}
-          establishLink={this._establishLink}
-        />);
     }
 
     return this.renderStatic();

--- a/frontend/src/secure_file_submission/SecureFileSubmissionDetailContainer.js
+++ b/frontend/src/secure_file_submission/SecureFileSubmissionDetailContainer.js
@@ -11,7 +11,8 @@ import SecureFileSubmissionUtilityFunctions from './SecureFileSubmissionUtilityF
 
 import {
   addCommentToDocument, deleteDocumentUpload, getDocumentUpload,
-  linkDocument, partialUpdateDocument, unlinkDocument, updateCommentOnDocument
+  linkDocument, partialUpdateDocument, unlinkDocument, updateCommentOnDocument,
+  getLinkableCreditTransactions
 } from '../actions/documentUploads';
 import Modal from '../app/components/Modal';
 import history from '../app/History';
@@ -20,7 +21,6 @@ import SECURE_DOCUMENT_UPLOAD from '../constants/routes/SecureDocumentUpload';
 import * as Lang from '../constants/langEnUs';
 import toastr from '../utils/toastr';
 import LinkedCreditTransferSelection from './components/LinkedCreditTransferSelection';
-import { getCreditTransfers } from '../actions/creditTransfersActions';
 
 class SecureFileSubmissionDetailContainer extends Component {
   constructor (props) {
@@ -33,18 +33,18 @@ class SecureFileSubmissionDetailContainer extends Component {
       hasCommented: false,
       isCommenting: false,
       isCreatingPrivilegedComment: false,
-      isLinking: false
+      selectedLinkId: null
     };
 
     this._addComment = this._addComment.bind(this);
+    this._addLink = this._addLink.bind(this);
     this._cancelComment = this._cancelComment.bind(this);
+    this._establishLink = this._establishLink.bind(this);
     this._getDocumentStatus = this._getDocumentStatus.bind(this);
     this._handleRecordNumberChange = this._handleRecordNumberChange.bind(this);
     this._handleSubmit = this._handleSubmit.bind(this);
     this._saveComment = this._saveComment.bind(this);
-    this._addLink = this._addLink.bind(this);
-    this._cancelLink = this._cancelLink.bind(this);
-    this._establishLink = this._establishLink.bind(this);
+    this._selectLinkIdForModal = this._selectLinkIdForModal.bind(this);
     this._unLink = this._unLink.bind(this);
   }
 
@@ -63,6 +63,10 @@ class SecureFileSubmissionDetailContainer extends Component {
     });
   }
 
+  _addLink () {
+    this.props.fetchCreditTransfers(this.props.match.params.id);
+  }
+
   _cancelComment () {
     this.setState({
       isCommenting: false,
@@ -70,32 +74,21 @@ class SecureFileSubmissionDetailContainer extends Component {
     });
   }
 
-  _cancelLink () {
-    this.setState({
-      isLinking: false
-    });
-  }
-
-  _addLink () {
-    this.props.fetchCreditTransfers();
-
-    this.setState({
-      isLinking: true
+  _deleteCreditTransferRequest (id) {
+    this.props.deleteDocumentUpload(id).then(() => {
+      history.push(SECURE_DOCUMENT_UPLOAD.LIST);
+      toastr.documentUpload(null, 'Draft deleted.');
     });
   }
 
   _establishLink (id) {
-    const docid = this.props.documentUpload.item.id;
-
-    this.setState({
-      isLinking: false
-    });
+    const docId = this.props.documentUpload.item.id;
 
     const data = {
       creditTrade: id
     };
 
-    this.props.linkDocument(docid, data).then((response) => {
+    this.props.linkDocument(docId, data).then((response) => {
       this.props.getDocumentUpload(this.props.documentUpload.item.id);
     });
   }
@@ -112,25 +105,6 @@ class SecureFileSubmissionDetailContainer extends Component {
     });
 
     return validationMessage;
-  }
-
-  _unLink (id) {
-    const docid = this.props.documentUpload.item.id;
-
-    const data = {
-      creditTrade: id
-    };
-
-    this.props.unlinkDocument(docid, data).then((response) => {
-      this.props.getDocumentUpload(this.props.documentUpload.item.id);
-    });
-  }
-
-  _deleteCreditTransferRequest (id) {
-    this.props.deleteDocumentUpload(id).then(() => {
-      history.push(SECURE_DOCUMENT_UPLOAD.LIST);
-      toastr.documentUpload(null, 'Draft deleted.');
-    });
   }
 
   _getDocumentStatus (status) {
@@ -212,6 +186,24 @@ class SecureFileSubmissionDetailContainer extends Component {
     }
   }
 
+  _selectLinkIdForModal (id) {
+    this.setState({
+      selectedLinkId: id
+    });
+  }
+
+  _unLink (id) {
+    const docId = this.props.documentUpload.item.id;
+
+    const data = {
+      creditTrade: id
+    };
+
+    this.props.unlinkDocument(docId, data).then((response) => {
+      this.props.getDocumentUpload(this.props.documentUpload.item.id);
+    });
+  }
+
   renderStatic () {
     const {
       errors, item, isFetching, success
@@ -227,9 +219,8 @@ class SecureFileSubmissionDetailContainer extends Component {
         <SecureFileSubmissionDetails
           addComment={this._addComment}
           availableActions={availableActions}
-          cancelComment={this._cancelComment}
           addLink={this._addLink}
-          unLink={this._unLink}
+          cancelComment={this._cancelComment}
           canComment={SecureFileSubmissionUtilityFunctions
             .canComment(this.props.loggedInUser, this.props.documentUpload.item)}
           canCreatePrivilegedComment={
@@ -254,6 +245,7 @@ class SecureFileSubmissionDetailContainer extends Component {
           item={item}
           key="details"
           saveComment={this._saveComment}
+          selectLinkIdForModal={this._selectLinkIdForModal}
         />,
         <Modal
           handleSubmit={(event) => {
@@ -300,16 +292,26 @@ class SecureFileSubmissionDetailContainer extends Component {
           Government of British Columbia?
         </Modal>,
         <Modal
-          cancelLabel={Lang.BTN_CANCEL_LINK_CREDIT_TRANSACTION}
-          id="linkCreditTransfer"
-          key="linkCreditTransfer"
-          showConfirmButton={false}
-          title="Link Credit Transaction"
+          handleSubmit={() => this._unLink(this.state.selectedLinkId)}
+          id="confirmUnlink"
+          key="confirmUnlink"
         >
+          Are you sure you want to delete this link with the credit transaction?
+        </Modal>,
+        <Modal
+          cancelLabel={Lang.BTN_CANCEL_LINK_CREDIT_TRANSACTION}
+          id="modalCreditTransfer"
+          key="modalCreditTransfer"
+          showConfirmButton={false}
+          title={Lang.BTN_LINK_CREDIT_TRANSACTION}
+        >
+          {this.props.creditTransfers.isFetching && <Loading />}
+          {!this.props.creditTransfers.isFetching &&
           <LinkedCreditTransferSelection
             creditTransfers={this.props.creditTransfers.items}
             establishLink={this._establishLink}
           />
+          }
         </Modal>
       ]);
     }
@@ -320,12 +322,6 @@ class SecureFileSubmissionDetailContainer extends Component {
   render () {
     if (this.props.isFetching) {
       return <Loading />;
-    }
-
-    if (this.state.isLinking) {
-      if (this.props.creditTransfers.isFetching) {
-        return <Loading />;
-      }
     }
 
     return this.renderStatic();
@@ -406,7 +402,7 @@ const mapDispatchToProps = dispatch => ({
   getDocumentUpload: bindActionCreators(getDocumentUpload, dispatch),
   partialUpdateDocument: bindActionCreators(partialUpdateDocument, dispatch),
   updateCommentOnDocument: bindActionCreators(updateCommentOnDocument, dispatch),
-  fetchCreditTransfers: bindActionCreators(getCreditTransfers, dispatch),
+  fetchCreditTransfers: bindActionCreators(getLinkableCreditTransactions, dispatch),
   linkDocument: bindActionCreators(linkDocument, dispatch),
   unlinkDocument: bindActionCreators(unlinkDocument, dispatch)
 });

--- a/frontend/src/secure_file_submission/components/LinkedCreditTransactions.js
+++ b/frontend/src/secure_file_submission/components/LinkedCreditTransactions.js
@@ -1,0 +1,53 @@
+/*
+ * Presentational component
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { Link } from 'react-router-dom';
+
+import CREDIT_TRANSACTIONS from '../../constants/routes/CreditTransactions';
+
+const LinkedCreditTransactions = props => (
+  <div className="linked-credit-transactions">
+    <div className="row">
+      <div className="col-xs-2 header">ID</div>
+      <div className="col-xs-4 header">Type</div>
+      <div className="col-xs-4 status header">Status</div>
+      <div className="col-xs-2 unlink header">Unlink</div>
+    </div>
+    {props.creditTrades.map(creditTrade => (
+      <div className="row" key={creditTrade.id}>
+        <div className="col-xs-2">
+          <Link to={CREDIT_TRANSACTIONS.DETAILS.replace(':id', creditTrade.id)}>
+            {creditTrade.id}
+          </Link>
+        </div>
+        <div className="col-xs-4">{creditTrade.type.theType}</div>
+        <div className="col-xs-4 status">{creditTrade.status.status}</div>
+        <div className="col-xs-2 unlink">
+          <button
+            className="unlink-action text-danger"
+            data-target="#confirmUnlink"
+            data-toggle="modal"
+            onClick={() => props.selectLinkIdForModal(creditTrade.id)}
+            type="button"
+          >
+            <FontAwesomeIcon icon="unlink" />
+          </button>
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+LinkedCreditTransactions.propTypes = {
+  creditTrades: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    status: PropTypes.shape(),
+    type: PropTypes.shape()
+  })).isRequired,
+  selectLinkIdForModal: PropTypes.func.isRequired
+};
+
+export default LinkedCreditTransactions;

--- a/frontend/src/secure_file_submission/components/LinkedCreditTransferSelection.js
+++ b/frontend/src/secure_file_submission/components/LinkedCreditTransferSelection.js
@@ -16,13 +16,13 @@ const LinkedCreditTransferSelection = (props) => {
     className: 'col-id',
     Header: 'ID',
     resizable: false,
-    width: 45
+    width: 50
   }, {
     accessor: item => (item.compliancePeriod ? item.compliancePeriod.description : ''),
     className: 'col-compliance-period',
     Header: 'Compliance Period',
     id: 'compliancePeriod',
-    minWidth: 45
+    minWidth: 90
   }, {
     accessor: item => getCreditTransferType(item.type.id),
     className: 'col-transfer-type',
@@ -45,7 +45,7 @@ const LinkedCreditTransferSelection = (props) => {
     },
     Header: 'Credits From',
     id: 'creditsFrom',
-    minWidth: 190
+    minWidth: 200
   }, {
     accessor: item => ((item.type.id === CREDIT_TRANSFER_TYPES.retirement.id) ? '' : item.creditsTo.name),
     Cell: (row) => {
@@ -59,7 +59,7 @@ const LinkedCreditTransferSelection = (props) => {
     },
     Header: 'Credits To',
     id: 'creditsTo',
-    minWidth: 190
+    minWidth: 200
   }, {
     accessor: item => item.numberOfCredits,
     className: 'col-credits',
@@ -67,7 +67,7 @@ const LinkedCreditTransferSelection = (props) => {
     filterMethod: (filter, row) => filterNumber(filter.value, row.numberOfCredits, 0),
     Header: 'Quantity of Credits',
     id: 'numberOfCredits',
-    minWidth: 75
+    minWidth: 100
   }, {
     accessor: (item) => {
       if (item.type.id === CREDIT_TRANSFER_TYPES.part3Award.id ||
@@ -85,7 +85,7 @@ const LinkedCreditTransferSelection = (props) => {
     filterMethod: (filter, row) => filterNumber(filter.value, row.fairMarketValuePerCredit),
     Header: 'Value Per Credit',
     id: 'fairMarketValuePerCredit',
-    minWidth: 65
+    minWidth: 100
   }, {
     accessor: item => (item.isRescinded
       ? CREDIT_TRANSFER_STATUS.rescinded.description
@@ -100,14 +100,13 @@ const LinkedCreditTransferSelection = (props) => {
     accessor: item => (item.updateTimestamp ? moment(item.updateTimestamp).format('YYYY-MM-DD') : '-'),
     className: 'col-date',
     Header: 'Last Updated On',
-    id: 'updateTimestamp',
-    minWidth: 95
+    id: 'updateTimestamp'
   }, {
     accessor: 'id',
     Cell: row => (
       <button
-        id="credit-transfer-link"
-        className="btn btn-primary"
+        className="credit-transfer-link"
+        data-dismiss="modal"
         onClick={() => props.establishLink(row.value)}
         type="button"
       >
@@ -118,7 +117,7 @@ const LinkedCreditTransferSelection = (props) => {
     filterable: false,
     Header: 'Link',
     id: 'actions',
-    minWidth: 100
+    minWidth: 50
   }];
 
   const filterMethod = (filter, row, column) => {
@@ -141,6 +140,7 @@ const LinkedCreditTransferSelection = (props) => {
         id: 'id',
         desc: true
       }]}
+      id="link-credit-transfer-table"
       filterable={filterable}
       pageSizeOptions={[5, 10, 15, 20, 25, 50, 100]}
     />

--- a/frontend/src/secure_file_submission/components/LinkedCreditTransferSelection.js
+++ b/frontend/src/secure_file_submission/components/LinkedCreditTransferSelection.js
@@ -1,16 +1,14 @@
-import React, {Component} from 'react';
+import React from 'react';
+import ReactTable from 'react-table';
+import moment from 'moment';
+import numeral from 'numeral';
 import PropTypes from 'prop-types';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import * as Lang from '../../constants/langEnUs';
-import SecureFileSubmissionCommentForm from './SecureFileSubmissionCommentForm';
-import ReactTable from "react-table";
-import moment from "moment";
-import {Link} from "react-router-dom";
-import {CREDIT_TRANSFER_STATUS, CREDIT_TRANSFER_TYPES} from "../../constants/values";
-import {getCreditTransferType} from "../../actions/creditTransfersActions";
-import numeral from "numeral";
-import * as NumberFormat from "../../constants/numeralFormats";
-import filterNumber from "../../utils/filters";
+
+import { CREDIT_TRANSFER_STATUS, CREDIT_TRANSFER_TYPES } from '../../constants/values';
+import { getCreditTransferType } from '../../actions/creditTransfersActions';
+import * as NumberFormat from '../../constants/numeralFormats';
+import filterNumber from '../../utils/filters';
 
 const LinkedCreditTransferSelection = (props) => {
   const columns = [{
@@ -19,113 +17,109 @@ const LinkedCreditTransferSelection = (props) => {
     Header: 'ID',
     resizable: false,
     width: 45
-  },
-    {
-      accessor: item => (item.compliancePeriod ? item.compliancePeriod.description : ''),
-      className: 'col-compliance-period',
-      Header: 'Compliance Period',
-      id: 'compliancePeriod',
-      minWidth: 45
-    }, {
-      accessor: item => getCreditTransferType(item.type.id),
-      className: 'col-transfer-type',
-      Header: 'Type',
-      id: 'transactionType',
-      minWidth: 110
-    }, {
-      accessor: item => ([
-        CREDIT_TRANSFER_TYPES.part3Award.id, CREDIT_TRANSFER_TYPES.validation.id
-      ].includes(item.type.id) ? '' : item.creditsFrom.name),
-      Cell: (row) => {
-        if (row.original.type.id === CREDIT_TRANSFER_TYPES.part3Award.id ||
-          row.original.type.id === CREDIT_TRANSFER_TYPES.validation.id) {
-          return (
-            <div className="greyed-out">N/A</div>
-          );
-        }
-
-        return row.value;
-      },
-      Header: 'Credits From',
-      id: 'creditsFrom',
-      minWidth: 190
-    }, {
-      accessor: item => ((item.type.id === CREDIT_TRANSFER_TYPES.retirement.id) ? '' : item.creditsTo.name),
-      Cell: (row) => {
-        if (row.original.type.id === CREDIT_TRANSFER_TYPES.retirement.id) {
-          return (
-            <div className="greyed-out">N/A</div>
-          );
-        }
-
-        return row.value;
-      },
-      Header: 'Credits To',
-      id: 'creditsTo',
-      minWidth: 190
-    }, {
-      accessor: item => item.numberOfCredits,
-      className: 'col-credits',
-      Cell: row => numeral(row.value).format(NumberFormat.INT),
-      filterMethod: (filter, row) => filterNumber(filter.value, row.numberOfCredits, 0),
-      Header: 'Quantity of Credits',
-      id: 'numberOfCredits',
-      minWidth: 75
-    }, {
-      accessor: (item) => {
-        if (item.type.id === CREDIT_TRANSFER_TYPES.part3Award.id ||
-          item.type.id === CREDIT_TRANSFER_TYPES.retirement.id ||
-          item.type.id === CREDIT_TRANSFER_TYPES.validation.id) {
-          return -1; // this is to fix sorting (value can't be negative)
-        }
-
-        return parseFloat(item.fairMarketValuePerCredit);
-      },
-      Cell: row => (
-        (row.value === -1) ? '-' : numeral(row.value).format(NumberFormat.CURRENCY)
-      ),
-      className: 'col-price',
-      filterMethod: (filter, row) => filterNumber(filter.value, row.fairMarketValuePerCredit),
-      Header: 'Value Per Credit',
-      id: 'fairMarketValuePerCredit',
-      minWidth: 65
-    },
-    {
-      accessor: item => (item.isRescinded
-        ? CREDIT_TRANSFER_STATUS.rescinded.description
-        : (
-          Object.values(CREDIT_TRANSFER_STATUS).find(element => element.id === item.status.id)
-        ).description),
-      className: 'col-status',
-      Header: 'Status',
-      id: 'status',
-      minWidth: 80
-    }, {
-      accessor: item => (item.updateTimestamp ? moment(item.updateTimestamp).format('YYYY-MM-DD') : '-'),
-      className: 'col-date',
-      Header: 'Last Updated On',
-      id: 'updateTimestamp',
-      minWidth: 95
-    },
-    {
-      accessor: 'id',
-      Cell: (row) => {
+  }, {
+    accessor: item => (item.compliancePeriod ? item.compliancePeriod.description : ''),
+    className: 'col-compliance-period',
+    Header: 'Compliance Period',
+    id: 'compliancePeriod',
+    minWidth: 45
+  }, {
+    accessor: item => getCreditTransferType(item.type.id),
+    className: 'col-transfer-type',
+    Header: 'Type',
+    id: 'transactionType',
+    minWidth: 110
+  }, {
+    accessor: item => ([
+      CREDIT_TRANSFER_TYPES.part3Award.id, CREDIT_TRANSFER_TYPES.validation.id
+    ].includes(item.type.id) ? '' : item.creditsFrom.name),
+    Cell: (row) => {
+      if (row.original.type.id === CREDIT_TRANSFER_TYPES.part3Award.id ||
+        row.original.type.id === CREDIT_TRANSFER_TYPES.validation.id) {
         return (
-       <button
-          id="credit-transfer-link"
-          className="btn btn-primary"
-          onClick={() => props.establishLink(row.value)}
-          type="button"
-        >
-         <FontAwesomeIcon icon="link"/>
-        </button>);
-      },
-      className: 'col-actions',
-      filterable: false,
-      Header: 'Link',
-      id: 'actions',
-      minWidth: 100
-    }];
+          <div className="greyed-out">N/A</div>
+        );
+      }
+
+      return row.value;
+    },
+    Header: 'Credits From',
+    id: 'creditsFrom',
+    minWidth: 190
+  }, {
+    accessor: item => ((item.type.id === CREDIT_TRANSFER_TYPES.retirement.id) ? '' : item.creditsTo.name),
+    Cell: (row) => {
+      if (row.original.type.id === CREDIT_TRANSFER_TYPES.retirement.id) {
+        return (
+          <div className="greyed-out">N/A</div>
+        );
+      }
+
+      return row.value;
+    },
+    Header: 'Credits To',
+    id: 'creditsTo',
+    minWidth: 190
+  }, {
+    accessor: item => item.numberOfCredits,
+    className: 'col-credits',
+    Cell: row => numeral(row.value).format(NumberFormat.INT),
+    filterMethod: (filter, row) => filterNumber(filter.value, row.numberOfCredits, 0),
+    Header: 'Quantity of Credits',
+    id: 'numberOfCredits',
+    minWidth: 75
+  }, {
+    accessor: (item) => {
+      if (item.type.id === CREDIT_TRANSFER_TYPES.part3Award.id ||
+        item.type.id === CREDIT_TRANSFER_TYPES.retirement.id ||
+        item.type.id === CREDIT_TRANSFER_TYPES.validation.id) {
+        return -1; // this is to fix sorting (value can't be negative)
+      }
+
+      return parseFloat(item.fairMarketValuePerCredit);
+    },
+    Cell: row => (
+      (row.value === -1) ? '-' : numeral(row.value).format(NumberFormat.CURRENCY)
+    ),
+    className: 'col-price',
+    filterMethod: (filter, row) => filterNumber(filter.value, row.fairMarketValuePerCredit),
+    Header: 'Value Per Credit',
+    id: 'fairMarketValuePerCredit',
+    minWidth: 65
+  }, {
+    accessor: item => (item.isRescinded
+      ? CREDIT_TRANSFER_STATUS.rescinded.description
+      : (
+        Object.values(CREDIT_TRANSFER_STATUS).find(element => element.id === item.status.id)
+      ).description),
+    className: 'col-status',
+    Header: 'Status',
+    id: 'status',
+    minWidth: 80
+  }, {
+    accessor: item => (item.updateTimestamp ? moment(item.updateTimestamp).format('YYYY-MM-DD') : '-'),
+    className: 'col-date',
+    Header: 'Last Updated On',
+    id: 'updateTimestamp',
+    minWidth: 95
+  }, {
+    accessor: 'id',
+    Cell: row => (
+      <button
+        id="credit-transfer-link"
+        className="btn btn-primary"
+        onClick={() => props.establishLink(row.value)}
+        type="button"
+      >
+        <FontAwesomeIcon icon="link" />
+      </button>
+    ),
+    className: 'col-actions',
+    filterable: false,
+    Header: 'Link',
+    id: 'actions',
+    minWidth: 100
+  }];
 
   const filterMethod = (filter, row, column) => {
     const id = filter.pivotId || filter.id;
@@ -136,10 +130,7 @@ const LinkedCreditTransferSelection = (props) => {
 
   const filterable = true;
 
-
-  return (<div>
-    <h3>Linking Credit Transfer</h3>
-
+  return (
     <ReactTable
       className="searchable"
       columns={columns}
@@ -153,23 +144,14 @@ const LinkedCreditTransferSelection = (props) => {
       filterable={filterable}
       pageSizeOptions={[5, 10, 15, 20, 25, 50, 100]}
     />
-
-    <button
-      id="add-credit-transfer-link"
-      className="btn btn-danger"
-      onClick={() => props.cancelLink()}
-      type="button"
-    >
-      {Lang.BTN_CANCEL_LINK_CREDIT_TRANSACTION}
-    </button>
-  </div>);
+  );
 };
 
 LinkedCreditTransferSelection.defaultProps = {
+  creditTransfers: []
 };
 
 LinkedCreditTransferSelection.propTypes = {
-  cancelLink: PropTypes.func.isRequired,
   establishLink: PropTypes.func.isRequired,
   creditTransfers: PropTypes.arrayOf(PropTypes.shape)
 

--- a/frontend/src/secure_file_submission/components/SecureFileSubmissionDetails.js
+++ b/frontend/src/secure_file_submission/components/SecureFileSubmissionDetails.js
@@ -4,19 +4,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import axios from 'axios';
-import { Link } from 'react-router-dom';
 
 import Errors from '../../app/components/Errors';
 import TooltipWhenDisabled from '../../app/components/TooltipWhenDisabled';
 import history from '../../app/History';
 import * as Lang from '../../constants/langEnUs';
 import SECURE_DOCUMENT_UPLOAD from '../../constants/routes/SecureDocumentUpload';
-import { getFileSize, getIcon, getScanStatusIcon } from '../../utils/functions';
+import LinkedCreditTransactions from './LinkedCreditTransactions';
 import SecureFileSubmissionComment from './SecureFileSubmissionComment';
 import SecureFileSubmissionCommentButtons from './SecureFileSubmissionCommentButtons';
 import SecureFileSubmissionCommentForm from './SecureFileSubmissionCommentForm';
-import CREDIT_TRANSACTIONS from '../../constants/routes/CreditTransactions';
+import SecureFileSubmissionFileAttachments from './SecureFileSubmissionFileAttachments';
 
 const SecureFileSubmissionDetails = props => (
   <div className="page-credit-transaction-request-details">
@@ -52,29 +50,42 @@ const SecureFileSubmissionDetails = props => (
           </div>
           }
 
-          {props.item.type.theType === 'Evidence' &&
           <div className="row">
             <div className="form-group col-md-12">
-              <label htmlFor="agreement-name">Part 3 Agreement Name:
+              <label htmlFor="title">{props.item.type.theType === 'Evidence' ? 'Part 3 Agreement Name' : 'Title'}:
                 <div className="value">
                   {props.item.title}
                 </div>
               </label>
             </div>
           </div>
-          }
 
-          {props.item.type.theType !== 'Evidence' &&
           <div className="row">
             <div className="form-group col-md-12">
-              <label htmlFor="agreement-name">Title:
-                <div className="value">
-                  {props.item.title}
-                </div>
+              <label className="label-credit-transactions" htmlFor="credit-transactions">Linked Credit Transactions:
+                {(props.item.creditTrades && props.item.creditTrades.length > 0)
+                  ? (
+                    <LinkedCreditTransactions
+                      creditTrades={props.item.creditTrades}
+                      selectLinkIdForModal={props.selectLinkIdForModal}
+                    />)
+                  : (<div className="value">None</div>)
+                }
+                {props.canLink &&
+                <button
+                  id="add-credit-transfer-link"
+                  className="btn btn-primary"
+                  data-target="#modalCreditTransfer"
+                  data-toggle="modal"
+                  onClick={() => props.addLink()}
+                  type="button"
+                >
+                  {Lang.BTN_LINK_CREDIT_TRANSACTION}
+                </button>
+                }
               </label>
             </div>
           </div>
-          }
         </div>
 
         <div className="col-md-6">
@@ -91,143 +102,17 @@ const SecureFileSubmissionDetails = props => (
           <div className="row">
             <div className="form-group col-md-12">
               <label htmlFor="document-type">Attachments:</label>
-              <div className={`file-submission-attachments ${
-                ((props.item.status.status === 'Received' && props.availableActions.includes('Archived')) ||
-                props.item.status.status === 'Archived') ? 'hide-security-scan' : 'hide-trim'}`
-              }
-              >
-                <div className="row">
-                  <div className="col-xs-6 header">Filename</div>
-                  <div className="col-xs-3 size header">Size</div>
-                  <div className="col-xs-3 security-scan-status header">Security Scan</div>
-                  <div className="col-xs-3 trim-record-number header">TRIM Record #</div>
-                </div>
-                {props.item.attachments.map((attachment, index) => (
-                  <div className="row" key={attachment.url}>
-                    <div className="col-xs-6 filename">
-                      <span className="icon">
-                        <FontAwesomeIcon icon={getIcon(attachment.mimeType)} fixedWidth />
-                      </span>
-                      <button
-                        className="text"
-                        onClick={() => {
-                          axios.get(attachment.url, {
-                            responseType: 'blob'
-                          }).then((response) => {
-                            const objectURL =
-                              window.URL.createObjectURL(new Blob([response.data]));
-                            const link = document.createElement('a');
-                            link.href = objectURL;
-                            link.setAttribute('download', attachment.filename);
-                            document.body.appendChild(link);
-                            link.click();
-                          });
-                        }}
-                        type="button"
-                      >
-                        {attachment.filename}
-                      </button>
-                    </div>
+              <SecureFileSubmissionFileAttachments
+                attachments={props.item.attachments}
+                availableActions={props.availableActions}
+                fields={props.fields}
+                handleRecordNumberChange={props.handleRecordNumberChange}
+                status={props.item.status}
 
-                    <div className="col-xs-3 size">
-                      <span>{getFileSize(attachment.size)}</span>
-                    </div>
-
-                    <div className="col-xs-3 security-scan-status">
-                      <span className="security-scan-icon" data-security-scan-status={attachment.securityScanStatus}>
-                        <FontAwesomeIcon
-                          icon={getScanStatusIcon(attachment.securityScanStatus)}
-                          fixedWidth
-                        />
-                      </span>
-                    </div>
-
-                    <div className="col-xs-3 trim-record-number">
-                      {props.item.status.status === 'Received' &&
-                      <input
-                        className="form-control"
-                        id={`record-number-${index}`}
-                        name="recordNumbers"
-                        onChange={(event) => {
-                          props.handleRecordNumberChange(event, index, attachment.id);
-                        }}
-                        required="required"
-                        type="text"
-                        value={props.fields.recordNumbers[index] ? props.fields.recordNumbers[index].value : ''}
-                      />
-                      }
-                      {props.item.status.status === 'Archived' &&
-                      <span>{attachment.recordNumber}</span>
-                      }
-                    </div>
-                  </div>
-                ))}
-                {props.item.attachments.length === 0 &&
-                <div className="row">
-                  <div className="col-xs-12">No files attached.</div>
-                </div>
-                }
-              </div>
+              />
             </div>
           </div>
         </div>
-
-        <div className="col-md-6">
-          <div className="row">
-            <div className="form-group col-md-12">
-              <label htmlFor="credit-transactions">Linked Credit Transactions:
-                {(props.item.creditTrades && props.item.creditTrades.length > 0)
-                  ? (
-                    <table>
-                      <thead>
-                        <tr>
-                          <th>Type</th>
-                          <th>Status</th>
-                          <th>Link</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {props.item.creditTrades.map(creditTrade => (
-                          <tr key={creditTrade.id}>
-                            <td>{creditTrade.type.theType}</td>
-                            <td>{creditTrade.status.status}</td>
-                            <td>
-                              <Link to={CREDIT_TRANSACTIONS.DETAILS.replace(':id', creditTrade.id)}>
-                                <FontAwesomeIcon icon="box-open" />
-                              </Link>
-                            </td>
-                            <td>
-                              <button
-                                className="btn btn-danger"
-                                type="button"
-                                onClick={() => props.unLink(creditTrade.id)}
-                              >
-                                <FontAwesomeIcon icon="trash" />
-                              </button>
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>) : (<p>None</p>)
-                }
-              </label>
-            </div>
-            {props.canLink &&
-            <div className="form-group col-md-12">
-              <button
-                id="add-credit-transfer-link"
-                className="btn btn-primary"
-                data-target="#linkCreditTransfer"
-                data-toggle="modal"
-                type="button"
-              >
-                {Lang.BTN_LINK_CREDIT_TRANSACTION}
-              </button>
-            </div>
-            }
-          </div>
-        </div>
-
       </div>
 
       {Object.keys(props.errors).length > 0 &&
@@ -238,13 +123,17 @@ const SecureFileSubmissionDetails = props => (
       </div>
       }
 
-      {props.item.comments.length > 0 && <h3 className="comments-header">Comments</h3>}
-      {props.item.comments.map(c => (
-        <SecureFileSubmissionComment comment={c} key={c.id} saveComment={props.saveComment} />
-      ))
-      }
       <div className="row">
-        <div className="col-md-12">
+        <div className="form-group col-md-12">
+          <label htmlFor="comments">Comments:</label>
+          {props.item.comments.length === 0 &&
+          !props.isCommenting &&
+            <div className="form-group value">None</div>
+          }
+          {props.item.comments.map(c => (
+            <SecureFileSubmissionComment comment={c} key={c.id} saveComment={props.saveComment} />
+          ))
+          }
           <SecureFileSubmissionCommentButtons
             addComment={props.addComment}
             canComment={props.canComment}
@@ -270,7 +159,6 @@ const SecureFileSubmissionDetails = props => (
       >
         <FontAwesomeIcon icon="arrow-circle-left" /> {Lang.BTN_APP_CANCEL}
       </button>
-
       {props.availableActions.includes('Cancelled') &&
       <button
         className="btn btn-danger"
@@ -281,7 +169,6 @@ const SecureFileSubmissionDetails = props => (
         <FontAwesomeIcon icon="minus-circle" /> {Lang.BTN_DELETE_DRAFT}
       </button>
       }
-
       {props.availableActions.includes('Draft') &&
       ['Draft', 'Security Scan Failed'].includes(props.item.status.status) &&
       <button
@@ -292,7 +179,6 @@ const SecureFileSubmissionDetails = props => (
         <FontAwesomeIcon icon="edit" /> {Lang.BTN_EDIT}
       </button>
       }
-
       {props.availableActions.includes('Draft') &&
       ['Submitted', 'Pending Submission'].includes(props.item.status.status) &&
       <button
@@ -304,7 +190,6 @@ const SecureFileSubmissionDetails = props => (
         <FontAwesomeIcon icon="undo-alt" /> {Lang.BTN_RESCIND_AS_DRAFT}
       </button>
       }
-
       {props.availableActions.includes('Submitted') &&
       <button
         className="btn btn-primary"
@@ -355,7 +240,6 @@ SecureFileSubmissionDetails.propTypes = {
   availableActions: PropTypes.arrayOf(PropTypes.string).isRequired,
   cancelComment: PropTypes.func.isRequired,
   addLink: PropTypes.func.isRequired,
-  unLink: PropTypes.func.isRequired,
   canComment: PropTypes.bool.isRequired,
   canLink: PropTypes.bool.isRequired,
   canCreatePrivilegedComment: PropTypes.bool.isRequired,
@@ -368,7 +252,8 @@ SecureFileSubmissionDetails.propTypes = {
   isCommenting: PropTypes.bool.isRequired,
   isCreatingPrivilegedComment: PropTypes.bool.isRequired,
   item: PropTypes.shape().isRequired,
-  saveComment: PropTypes.func.isRequired
+  saveComment: PropTypes.func.isRequired,
+  selectLinkIdForModal: PropTypes.func.isRequired
 };
 
 export default SecureFileSubmissionDetails;

--- a/frontend/src/secure_file_submission/components/SecureFileSubmissionDetails.js
+++ b/frontend/src/secure_file_submission/components/SecureFileSubmissionDetails.js
@@ -217,7 +217,8 @@ const SecureFileSubmissionDetails = props => (
               <button
                 id="add-credit-transfer-link"
                 className="btn btn-primary"
-                onClick={() => props.addLink()}
+                data-target="#linkCreditTransfer"
+                data-toggle="modal"
                 type="button"
               >
                 {Lang.BTN_LINK_CREDIT_TRANSACTION}

--- a/frontend/src/secure_file_submission/components/SecureFileSubmissionFileAttachments.js
+++ b/frontend/src/secure_file_submission/components/SecureFileSubmissionFileAttachments.js
@@ -1,0 +1,101 @@
+/*
+ * Presentational component
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import axios from 'axios';
+
+import { getFileSize, getIcon, getScanStatusIcon } from '../../utils/functions';
+
+const SecureFileSubmissionFileAttachments = props => (
+  <div className={`file-submission-attachments ${
+    ((props.status.status === 'Received' && props.availableActions.includes('Archived')) ||
+    props.status.status === 'Archived') ? 'hide-security-scan' : 'hide-trim'}`
+  }
+  >
+    <div className="row">
+      <div className="col-xs-6 header">Filename</div>
+      <div className="col-xs-3 size header">Size</div>
+      <div className="col-xs-3 security-scan-status header">Security Scan</div>
+      <div className="col-xs-3 trim-record-number header">TRIM Record #</div>
+    </div>
+    {props.attachments.map((attachment, index) => (
+      <div className="row" key={attachment.url}>
+        <div className="col-xs-6 filename">
+          <span className="icon">
+            <FontAwesomeIcon icon={getIcon(attachment.mimeType)} fixedWidth />
+          </span>
+          <button
+            className="text"
+            onClick={() => {
+              axios.get(attachment.url, {
+                responseType: 'blob'
+              }).then((response) => {
+                const objectURL =
+                  window.URL.createObjectURL(new Blob([response.data]));
+                const link = document.createElement('a');
+                link.href = objectURL;
+                link.setAttribute('download', attachment.filename);
+                document.body.appendChild(link);
+                link.click();
+              });
+            }}
+            type="button"
+          >
+            {attachment.filename}
+          </button>
+        </div>
+
+        <div className="col-xs-3 size">
+          <span>{getFileSize(attachment.size)}</span>
+        </div>
+
+        <div className="col-xs-3 security-scan-status">
+          <span className="security-scan-icon" data-security-scan-status={attachment.securityScanStatus}>
+            <FontAwesomeIcon
+              icon={getScanStatusIcon(attachment.securityScanStatus)}
+              fixedWidth
+            />
+          </span>
+        </div>
+
+        <div className="col-xs-3 trim-record-number">
+          {props.status.status === 'Received' &&
+          <input
+            className="form-control"
+            id={`record-number-${index}`}
+            name="recordNumbers"
+            onChange={(event) => {
+              props.handleRecordNumberChange(event, index, attachment.id);
+            }}
+            required="required"
+            type="text"
+            value={props.fields.recordNumbers[index] ? props.fields.recordNumbers[index].value : ''}
+          />
+          }
+          {props.status.status === 'Archived' &&
+          <span>{attachment.recordNumber}</span>
+          }
+        </div>
+      </div>
+    ))}
+    {props.attachments.length === 0 &&
+    <div className="row">
+      <div className="col-xs-12">No files attached.</div>
+    </div>
+    }
+  </div>
+);
+
+SecureFileSubmissionFileAttachments.propTypes = {
+  attachments: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+  availableActions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  fields: PropTypes.shape({
+    recordNumbers: PropTypes.arrayOf(PropTypes.shape())
+  }).isRequired,
+  status: PropTypes.shape().isRequired,
+  handleRecordNumberChange: PropTypes.func.isRequired
+};
+
+export default SecureFileSubmissionFileAttachments;

--- a/frontend/styles/SecureFileSubmissions.scss
+++ b/frontend/styles/SecureFileSubmissions.scss
@@ -195,3 +195,17 @@
   text-align: left;
   text-overflow: ellipsis;
 }
+
+#linkCreditTransfer {
+  .modal-dialog {
+    width: 90%;
+
+    .modal-body {
+      padding: 0;
+
+      .ReactTable {
+        border: none;
+      }
+    }
+  }
+}

--- a/frontend/styles/SecureFileSubmissions.scss
+++ b/frontend/styles/SecureFileSubmissions.scss
@@ -37,6 +37,10 @@
   .credit-transaction-request-details {
     label {
       font-weight: normal;
+
+      &.label-credit-transactions {
+        width: 100%;
+      }
     }
 
     .row.comment-form {
@@ -187,6 +191,39 @@
   }
 }
 
+.linked-credit-transactions {
+  padding: 0 1rem;
+
+  .header {
+    font-weight: bold;
+    padding-bottom: 0.5rem;
+    padding-top: 0.5rem;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+
+    &:nth-of-type(even) {
+      background-color: $background-grey;
+    }
+  }
+
+  .status, .unlink {
+    text-align: center;
+  }
+
+  .unlink-action {
+    background: transparent;
+    border: none;
+    margin: 0.5rem;
+
+    &:hover {
+      color: $red;
+    }
+  }
+}
+
 .progress-bars .text {
   display: block;
   max-width: 100%;
@@ -196,7 +233,11 @@
   text-overflow: ellipsis;
 }
 
-#linkCreditTransfer {
+#add-credit-transfer-link {
+  margin-top: 1rem;
+}
+
+#modalCreditTransfer {
   .modal-dialog {
     width: 90%;
 
@@ -205,6 +246,26 @@
 
       .ReactTable {
         border: none;
+
+        .col-actions .credit-transfer-link {
+          background-color: transparent;
+          border: none;
+          color: $blue;
+          margin: 0;
+          padding: 0;
+        }
+
+        .col-credits, .col-date, .col-id, .col-price {
+          text-align: right;
+        }
+
+        .col-status {
+          text-align: center;
+        }
+      }
+
+      .text-center {
+        margin: 5rem;
       }
     }
   }


### PR DESCRIPTION
#969 #973 #974 #975 #976 

Did some minor layout cleanup, and restricted the credit transactions shown in Link Credit Transactions to related credit transactions only

Changelog:
- Fixed milestone becoming overwritten after it's been received
- Link Credit Transactions now only show records that involved the fuel supplier
- Updated layout for consistency
- Moved Link Credit Transactions table into a modal window to provide more context to the user
- Code cleanup