### PR TITLE
Reset page number after filtering.

### DIFF
--- a/frontend/src/actions/stateSavingReactTableActions.js
+++ b/frontend/src/actions/stateSavingReactTableActions.js
@@ -6,10 +6,10 @@ const saveTableState = (key, data) => (dispatch) => {
 };
 
 const saveTableStateAction = (key, data) => ({
-  key: key,
-  data: data,
-    name: ReducerTypes.SAVE_TABLE_STATE,
-    type: ActionTypes.SAVE_TABLE_STATE,
+  key,
+  data,
+  name: ReducerTypes.SAVE_TABLE_STATE,
+  type: ActionTypes.SAVE_TABLE_STATE
 });
 
 export default saveTableState;

--- a/frontend/src/app/components/StateSavingReactTable.js
+++ b/frontend/src/app/components/StateSavingReactTable.js
@@ -1,69 +1,69 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import ReactTable from 'react-table';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from "redux";
-import connect from "react-redux/es/connect/connect";
-import saveTableState from "../../actions/stateSavingReactTableActions";
+import { bindActionCreators } from 'redux';
+import connect from 'react-redux/es/connect/connect';
+import saveTableState from '../../actions/stateSavingReactTableActions';
 
 class StateSavingReactTable extends Component {
-
-  constructor(props) {
+  constructor (props) {
     super(props);
 
     this._pageChanged = this._pageChanged.bind(this);
     this._pageSizeChanged = this._pageSizeChanged.bind(this);
     this._sortedChanged = this._sortedChanged.bind(this);
     this._filteredChange = this._filteredChange.bind(this);
-
   }
 
-  _pageSizeChanged(pageSize, pageIndex) {
+  _pageSizeChanged (pageSize, pageIndex) {
     this.props.saveTableState(this.props.stateKey, {
       ...this.props.tableState,
-      pageSize: pageSize,
+      pageSize,
       page: pageIndex
     });
   }
 
-  _pageChanged(pageIndex) {
+  _pageChanged (pageIndex) {
     this.props.saveTableState(this.props.stateKey, {
       ...this.props.tableState,
       page: pageIndex
     });
   }
 
-  _sortedChanged(newSorted, column, shiftKey) {
+  _sortedChanged (newSorted, column, shiftKey) {
     this.props.saveTableState(this.props.stateKey, {
       ...this.props.tableState,
-      sorted: newSorted,
+      sorted: newSorted
     });
   }
 
-  _filteredChange(filtered, column) {
+  _filteredChange (filtered, column) {
     this.props.saveTableState(this.props.stateKey, {
       ...this.props.tableState,
-      filtered: filtered
+      filtered,
+      page: 0 // reset the page number after filtering
     });
   }
 
-  render() {
+  render () {
     if (this.props.saveState) {
-      return <ReactTable
-        page={this.props.tableState.page}
-        pageSize={this.props.tableState.pageSize}
-        sorted={this.props.tableState.sorted}
-        filtered={this.props.tableState.filtered}
-        onPageChange={this._pageChanged}
-        onPageSizeChange={this._pageSizeChanged}
-        onSortedChange={this._sortedChanged}
-        onFilteredChange={this._filteredChange}
-        {...this.props} />;
-    } else {
-      return <ReactTable
-        {...this.props} />;
+      return (
+        <ReactTable
+          page={this.props.tableState.page}
+          pageSize={this.props.tableState.pageSize}
+          sorted={this.props.tableState.sorted}
+          filtered={this.props.tableState.filtered}
+          onPageChange={this._pageChanged}
+          onPageSizeChange={this._pageSizeChanged}
+          onSortedChange={this._sortedChanged}
+          onFilteredChange={this._filteredChange}
+          {...this.props}
+        />
+      );
     }
-  }
 
+    return <ReactTable {...this.props} />;
+  }
 }
 
 StateSavingReactTable.defaultProps = {
@@ -71,32 +71,31 @@ StateSavingReactTable.defaultProps = {
   defaultPageSize: 5,
   defaultSorted: [],
   defaultFiltered: []
-}
+};
 
 StateSavingReactTable.propTypes = {
   stateKey: PropTypes.string.isRequired,
   saveState: PropTypes.bool,
   defaultPageSize: PropTypes.number,
-  defaultSorted: PropTypes.array,
-  defaultFiltered: PropTypes.array,
-  tableState: PropTypes.object.isRequired
-}
+  defaultSorted: PropTypes.arrayOf(PropTypes.shape()),
+  defaultFiltered: PropTypes.arrayOf(PropTypes.shape()),
+  tableState: PropTypes.shape().isRequired,
+  saveTableState: PropTypes.func.isRequired
+};
 
 const mapStateToProps = (state, ownProps) => ({
   tableState:
-    ownProps.stateKey in state.rootReducer.tableState.savedState ?
-      state.rootReducer.tableState.savedState[ownProps.stateKey] : {
+    ownProps.stateKey in state.rootReducer.tableState.savedState
+      ? state.rootReducer.tableState.savedState[ownProps.stateKey] : {
         page: 0,
         pageSize: ownProps.defaultPageSize,
         sorted: ownProps.defaultSorted,
-        filtered: ownProps.defaultFiltered,
+        filtered: ownProps.defaultFiltered
       }
 });
 
 const mapDispatchToProps = dispatch => ({
-  saveTableState: bindActionCreators(saveTableState, dispatch),
+  saveTableState: bindActionCreators(saveTableState, dispatch)
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(StateSavingReactTable);
-
-


### PR DESCRIPTION
Al found a bug where if you go to a page with a table and navigate to the last page, then try to filter, it shows a blank table.

The issue is caused by the page number being higher than the total number of pages.

The fix here is to reset the page number to the first page after filtering, which is the default behaviour for the react tables.