### PR TITLE
Notification Settings Update

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -27,6 +27,9 @@ const CONFIG = {
   },
   FUEL_CODES: {
     ENABLED: getConfig('fuel_codes.enabled', false)
+  },
+  CREDIT_TRANSFER: {
+    ENABLED: getConfig('credit_transfer.enabled', false)
   }
 };
 

--- a/frontend/src/constants/settings/notificationsCreditTransfers.js
+++ b/frontend/src/constants/settings/notificationsCreditTransfers.js
@@ -3,60 +3,69 @@ const CREDIT_TRANSFER_NOTIFICATIONS = [{
   code: 'CREDIT_TRANSFER_CREATED',
   description: 'Draft Saved',
   key: 'draft',
-  recipients: ['fuel_supplier']
+  recipients: ['fuel_supplier'],
+  feature: 'credit_transfer'
 }, {
   id: 2,
   code: 'CREDIT_TRANSFER_SIGNED_1OF2',
   description: 'Signed 1/2',
   key: 'submitted',
-  recipients: ['fuel_supplier']
+  recipients: ['fuel_supplier'],
+  feature: 'credit_transfer'
 }, {
   id: 10,
   code: 'CREDIT_TRANSFER_PROPOSAL_REFUSED',
   description: 'Refused',
   key: 'refused',
-  recipients: ['fuel_supplier']
+  recipients: ['fuel_supplier'],
+  feature: 'credit_transfer'
 }, {
   id: 3,
   code: 'CREDIT_TRANSFER_SIGNED_2OF2',
   description: 'Signed 2/2',
   key: 'accepted',
-  recipients: ['fuel_supplier', 'government']
+  recipients: ['fuel_supplier', 'government'],
+  feature: 'credit_transfer'
 }, {
   id: 4,
   code: 'CREDIT_TRANSFER_RECOMMENDED_FOR_APPROVAL',
   description: 'Recommend Director Approval',
   key: 'recommended',
   permission: 'RECOMMEND_CREDIT_TRANSFER',
-  recipients: ['government']
+  recipients: ['government'],
+  feature: 'base'
 }, {
   id: 5,
   code: 'CREDIT_TRANSFER_RECOMMENDED_FOR_DECLINATION',
   description: 'Recommend Director Approval Decline',
   key: 'not_recommended',
   permission: 'RECOMMEND_CREDIT_TRANSFER',
-  recipients: ['government']
+  recipients: ['government'],
+  feature: 'base'
 }, {
   id: 7,
   code: 'CREDIT_TRANSFER_APPROVED',
   description: 'Director Approval',
   key: 'approved',
   permission: 'APPROVE_CREDIT_TRANSFER',
-  recipients: ['fuel_supplier', 'government']
+  recipients: ['fuel_supplier', 'government'],
+  feature: 'base'
 }, {
   id: 9,
   code: 'CREDIT_TRANSFER_DECLINED',
   description: 'Director Declined to Approve',
   key: 'declined',
   permission: 'DECLINE_CREDIT_TRANSFER',
-  recipients: ['fuel_supplier', 'government']
+  recipients: ['fuel_supplier', 'government'],
+  feature: 'base'
 }, {
   id: 11,
   code: 'CREDIT_TRANSFER_RESCINDED',
   description: 'Rescinded',
   key: 'rescinded',
   permission: 'RESCIND_CREDIT_TRANSFER',
-  recipients: ['fuel_supplier', 'government']
+  recipients: ['fuel_supplier', 'government'],
+  feature: 'credit_transfer'
 }];
 
 export default CREDIT_TRANSFER_NOTIFICATIONS;

--- a/frontend/src/settings/components/NotificationsCreditTransactionsTable.js
+++ b/frontend/src/settings/components/NotificationsCreditTransactionsTable.js
@@ -3,11 +3,10 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactTable from 'react-table';
 import 'react-table/react-table.css';
 
 import CheckBox from '../../app/components/CheckBox';
