### PR TITLE
Added a check in both front-end and back-end for the expiry and effective dates

### DIFF
--- a/backend/api/serializers/FuelCode.py
+++ b/backend/api/serializers/FuelCode.py
@@ -106,7 +106,7 @@ class FuelCodeSaveSerializer(serializers.ModelSerializer):
         """
         if data['expiry_date'] < data['effective_date']:
             raise serializers.ValidationError({
-                'invalid': "The expiry date proceeds the effective date"
+                'invalid': "The expiry date precedes the effective date"
             })
 
         return data

--- a/backend/api/serializers/FuelCode.py
+++ b/backend/api/serializers/FuelCode.py
@@ -100,6 +100,17 @@ class FuelCodeSaveSerializer(serializers.ModelSerializer):
         queryset=TransportMode.objects.all()
     )
 
+    def validate(self, data):
+        """
+        Validation to check that the expiry date is after the effective date.
+        """
+        if data['expiry_date'] < data['effective_date']:
+            raise serializers.ValidationError({
+                'invalid': "The expiry date proceeds the effective date"
+            })
+
+        return data
+
     def create(self, validated_data):
         feedstock_modes = validated_data.pop('feedstock_transport_mode')
         fuel_modes = validated_data.pop('fuel_transport_mode')

--- a/frontend/src/admin/fuel_codes/components/FuelCodeDetails.js
+++ b/frontend/src/admin/fuel_codes/components/FuelCodeDetails.js
@@ -125,14 +125,14 @@ const FuelCodeDetails = props => (
         <div className="col-sm-6">
           <div className="form-group">
             <label htmlFor="feedstock-transport-mode">Feedstock Transport Mode
-              <div className="value">{props.item.feedstockTransportMode.join(', ')}</div>
+              <div className="value">{props.item.feedstockTransportMode && props.item.feedstockTransportMode.join(', ')}</div>
             </label>
           </div>
         </div>
         <div className="col-sm-6">
           <div className="form-group">
             <label htmlFor="fuel-transport-mode">Finished Fuel Transport Mode
-              <div className="value">{props.item.fuelTransportMode.join(', ')}</div>
+              <div className="value">{props.item.fuelTransportMode && props.item.fuelTransportMode.join(', ')}</div>
             </label>
           </div>
         </div>

--- a/frontend/src/admin/fuel_codes/components/FuelCodeForm.js
+++ b/frontend/src/admin/fuel_codes/components/FuelCodeForm.js
@@ -51,6 +51,10 @@ class FuelCodeForm extends Component {
       validationMessage.push('Please select a finished fuel transport mode.');
     }
 
+    if (this.props.fields.expiryDate < this.props.fields.effectiveDate) {
+      validationMessage.push('The expiry date proceeds the effective date.');
+    }
+
     return validationMessage;
   }
 

--- a/frontend/src/admin/fuel_codes/components/FuelCodeForm.js
+++ b/frontend/src/admin/fuel_codes/components/FuelCodeForm.js
@@ -52,7 +52,7 @@ class FuelCodeForm extends Component {
     }
 
     if (this.props.fields.expiryDate < this.props.fields.effectiveDate) {
-      validationMessage.push('The expiry date proceeds the effective date.');
+      validationMessage.push('The expiry date precedes the effective date.');
     }
 
     return validationMessage;


### PR DESCRIPTION
#1054

Added an additional validation to make sure that the expiry date is always after the effective date.

Changelog:
- Added a front-end check to make sure the expiry date is after the effective date
- Added a back-end check to make sure the expiry date is after the effective date when creating or updating