### PR TITLE
Visual representation fluid

### DIFF
--- a/frontend/src/admin/credit_trade_history/components/CreditTradeHistoryTable.js
+++ b/frontend/src/admin/credit_trade_history/components/CreditTradeHistoryTable.js
@@ -4,8 +4,8 @@
 import React from 'react';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { Link } from 'react-router-dom';
-import 'react-table/react-table.css';
 import ReactTable from 'react-table';
+import 'react-table/react-table.css';
 import axios from 'axios';
 
 import history from '../../../app/History';
@@ -13,7 +13,7 @@ import CREDIT_TRANSACTIONS from '../../../constants/routes/CreditTransactions';
 import { CREDIT_TRANSFER_STATUS } from '../../../constants/values';
 import * as Routes from '../../../constants/routes';
 import { CREDIT_TRANSACTIONS_HISTORY } from '../../../constants/routes/Admin';
-// import ReactTable from '../../../app/components/StateSavingReactTable';
+import StateSavingReactTable from "../../../app/components/StateSavingReactTable";
 
 class CreditTradeHistoryTable extends React.Component {
   constructor () {
@@ -138,7 +138,7 @@ class CreditTradeHistoryTable extends React.Component {
     const { data, pages, loading } = this.state;
 
     return (
-      <ReactTable
+      <StateSavingReactTable
         stateKey="credit-trade-history"
         defaultPageSize={10}
         defaultSorted={[{

--- a/frontend/src/admin/credit_trade_history/components/CreditTradeHistoryTable.js
+++ b/frontend/src/admin/credit_trade_history/components/CreditTradeHistoryTable.js
@@ -4,8 +4,8 @@
 import React from 'react';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { Link } from 'react-router-dom';
-import ReactTable from 'react-table';
 import 'react-table/react-table.css';
+import ReactTable from 'react-table';
 import axios from 'axios';
 
 import history from '../../../app/History';
@@ -13,7 +13,7 @@ import CREDIT_TRANSACTIONS from '../../../constants/routes/CreditTransactions';
 import { CREDIT_TRANSFER_STATUS } from '../../../constants/values';
 import * as Routes from '../../../constants/routes';
 import { CREDIT_TRANSACTIONS_HISTORY } from '../../../constants/routes/Admin';
-import StateSavingReactTable from "../../../app/components/StateSavingReactTable";
+// import ReactTable from '../../../app/components/StateSavingReactTable';
 
 class CreditTradeHistoryTable extends React.Component {
   constructor () {
@@ -138,7 +138,7 @@ class CreditTradeHistoryTable extends React.Component {
     const { data, pages, loading } = this.state;
 
     return (
-      <StateSavingReactTable
+      <ReactTable
         stateKey="credit-trade-history"
         defaultPageSize={10}
         defaultSorted={[{

--- a/frontend/src/credit_transfers/components/CreditTransferVisualRepresentation.js
+++ b/frontend/src/credit_transfers/components/CreditTransferVisualRepresentation.js
@@ -10,19 +10,15 @@ import { getCreditTransferType } from '../../actions/creditTransfersActions';
 class CreditTransferVisualRepresentation extends Component {
   _renderPart3Award () {
     return (
-      <div className="row visual-representation">
-        <div className="col-sm-6 col-lg-3 col-lg-offset-1">
+      <div className="row visual-representation container">
+        <div className="col-xs-10 col-sm-8 col-md-4">
           <div className="respondent-container">
-            <div>
-              { this.props.creditsTo && this.props.creditsTo.name }
-            </div>
+            {this.props.creditsTo && this.props.creditsTo.name}
           </div>
         </div>
-        <div className="col-sm-4 col-lg-4">
-          <div className="arrow">
-            <div>{numeral(this.props.numberOfCredits).format(NumberFormat.INT)} credit{this.props.numberOfCredits > 1 && 's'}</div>
-            <FontAwesomeIcon icon="arrow-alt-circle-up" size="4x" /> <div>{getCreditTransferType(this.props.tradeType.id)}</div>
-          </div>
+        <div className="col-xs-12 col-md-2 arrow">
+          <div>{numeral(this.props.numberOfCredits).format(NumberFormat.INT)} credit{this.props.numberOfCredits > 1 && 's'}</div>
+          <FontAwesomeIcon icon="arrow-alt-circle-up" size="4x" /> <div>{getCreditTransferType(this.props.tradeType.id)}</div>
         </div>
       </div>
     );
@@ -30,19 +26,15 @@ class CreditTransferVisualRepresentation extends Component {
 
   _renderRetirement () {
     return (
-      <div className="row visual-representation">
-        <div className="col-sm-6 col-lg-3 col-lg-offset-1">
+      <div className="row visual-representation container">
+        <div className="col-xs-10 col-sm-8 col-md-4">
           <div className="initiator-container">
-            <div>
-              { this.props.creditsFrom && this.props.creditsFrom.name }
-            </div>
+            {this.props.creditsFrom && this.props.creditsFrom.name}
           </div>
         </div>
-        <div className="col-sm-4 col-lg-4">
-          <div className="arrow">
-            <div>{numeral(this.props.numberOfCredits).format(NumberFormat.INT)} credit{this.props.numberOfCredits > 2 && 's'}</div>
-            <FontAwesomeIcon icon="arrow-alt-circle-down" size="4x" /> <div>{getCreditTransferType(this.props.tradeType.id)}</div>
-          </div>
+        <div className="col-xs-12 col-md-2 arrow">
+          <div>{numeral(this.props.numberOfCredits).format(NumberFormat.INT)} credit{this.props.numberOfCredits > 2 && 's'}</div>
+          <FontAwesomeIcon icon="arrow-alt-circle-down" size="4x" /> <div>{getCreditTransferType(this.props.tradeType.id)}</div>
         </div>
       </div>
     );
@@ -73,31 +65,27 @@ class CreditTransferVisualRepresentation extends Component {
 
   _renderCreditTransfer () {
     return (
-      <div className="row visual-representation">
-        <div className="col-sm-4 col-md-4">
+      <div className="row visual-representation container">
+        <div className="col-xs-10 col-sm-8 col-md-4">
           <div className="initiator-container">
-            <div>
-              { this.props.creditsFrom && this.props.creditsFrom.name }
-            </div>
+            {this.props.creditsFrom && this.props.creditsFrom.name}
           </div>
         </div>
-        <div className="col-sm-2 col-md-2">
-          <div className="arrow">
-            {(Number(this.props.numberOfCredits) > 0) &&
-            <div>{numeral(this.props.numberOfCredits).format(NumberFormat.INT)} credit{this.props.numberOfCredits > 1 && 's'}</div>
-            }
-            <FontAwesomeIcon
-              icon={this._creditTransferIcon().icon}
-              className={this._creditTransferIcon().className}
-              size="6x"
-            />
-            {Number(this.props.totalValue) > 0 &&
-            <div>{numeral(this.props.totalValue).format(NumberFormat.CURRENCY)}</div>}
-          </div>
+        <div className="col-xs-12 col-md-2 arrow">
+          {(Number(this.props.numberOfCredits) > 0) &&
+          <div>{numeral(this.props.numberOfCredits).format(NumberFormat.INT)} credit{this.props.numberOfCredits > 1 && 's'}</div>
+          }
+          <FontAwesomeIcon
+            icon={this._creditTransferIcon().icon}
+            className={this._creditTransferIcon().className}
+            size="6x"
+          />
+          {Number(this.props.totalValue) > 0 &&
+          <div>{numeral(this.props.totalValue).format(NumberFormat.CURRENCY)}</div>}
         </div>
-        <div className="col-sm-4 col-md-4">
+        <div className="col-xs-10 col-sm-8 col-md-4">
           <div className="respondent-container">
-            <div>{this.props.creditsTo.name}</div>
+            {this.props.creditsTo && this.props.creditsTo.name}
           </div>
         </div>
       </div>

--- a/frontend/styles/CreditTransfers.scss
+++ b/frontend/styles/CreditTransfers.scss
@@ -392,14 +392,16 @@
   justify-content: center;
   padding: 2rem 0;
 
+  &.container {
+    margin: 0 auto;
+  }
+
   .col-md-4 {
     text-align: center;
   }
 
   .arrow {
-    display: inline-block;
-    margin: 2rem;
-    border-radius: 5px;
+    padding: 2rem;
     text-align: center;
 
     @include mobile {
@@ -479,7 +481,7 @@
   }
   .initiator-container {
     border-color: $green;
-    margin-right: 1em;
+
     &::before {
       content: "\f1bb\00a0";
       color: $green;


### PR DESCRIPTION
#1017 

After the update to make the containers "fluid" it kind of messed up the visual representation of Credit Transfers. It wasn't too bad, but also not the prettiest.

This is to update it so it looks a bit better (much more evenly spaced out and not too long boxes)

Changelog:
- Removed unnecessary divs
- Removed unused css attributes
- Used grid system a bit better so that it resizes much more gracefully