-import StateSavingReactTable from "../../app/components/StateSavingReactTable";
+import ReactTable from '../../app/components/StateSavingReactTable';
 
 const NotificationsCreditTransactionsTable = (props) => {
   const columns = [{
@@ -71,7 +70,7 @@ const NotificationsCreditTransactionsTable = (props) => {
   }];
 
   return (
-    <StateSavingReactTable
+    <ReactTable
       stateKey="notifications-credit-transactions"
       data={props.items}
       defaultPageSize={props.items.length}

--- a/frontend/src/settings/components/SettingsDetails.js
+++ b/frontend/src/settings/components/SettingsDetails.js
@@ -40,11 +40,23 @@ const SettingsDetails = props => (
         <NotificationsCreditTransactionsTable
           addToFields={props.addToFields}
           fields={props.fields.settings.notifications}
-          items={CREDIT_TRANSFER_NOTIFICATIONS.filter(notification =>
-            (props.loggedInUser.isGovernmentUser
-              ? notification.recipients.includes('government')
-              : notification.recipients.includes('fuel_supplier')
-            ))}
+          items={CREDIT_TRANSFER_NOTIFICATIONS.filter((notification) => {
+            if (props.loggedInUser.isGovernmentUser) {
+              return notification.recipients.includes('government');
+            }
+
+            if (notification.recipients.includes('fuel_supplier')) {
+              if (notification.feature === 'base') {
+                return true;
+              }
+
+              if (CONFIG.CREDIT_TRANSFER.ENABLED && notification.feature === 'credit_transfer') {
+                return true;
+              }
+            }
+
+            return false;
+          })}
           key="table-credit-transactions"
           toggleCheck={props.toggleCheck}
           type="credit-transfer"

--- a/frontend/src/settings/components/SettingsDetails.js
+++ b/frontend/src/settings/components/SettingsDetails.js
@@ -80,7 +80,7 @@ const SettingsDetails = props => (
       {!props.subscriptions.isFetching && props.subscriptions.success &&
       CONFIG.SECURE_DOCUMENT_UPLOAD.ENABLED && [
         <h3 key="header-doc">
-          File Submission {CONFIG.SECURE_DOCUMENT_UPLOAD.ENABLED}
+          File Submission
         </h3>,
         <NotificationsCreditTransactionsTable
           addToFields={props.addToFields}

--- a/frontend/src/settings/components/SettingsDetails.js
+++ b/frontend/src/settings/components/SettingsDetails.js
@@ -11,6 +11,7 @@ import GOVERNMENT_TRANSFER_NOTIFICATIONS from '../../constants/settings/notifica
 import * as Lang from '../../constants/langEnUs';
 import SettingsTabs from './SettingsTabs';
 import DOCUMENT_NOTIFICATIONS from '../../constants/settings/notificationsDocuments';
+import CONFIG from '../../config';
 
 const SettingsDetails = props => (
   <div className="page_settings">
@@ -62,9 +63,12 @@ const SettingsDetails = props => (
           key="table-pvr"
           toggleCheck={props.toggleCheck}
           type="government-transfer"
-        />,
+        />
+      ]}
+      {!props.subscriptions.isFetching && props.subscriptions.success &&
+      CONFIG.SECURE_DOCUMENT_UPLOAD.ENABLED && [
         <h3 key="header-doc">
-          File Submission
+          File Submission {CONFIG.SECURE_DOCUMENT_UPLOAD.ENABLED}
         </h3>,
         <NotificationsCreditTransactionsTable
           addToFields={props.addToFields}
@@ -77,7 +81,9 @@ const SettingsDetails = props => (
           key="table-doc"
           toggleCheck={props.toggleCheck}
           type="documents"
-        />,
+        />
+      ]}
+      {!props.subscriptions.isFetching && props.subscriptions.success && [
         <div className="btn-container" key="container-buttons">
           <button
             className="btn btn-primary"


### PR DESCRIPTION
#1035

Changelog:
- Notification settings for Secure File Submission will now only show up if the feature is enabled
- Some Notification settings for Credit Transfer only show up when the new config credit_transfer.enabled is set to true

@kuanfandevops we need a new setting for the front-end:
```
credit_transfer.enabled: true
```

Please add this to DEV and TEST, but not in PROD