### PR TITLE
Submit notification is now sent to government users

### DIFF
--- a/backend/api/services/DocumentService.py
+++ b/backend/api/services/DocumentService.py
@@ -162,6 +162,10 @@ class DocumentService(object):
             interested_organizations.extend([government, user.organization])
             notification_type = NotificationType.DOCUMENT_ARCHIVED
 
+        elif document.status.status == "Security Scan Failed":
+            interested_organizations.append(user.organization)
+            notification_type = NotificationType.DOCUMENT_SCAN_FAILED
+
         if notification_type:
             for organization in interested_organizations:
                 AMQPNotificationService.send_notification(


### PR DESCRIPTION
#991

Submitted Secure File Submissions Notifications should be sent to government users now

Changelog:
- Changed to use the helper function to send the notifications
- Additional check for files that are marked failed
