### PR TITLE
Government roles should only show up when creating IDIR users

### DIFF
--- a/frontend/src/admin/users/components/UserFormDetails.js
+++ b/frontend/src/admin/users/components/UserFormDetails.js
@@ -264,7 +264,13 @@ const UserFormDetails = props => (
           </div>
 
           <div className="row roles" id="user-roles">
-            {props.roles.items.map(role => (
+            {props.roles.items.filter((role) => {
+              if (document.location.pathname.indexOf('/admin/users/') >= 0) {
+                return role.isGovernmentRole;
+              }
+
+              return !role.isGovernmentRole;
+            }).map(role => (
               <div className="col-sm-4 checkbox-group" key={role.id}>
                 <CheckBox
                   addToFields={props.addToFields}


### PR DESCRIPTION
#1162

I think we accidentally removed the auto-filter. This should add back the logic to show the roles based on the user being created. 