### PR TITLE
Fuel Code Form Label Changes

### DIFF
--- a/backend/api/viewsets/FuelCode.py
+++ b/backend/api/viewsets/FuelCode.py
@@ -109,7 +109,7 @@ class FuelCodeViewSet(AuditableMixin,
         """
         Gets the list of transport modes
         """
-        approved_fuels = ApprovedFuel.objects.all()
+        approved_fuels = ApprovedFuel.objects.all().order_by('name')
 
         serializer = self.get_serializer(
             approved_fuels, read_only=True, many=True)

--- a/frontend/src/admin/fuel_codes/FuelCodeAddContainer.js
+++ b/frontend/src/admin/fuel_codes/FuelCodeAddContainer.js
@@ -66,7 +66,8 @@ class FuelCodeAddContainer extends Component {
   }
 
   _handleInputChange (event) {
-    const { value, name } = event.target;
+    const { name } = event.target;
+    let { value } = event.target;
     const fieldState = { ...this.state.fields };
 
     if (typeof fieldState[name] === 'object') {
@@ -75,6 +76,13 @@ class FuelCodeAddContainer extends Component {
         fields: fieldState
       });
     } else {
+      if (name === 'facilityNameplate') {
+        // as you're typing remove non-numeric values
+        // (this is so we don't mess our count, but we'll add commas later)
+        value = value.replace(/\D/g, '');
+        value = value.replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
+      }
+
       fieldState[name] = value;
       this.setState({
         fields: fieldState
@@ -94,7 +102,7 @@ class FuelCodeAddContainer extends Component {
       effectiveDate: this.state.fields.effectiveDate !== '' ? this.state.fields.effectiveDate : null,
       expiryDate: this.state.fields.expiryDate !== '' ? this.state.fields.expiryDate : null,
       facilityLocation: this.state.fields.facilityLocation,
-      facilityNameplate: this.state.fields.facilityNameplate !== '' ? this.state.fields.facilityNameplate : null,
+      facilityNameplate: this.state.fields.facilityNameplate !== '' ? this.state.fields.facilityNameplate.replace(/\D/g, '') : null,
       feedstock: this.state.fields.feedstock,
       feedstockLocation: this.state.fields.feedstockLocation,
       feedstockMisc: this.state.fields.feedstockMisc,

--- a/frontend/src/admin/fuel_codes/FuelCodeEditContainer.js
+++ b/frontend/src/admin/fuel_codes/FuelCodeEditContainer.js
@@ -72,7 +72,7 @@ class FuelCodeEditContainer extends Component {
         effectiveDate: item.effectiveDate || '',
         expiryDate: item.expiryDate || '',
         facilityLocation: item.facilityLocation,
-        facilityNameplate: item.facilityNameplate || '',
+        facilityNameplate: item.facilityNameplate ? item.facilityNameplate.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,') : '',
         feedstock: item.feedstock,
         feedstockLocation: item.feedstockLocation,
         feedstockMisc: item.feedstockMisc,
@@ -111,7 +111,8 @@ class FuelCodeEditContainer extends Component {
   }
 
   _handleInputChange (event) {
-    const { value, name } = event.target;
+    const { name } = event.target;
+    let { value } = event.target;
     const fieldState = { ...this.state.fields };
 
     if (typeof fieldState[name] === 'object') {
@@ -120,6 +121,13 @@ class FuelCodeEditContainer extends Component {
         fields: fieldState
       });
     } else {
+      if (name === 'facilityNameplate') {
+        // as you're typing remove non-numeric values
+        // (this is so we don't mess our count, but we'll add commas later)
+        value = value.replace(/\D/g, '');
+        value = value.replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
+      }
+
       fieldState[name] = value;
       this.setState({
         fields: fieldState
@@ -141,7 +149,7 @@ class FuelCodeEditContainer extends Component {
       effectiveDate: this.state.fields.effectiveDate !== '' ? this.state.fields.effectiveDate : null,
       expiryDate: this.state.fields.expiryDate !== '' ? this.state.fields.expiryDate : null,
       facilityLocation: this.state.fields.facilityLocation,
-      facilityNameplate: this.state.fields.facilityNameplate !== '' ? this.state.fields.facilityNameplate : null,
+      facilityNameplate: this.state.fields.facilityNameplate !== '' ? this.state.fields.facilityNameplate.replace(/\D/g, '') : null,
       feedstock: this.state.fields.feedstock,
       feedstockLocation: this.state.fields.feedstockLocation,
       feedstockMisc: this.state.fields.feedstockMisc,

--- a/frontend/src/admin/fuel_codes/components/FuelCodeDetails.js
+++ b/frontend/src/admin/fuel_codes/components/FuelCodeDetails.js
@@ -115,7 +115,7 @@ const FuelCodeDetails = props => (
         <div className="col-sm-6">
           <div className="form-group">
             <label htmlFor="facility-nameplate">Fuel Production Facility Nameplate Capacity (litres/GJ per year):
-              <div className="value">{props.item.facilityNameplate}</div>
+              <div className="value">{props.item.facilityNameplate.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,')}</div>
             </label>
           </div>
         </div>

--- a/frontend/src/admin/fuel_codes/components/FuelCodeForm.js
+++ b/frontend/src/admin/fuel_codes/components/FuelCodeForm.js
@@ -27,6 +27,10 @@ class FuelCodeForm extends Component {
       validationMessage.push('Please enter the carbon intensity.');
     }
 
+    if (this.props.fields.applicationDate === '') {
+      validationMessage.push('Please enter an application date.');
+    }
+
     if (this.props.fields.fuel === '') {
       validationMessage.push('Please select a fuel.');
     }
@@ -43,11 +47,11 @@ class FuelCodeForm extends Component {
       validationMessage.push('Please enter a fuel production facility location.');
     }
 
-    if (this.props.fields.feedstockTransportMode === '') {
+    if (this.props.fields.feedstockTransportMode.length === 0) {
       validationMessage.push('Please select a feedstock transport mode.');
     }
 
-    if (this.props.fields.fuelTransportMode === '') {
+    if (this.props.fields.fuelTransportMode.length === 0) {
       validationMessage.push('Please select a finished fuel transport mode.');
     }
 
@@ -57,16 +61,16 @@ class FuelCodeForm extends Component {
   _getValidationMessagesForApproval () {
     const validationMessage = this._getValidationMessagesForDraft();
 
-    if (this.props.fields.applicationDate === '') {
-      validationMessage.push('Please enter an application date.');
-    }
-
     if (this.props.fields.effectiveDate === '') {
       validationMessage.push('Please enter an effective date.');
     }
 
     if (this.props.fields.expiryDate === '') {
       validationMessage.push('Please enter an expiry date.');
+    }
+
+    if (this.props.fields.facilityNameplate === '') {
+      validationMessage.push('Please enter a fuel production facility nameplate capacity.');
     }
 
     if (this.props.fields.approvalDate === '') {
@@ -117,7 +121,7 @@ class FuelCodeForm extends Component {
                 </button>
               </TooltipWhenDisabled>
               <TooltipWhenDisabled
-                className="adjust-tooltip"
+                className={`adjust-tooltip ${this.props.fields.facilityNameplate === '' ? 'adjust-for-facility-nameplate' : ''}`}
                 disabled={this._getValidationMessagesForApproval().length > 0}
                 title={this._getValidationMessagesForApproval()}
               >

--- a/frontend/src/admin/fuel_codes/components/FuelCodeFormDetails.js
+++ b/frontend/src/admin/fuel_codes/components/FuelCodeFormDetails.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import AutocompletedInput from './AutocompletedInput';
+import InputWithTooltip from '../../../app/components/InputWithTooltip';
 
 const FuelCodeFormDetails = props => (
   <div className="fuel-code-details">
@@ -22,7 +23,8 @@ const FuelCodeFormDetails = props => (
                   name="fuelCode"
                   onChange={props.handleInputChange}
                   required="required"
-                  type="text"
+                  step="0.01"
+                  type="number"
                   value={props.fields.fuelCode}
                 />
               </div>
@@ -54,14 +56,15 @@ const FuelCodeFormDetails = props => (
         <div className="col-sm-6">
           <div className="form-group">
             <label htmlFor="carbon-intensity">Carbon Intensity (gCO<sub>2</sub>e/MJ):
-              <input
-                className="form-control"
+              <InputWithTooltip
+                allowNegative
+                dataNumberToFixed={2}
+                handleInputChange={props.handleInputChange}
                 id="carbon-intensity"
+                min="0"
                 name="carbonIntensity"
-                onChange={props.handleInputChange}
-                required="required"
+                required
                 step="0.01"
-                type="number"
                 value={props.fields.carbonIntensity}
               />
             </label>
@@ -229,7 +232,7 @@ const FuelCodeFormDetails = props => (
                 id="facility-nameplate"
                 name="facilityNameplate"
                 onChange={props.handleInputChange}
-                type="number"
+                type="text"
                 value={props.fields.facilityNameplate}
               />
             </label>

--- a/frontend/src/admin/fuel_codes/components/FuelCodeFormDetails.js
+++ b/frontend/src/admin/fuel_codes/components/FuelCodeFormDetails.js
@@ -32,7 +32,7 @@ const FuelCodeFormDetails = props => (
 
         <div className="col-sm-6">
           <div className="form-group">
-            <label htmlFor="company">Company:
+            <label htmlFor="company">Company (full legal operating name):
               <AutocompletedInput
                 handleInputChange={props.handleInputChange}
                 autocompleteFieldName="fuel_code.company"
@@ -53,7 +53,7 @@ const FuelCodeFormDetails = props => (
       <div className="row">
         <div className="col-sm-6">
           <div className="form-group">
-            <label htmlFor="carbon-intensity">Carbon Intensity:
+            <label htmlFor="carbon-intensity">Carbon Intensity (gCO<sub>2</sub>e/MJ):
               <input
                 className="form-control"
                 id="carbon-intensity"
@@ -166,7 +166,7 @@ const FuelCodeFormDetails = props => (
       <div className="row">
         <div className="col-sm-6">
           <div className="form-group">
-            <label htmlFor="feedstock-location">Feedstock Location:
+            <label htmlFor="feedstock-location">Feedstock Location (e.g. US Central, Manitoba, Japan):
               <AutocompletedInput
                 handleInputChange={props.handleInputChange}
                 autocompleteFieldName="fuel_code.feedstock_location"
@@ -184,7 +184,7 @@ const FuelCodeFormDetails = props => (
         </div>
         <div className="col-sm-6">
           <div className="form-group">
-            <label htmlFor="feedstock-miscellaneous">Feedstock Misc:
+            <label htmlFor="feedstock-miscellaneous">Feedstock Misc (e.g. methane capture, no peat, etc.):
               <AutocompletedInput
                 handleInputChange={props.handleInputChange}
                 autocompleteFieldName="fuel_code.feedstock_misc"
@@ -206,18 +206,18 @@ const FuelCodeFormDetails = props => (
         <div className="col-sm-6">
           <div className="form-group">
             <label htmlFor="facility-location">Fuel Production Facility Location (City, Province/State/Country):
-                <AutocompletedInput
-                  handleInputChange={props.handleInputChange}
-                  autocompleteFieldName="fuel_code.facility_location"
-                  value={props.fields.facilityLocation}
-                  inputProps={
-                    {
-                      required: true,
-                      name: 'facilityLocation',
-                      id: 'facilityLocation'
-                    }
+              <AutocompletedInput
+                handleInputChange={props.handleInputChange}
+                autocompleteFieldName="fuel_code.facility_location"
+                value={props.fields.facilityLocation}
+                inputProps={
+                  {
+                    required: true,
+                    name: 'facilityLocation',
+                    id: 'facilityLocation'
                   }
-                />
+                }
+              />
             </label>
           </div>
         </div>

--- a/frontend/src/admin/fuel_codes/components/FuelCodesTable.js
+++ b/frontend/src/admin/fuel_codes/components/FuelCodesTable.js
@@ -4,14 +4,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import ReactTable from 'react-table';
 import 'react-table/react-table.css';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import moment from 'moment';
 
 import history from '../../../app/History';
 import { FUEL_CODES } from '../../../constants/routes/Admin';
-import StateSavingReactTable from "../../../app/components/StateSavingReactTable";
+import ReactTable from '../../../app/components/StateSavingReactTable';
 
 const FuelCodesTable = (props) => {
   const columns = [{
@@ -87,7 +86,7 @@ const FuelCodesTable = (props) => {
     id: 'facility-loc',
     width: 250
   }, {
-    accessor: item => item.facilityNameplate,
+    accessor: item => (item.facilityNameplate ? item.facilityNameplate.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,') : ''),
     className: 'col-facility-nameplate',
     Header: 'Fuel Production Facility Nameplate Capacity',
     id: 'facility-nameplate',
@@ -152,7 +151,7 @@ const FuelCodesTable = (props) => {
   const filterable = true;
 
   return (
-    <StateSavingReactTable
+    <ReactTable
       statekey="fuel-codes"
       className="searchable"
       columns={columns}

--- a/frontend/styles/FuelCodes.scss
+++ b/frontend/styles/FuelCodes.scss
@@ -41,6 +41,7 @@
   .fuel-code-details {
     div.value {
       font-weight: normal;
+      min-height: 2.5rem;
       padding: 0.5rem 1rem;
     }  
   }

--- a/frontend/styles/FuelCodes.scss
+++ b/frontend/styles/FuelCodes.scss
@@ -49,7 +49,15 @@
 .adjust-tooltip {
   z-index: 99;
 
-  .tooltip-inner, .tooltip-arrow {
-    margin-bottom: 1.5rem;
+  &.adjust-for-facility-nameplate {
+    .tooltip-inner, .tooltip-arrow {
+      margin-bottom: 1.5rem;
+      white-space: normal;
+    }  
+  }
+
+  .tooltip-inner {
+    margin-left: -15rem;
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
#1012 #1022 #1037 #1045 #1046 #1047 #1048 

Adjusted some labels and some validations for Fuel Code

Changelog:
- Added application date as a required field to save draft
- Changed the check the array length for transport modes
- Facility nameplate is now a required field
- Fixed an overlap issue with the tooltip
- Adjust fuel code form labels
- Changed the ordering for Approved fuels to alphabetical
- Fuel Code is now restricted to numbers and decimals
- Carbon Intensity is restricted to 2 decimals
- Commas are automatically added to Nameplate capacity