### PR TITLE
Secure File Submission Fixes

### DIFF
--- a/backend/api/serializers/Document.py
+++ b/backend/api/serializers/Document.py
@@ -521,6 +521,30 @@ class DocumentUpdateSerializer(serializers.ModelSerializer):
                                    " before submitting."
                 })
 
+            attachments_to_be_removed = request.data.get(
+                'attachments_to_be_removed')
+
+            for attachment in current_attachments:
+                if attachment.security_scan_status == 'FAIL' and \
+                        not attachment.is_removed and \
+                        attachment.id not in attachments_to_be_removed:
+                    raise serializers.ValidationError({
+                        'attachments': "An attachment failing security scan "
+                                       "is preventing this {} from being "
+                                       "submitted".format(
+                                           document.type.description
+                                       )
+                    })
+
+                if attachment.security_scan_status == 'IN PROGRESS' and \
+                        not attachment.is_removed and \
+                        attachment.id not in attachments_to_be_removed:
+                    raise serializers.ValidationError({
+                        'attachments': "Please wait until the attachments "
+                                       "completed security scan before "
+                                       "submitting."
+                    })
+
         if status.status == "Archived":
             record_numbers = request.data.get('record_numbers', [])
 

--- a/backend/api/services/DocumentService.py
+++ b/backend/api/services/DocumentService.py
@@ -125,7 +125,7 @@ class DocumentService(object):
             return False
 
         if current_status.status in ["Security Scan Failed"] and \
-                next_status.status != "Draft":
+                next_status.status not in ["Draft", "Submitted"]:
             return False
 
         if current_status.status not in [

--- a/backend/api/services/SecurityScan.py
+++ b/backend/api/services/SecurityScan.py
@@ -39,14 +39,15 @@ class SecurityScan:
     @staticmethod
     def update_status_and_send_notifications(attachment):
         """Update document status and send notifications is it is required"""
-
         not_run_files = DocumentFileAttachment.objects.filter(
             document=attachment.document,
-            security_scan_status='NOT RUN'
+            security_scan_status='NOT RUN',
+            is_removed=False
         )
         in_progress_files = DocumentFileAttachment.objects.filter(
             document=attachment.document,
-            security_scan_status='IN PROGRESS'
+            security_scan_status='IN PROGRESS',
+            is_removed=False
         )
         failed_files = DocumentFileAttachment.objects.filter(
             document=attachment.document,

--- a/frontend/src/secure_file_submission/SecureFileSubmissionAddContainer.js
+++ b/frontend/src/secure_file_submission/SecureFileSubmissionAddContainer.js
@@ -123,7 +123,7 @@ class SecureFileSubmissionAddContainer extends Component {
       const progress = [];
       fieldState[name] = value;
 
-      for (let i = 0; i < value.length; i++) {
+      for (let i = 0; i < value.length; i += 1) {
         progress.push({
           index: i,
           started: false,
@@ -161,7 +161,7 @@ class SecureFileSubmissionAddContainer extends Component {
     const attachments = [];
     const attachedFiles = this.state.fields.files;
 
-    for (let i = 0; i < attachedFiles.length; i++) {
+    for (let i = 0; i < attachedFiles.length; i += 1) {
       const file = attachedFiles[i];
 
       uploadPromises.push(new Promise((resolve, reject) => {
@@ -171,18 +171,18 @@ class SecureFileSubmissionAddContainer extends Component {
           const blob = reader.result;
 
           this.props.requestURL().then((response) => {
-            let uploadProgress = this.state.uploadProgress;
-            uploadProgress[i] = {
-              ...uploadProgress[i],
+            const progress = this.state.uploadProgress;
+            progress[i] = {
+              ...progress[i],
               started: true
             };
             this.setState({
               ...this.state,
-              uploadProgress
+              uploadProgress: progress
             });
 
             this.props.uploadDocument(response.data.put, blob, (progressEvent) => {
-              let uploadProgress = this.state.uploadProgress;
+              const { uploadProgress } = this.state;
               uploadProgress[i] = {
                 ...uploadProgress[i],
                 progress: {
@@ -195,7 +195,7 @@ class SecureFileSubmissionAddContainer extends Component {
                 uploadProgress
               });
             }).then(() => {
-              let uploadProgress = this.state.uploadProgress;
+              const { uploadProgress } = this.state;
               uploadProgress[i] = {
                 ...uploadProgress[i],
                 complete: true,
@@ -206,7 +206,7 @@ class SecureFileSubmissionAddContainer extends Component {
                 uploadProgress
               });
             }).catch(() => {
-              let uploadProgress = this.state.uploadProgress;
+              const { uploadProgress } = this.state;
               uploadProgress[i] = {
                 ...uploadProgress[i],
                 complete: false,


### PR DESCRIPTION
#995 #996 

Some fixes relating to statuses not updating as expected.

Changelog:
- Fixed an issue where uploading new files on a submission that's in draft doesn't upload the files
- Added Upload Progress bar on Edit
- Allow submitting a submission that has a Security Failed Scan status
- Added validation to prevent users from submitting submission that contain attachments that have failed or in progress
- Security Scan Handler now takes into account files that have been removed (and should no longer cause submissions to get stuck in a status)
- eslint fixes on some files