### PR TITLE
Organization ID is now being saved when filtering in credit transactions page

### DIFF
--- a/frontend/src/credit_transfers/CreditTransactionsContainer.js
+++ b/frontend/src/credit_transfers/CreditTransactionsContainer.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import { getCreditTransfersIfNeeded } from '../actions/creditTransfersActions';
 import { getOrganization } from '../actions/organizationActions';
 import { getLoggedInUser } from '../actions/userActions';
+import saveTableState from '../actions/stateSavingReactTableActions';
 import CreditTransactionsPage from './components/CreditTransactionsPage';
 import CREDIT_TRANSACTIONS from '../constants/routes/CreditTransactions';
 
@@ -38,6 +39,18 @@ class CreditTransactionsContainer extends Component {
 
   loadData () {
     this.props.getCreditTransfersIfNeeded();
+
+    if ('credit-transfers' in this.props.savedState &&
+    'filterOrganization' in this.props.savedState['credit-transfers']) {
+      const { filterOrganization } = this.props.savedState['credit-transfers'];
+      if (filterOrganization !== -1) {
+        this.props.getOrganization(filterOrganization);
+
+        this.setState({
+          filterOrganization
+        });
+      }
+    }
   }
 
   _getCreditTransfers () {
@@ -83,6 +96,12 @@ class CreditTransactionsContainer extends Component {
 
     this.setState({
       filterOrganization: organizationId
+    });
+
+    this.props.saveTableState('credit-transfers', {
+      ...this.props.savedState,
+      filterOrganization: organizationId,
+      page: 0
     });
   }
 
@@ -134,7 +153,9 @@ CreditTransactionsContainer.propTypes = {
     organizationBalance: PropTypes.shape({
       validatedCredits: PropTypes.number
     })
-  })
+  }),
+  savedState: PropTypes.shape().isRequired,
+  saveTableState: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
@@ -143,7 +164,8 @@ const mapStateToProps = state => ({
     isFetching: state.rootReducer.creditTransfers.isFetching
   },
   loggedInUser: state.rootReducer.userRequest.loggedInUser,
-  organization: state.rootReducer.organizationRequest.fuelSupplier
+  organization: state.rootReducer.organizationRequest.fuelSupplier,
+  savedState: state.rootReducer.tableState.savedState
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -151,7 +173,8 @@ const mapDispatchToProps = dispatch => ({
     dispatch(getCreditTransfersIfNeeded());
   },
   getLoggedInUser: bindActionCreators(getLoggedInUser, dispatch),
-  getOrganization: bindActionCreators(getOrganization, dispatch)
+  getOrganization: bindActionCreators(getOrganization, dispatch),
+  saveTableState: bindActionCreators(saveTableState, dispatch)
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(CreditTransactionsContainer);

--- a/frontend/src/credit_transfers/CreditTransactionsContainer.js
+++ b/frontend/src/credit_transfers/CreditTransactionsContainer.js
@@ -40,10 +40,10 @@ class CreditTransactionsContainer extends Component {
   loadData () {
     this.props.getCreditTransfersIfNeeded();
 
-    if ('credit-transfers' in this.props.savedState &&
-    'filterOrganization' in this.props.savedState['credit-transfers']) {
+    if ('credit-transfers' in this.props.savedState) {
       const { filterOrganization } = this.props.savedState['credit-transfers'];
-      if (filterOrganization !== -1) {
+
+      if (filterOrganization && filterOrganization !== -1) {
         this.props.getOrganization(filterOrganization);
 
         this.setState({

--- a/frontend/src/credit_transfers/components/CreditTransactionsPage.js
+++ b/frontend/src/credit_transfers/components/CreditTransactionsPage.js
@@ -64,6 +64,7 @@ const CreditTransactionsPage = (props) => {
                     const organizationId = parseInt(event.target.value, 10);
                     props.selectOrganization(organizationId);
                   }}
+                  value={props.organization.id}
                 >
                   <option value="-1">All Organizations</option>
                   {props.organizations.map(organization =>

--- a/frontend/src/credit_transfers/components/CreditTransferSigningHistory.js
+++ b/frontend/src/credit_transfers/components/CreditTransferSigningHistory.js
@@ -71,8 +71,8 @@ class CreditTransferSigningHistory extends Component {
         roleDisplay &&
           <span>
             on {moment(history.createTimestamp).format('LL')} by
-            <strong> {history.user.firstName} {history.user.lastName},</strong>
-            <strong> {roleDisplay} </strong> under the
+            <strong> {history.user.firstName} {history.user.lastName}</strong>
+            <strong>{roleDisplay && `, ${roleDisplay}`} </strong> under the
           </span>
         }
         <em> Greenhouse Gas Reduction (Renewable and Low Carbon Fuel Requirements) Act</em>
@@ -81,11 +81,15 @@ class CreditTransferSigningHistory extends Component {
   }
 
   _renderDeclined (history) {
-    let roleDisplay = history.userRole.description;
+    let roleDisplay = null;
 
-    if (history.userRole.name === 'GovDeputyDirector' ||
-        history.userRole.name === 'GovDirector') {
-      roleDisplay = roleDisplay.replace('Government ', '');
+    if (history.userRole) {
+      roleDisplay = history.userRole.description;
+
+      if (history.userRole.name === 'GovDeputyDirector' ||
+      history.userRole.name === 'GovDirector') {
+        roleDisplay = roleDisplay.replace('Government ', '');
+      }
     }
 
     // if "recorded" status was found, this means this credit trade
@@ -104,8 +108,8 @@ class CreditTransferSigningHistory extends Component {
         {!CreditTransferSigningHistory.recordedFound(this.props.history) &&
           <span>
             on {moment(history.createTimestamp).format('LL')} by
-            <strong> {history.user.firstName} {history.user.lastName},</strong>
-            <strong> {roleDisplay} </strong> under the
+            <strong> {history.user.firstName} {history.user.lastName}</strong>
+            <strong>{roleDisplay && `, ${roleDisplay}`} </strong> under the
           </span>
         }
         <em> Greenhouse Gas Reduction (Renewable and Low Carbon Fuel Requirements) Act</em>

--- a/frontend/src/reducers/tableStateReducer.js
+++ b/frontend/src/reducers/tableStateReducer.js
@@ -1,19 +1,22 @@
-import ActionTypes from "../constants/actionTypes/Tables";
+import ActionTypes from '../constants/actionTypes/Tables';
 
 const tableState = (state = {
   savedState: {
-  },
+  }
 }, action) => {
   switch (action.type) {
-    case ActionTypes.SAVE_TABLE_STATE:
-      let newState =  {
+    case ActionTypes.SAVE_TABLE_STATE: {
+      const newState = {
         ...state,
         savedState: {
-          ...state.savedState,
+          ...state.savedState
         }
       };
+
       newState.savedState[action.key] = action.data;
+
       return newState;
+    }
     default:
       return state;
   }


### PR DESCRIPTION
#1133 

I piggy backed on the credit-transfers state, as it's sharing the variables anyway.

Changelog:
- Automatically save the organization in the credit-transfers state when selecting an organization
- Auto select organization in drop-down in credit transactions
- Fixed a potential issue in the credit transaction history when something is declined and the record didn't have any roles attached to it (old records)
- ESLint fixes