### PR TITLE
Token generation

### DIFF
--- a/backend/api/migrations/0128_clean_filenames.py
+++ b/backend/api/migrations/0128_clean_filenames.py
@@ -1,0 +1,35 @@
+from django.db import migrations
+from django.db.migrations import RunPython
+
+
+def clean_filenames(apps, schema_editor):
+    """
+    Removes query strings from urls
+    """
+    db_alias = schema_editor.connection.alias
+
+    attachments = apps.get_model('api', 'DocumentFileAttachment')
+
+    rows = attachments.objects.using(db_alias).filter(
+        url__contains="?"
+    )
+
+    for row in rows:
+        row.url = row.url.split('?')[0]
+        row.save()
+
+
+class Migration(migrations.Migration):
+    """
+    Remove query strings from all stored attachments
+    """
+    dependencies = [
+        ('api', '0127_add_petroleum_carbon_intensity_categories'),
+    ]
+
+    operations = [
+        RunPython(
+            clean_filenames,
+            None
+        )
+    ]

--- a/backend/api/services/DocumentService.py
+++ b/backend/api/services/DocumentService.py
@@ -82,12 +82,8 @@ class DocumentService(object):
         object_names = list(map(DocumentService.get_filename, attachments))
         to_delete = []
 
-        # print('list of object names: ' + '|'.join([o for o in object_names]))
-        # print('list of minio objects: ' + '|'.join([o.object_name for o in objects]))
-
         for o in objects:
             if not o.is_dir:
-                print('looking for ' + o.object_name + ' in ' + '|'.join(object_names))
                 if o.object_name not in object_names:
                     print('deleting: {} since it is not referenced'.format(o.object_name))
                     to_delete.append(o.object_name)

--- a/frontend/src/secure_file_submission/SecureFileSubmissionAddContainer.js
+++ b/frontend/src/secure_file_submission/SecureFileSubmissionAddContainer.js
@@ -222,7 +222,7 @@ class SecureFileSubmissionAddContainer extends Component {
               filename: file.name,
               mimeType: file.type,
               size: file.size,
-              url: response.data.get
+              url: response.data.get.split(/[?#]/)[0]
             });
             resolve();
           });

--- a/frontend/src/secure_file_submission/SecureFileSubmissionEditContainer.js
+++ b/frontend/src/secure_file_submission/SecureFileSubmissionEditContainer.js
@@ -262,7 +262,7 @@ class SecureFileSubmissionEditContainer extends Component {
               filename: file.name,
               mimeType: file.type,
               size: file.size,
-              url: response.data.get
+              url: response.data.get.split(/[?#]/)[0]
             });
             resolve();
           });


### PR DESCRIPTION
# Changelog
 - Migration to strip query parameters from urls in the database
 - Backend generates a fresh token on each download request
 - Don't upload the token as part of the attachment creation

Trello card 1355
