### PR TITLE
Added a clause to catch all kinds of error for handling security scans

### DIFF
--- a/backend/api/scripts/handle_security_scans.py
+++ b/backend/api/scripts/handle_security_scans.py
@@ -18,6 +18,8 @@ def run():
 
     except AMQPError as error:
         print('AMQP Error {}'.format(error))
+    except Exception as error:
+        print('Exception: {}'.format(error))
 
 
 def handle_message(ch, method, props, body):


### PR DESCRIPTION
We're running into an exception that we can't seem to catch. Adding a generic catcher so we know what kind of error it is.