### PR TITLE
Frontend Refactoring

### DIFF
--- a/frontend/src/compliance_reporting/ComplianceReportIntroContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportIntroContainer.js
@@ -18,6 +18,7 @@ class ComplianceReportIntroContainer extends Component {
         edit={this.props.edit}
         loggedInUser={this.props.loggedInUser}
         title="Compliance Reporting"
+        saving={this.props.saving}
       />
     );
   }
@@ -29,7 +30,8 @@ ComplianceReportIntroContainer.defaultProps = {
 ComplianceReportIntroContainer.propTypes = {
   loggedInUser: PropTypes.shape().isRequired,
   period: PropTypes.string.isRequired,
-  edit: PropTypes.bool.isRequired
+  edit: PropTypes.bool.isRequired,
+  saving: PropTypes.bool.isRequired
 };
 
 const mapStateToProps = state => ({

--- a/frontend/src/compliance_reporting/ComplianceReportIntroContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportIntroContainer.js
@@ -10,33 +10,12 @@ import { connect } from 'react-redux';
 import ComplianceReportIntro from './components/ComplianceReportIntro';
 
 class ComplianceReportIntroContainer extends Component {
-  constructor () {
-    super();
-
-    if (document.location.pathname.indexOf('/edit/') >= 0) {
-      this.edit = true;
-    } else {
-      this.edit = false;
-    }
-  }
-
-  componentDidMount () {
-  }
-
   render () {
-    const { id } = this.props.match.params;
-    let { period } = this.props.match.params;
-
-    if (!period) {
-      period = `${new Date().getFullYear() - 1}`;
-    }
-
     return (
       <ComplianceReportIntro
         activeTab="intro"
-        compliancePeriod={period}
-        edit={this.edit}
-        id={id}
+        period={this.props.period}
+        edit={this.props.edit}
         loggedInUser={this.props.loggedInUser}
         title="Compliance Reporting"
       />
@@ -49,19 +28,12 @@ ComplianceReportIntroContainer.defaultProps = {
 
 ComplianceReportIntroContainer.propTypes = {
   loggedInUser: PropTypes.shape().isRequired,
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      id: PropTypes.string,
-      period: PropTypes.string
-    }).isRequired
-  }).isRequired
+  period: PropTypes.string.isRequired,
+  edit: PropTypes.bool.isRequired
 };
 
 const mapStateToProps = state => ({
   loggedInUser: state.rootReducer.userRequest.loggedInUser
 });
 
-const mapDispatchToProps = dispatch => ({
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(ComplianceReportIntroContainer);
+export default connect(mapStateToProps, null)(ComplianceReportIntroContainer);

--- a/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
@@ -1,0 +1,273 @@
+/*
+ * Container component
+ * All data handling & manipulation should be handled here.
+ */
+
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
+import {Route, Switch, withRouter} from 'react-router';
+import {toastr as reduxToastr} from 'react-redux-toastr';
+import PropTypes from 'prop-types';
+
+import {complianceReporting} from '../actions/complianceReporting';
+import COMPLIANCE_REPORTING from '../constants/routes/ComplianceReporting';
+import ScheduleAContainer from "./ScheduleAContainer";
+import ScheduleBContainer from "./ScheduleBContainer";
+import ScheduleCContainer from "./ScheduleCContainer";
+import ScheduleDContainer from "./ScheduleDContainer";
+import withReferenceData from "../utils/reference_data_support";
+import ComplianceReportIntroContainer from "./ComplianceReportIntroContainer";
+import Loading from "../app/components/Loading";
+import ScheduleTabs from "./components/ScheduleTabs";
+import Modal from "../app/components/Modal";
+import history from "../app/History";
+import toastr from "../utils/toastr";
+import autosaved from "../utils/autosave_support";
+
+class ComplianceReportingEditContainer extends Component {
+
+  constructor(props) {
+    super(props);
+    this.tabComponent = Loading;
+    let {tab} = props.match.params;
+    this.tabComponent = ComplianceReportingEditContainer._componentForTabName(tab);
+
+    this.edit = document.location.pathname.indexOf('/edit/') >= 0
+    this._updateScheduleState = this._updateScheduleState.bind(this);
+    this._updateAutosaveState = this._updateAutosaveState.bind(this);
+    this.loadData = this.loadData.bind(this);
+
+    this.state = {
+      schedules: {},
+      autosaveState: {}
+    };
+  }
+
+  componentDidMount() {
+    if (this.edit) {
+      this.loadData();
+    }
+  }
+
+  loadData() {
+    this.props.getComplianceReport(this.props.match.params.id);
+  }
+
+  static _componentForTabName(tab) {
+
+    let TabComponent;
+
+    switch (tab) {
+
+      case 'schedule-a':
+        TabComponent = withReferenceData()(ScheduleAContainer);
+        break;
+
+      case 'schedule-b':
+        TabComponent = withReferenceData()(ScheduleBContainer);
+        break;
+
+      case 'schedule-c':
+        TabComponent = withReferenceData()(ScheduleCContainer);
+        break;
+
+      case 'schedule-d':
+        TabComponent = withReferenceData()(ScheduleDContainer);
+        break;
+
+      case 'intro':
+      default:
+        TabComponent = ComplianceReportIntroContainer;
+        break;
+    }
+    return TabComponent;
+  }
+
+  _updateScheduleState(mergedState) {
+    let {schedules} = this.state;
+
+    this.setState({
+      schedules: {
+        ...schedules,
+        ...mergedState
+      }
+    });
+
+  }
+
+  _handleDelete() {
+    if (this.edit) {
+      this.props.deleteComplianceReport({id: this.props.match.params.id});
+    }
+    history.push(COMPLIANCE_REPORTING.LIST);
+    toastr.complianceReporting('Cancelled');
+    this.props.invalidateAutosaved();
+  }
+
+  _handleSubmit() {
+
+    if (!this.edit) {
+      // creating new
+      const payload = {
+        status: 'Draft',
+        type: 'Compliance Report',
+        compliancePeriod: this.props.match.params.period,
+        ...this.state.schedules
+      };
+
+      this.props.createComplianceReport(payload);
+    } else {
+      // patch existing
+      const payload = {
+        ...this.state.schedules
+      };
+      this.props.updateComplianceReport({
+        id: this.props.match.params.id,
+        state: payload,
+        patch: true
+      });
+    }
+  }
+
+
+  componentWillReceiveProps(nextProps, nextContext) {
+
+    let {tab} = nextProps.match.params;
+    if (tab !== this.props.match.params.tab) {
+      this.tabComponent = ComplianceReportingEditContainer._componentForTabName(tab);
+    }
+
+    if (this.props.saving && !nextProps.saving) {
+      reduxToastr.success('Autosaved');
+    }
+
+    if (this.props.complianceReporting.isCreating && !nextProps.complianceReporting.isCreating) {
+      if (!nextProps.complianceReporting.success) {
+        reduxToastr.error('Error saving');
+      } else {
+        history.push(COMPLIANCE_REPORTING.LIST);
+        toastr.complianceReporting('Draft');
+        this.props.invalidateAutosaved();
+      }
+      return;
+    }
+
+    if (this.props.complianceReporting.isUpdating && !nextProps.complianceReporting.isUpdating) {
+      if (!nextProps.complianceReporting.success) {
+        reduxToastr.error('Error saving');
+      } else {
+        toastr.complianceReporting('Draft');
+        this.props.invalidateAutosaved();
+      }
+    }
+
+
+  }
+
+  _updateAutosaveState(tab, state) {
+    const autosaveState = {
+      ...this.state.autosaveState,
+      tab: state
+    };
+    this.setState({
+      autosaveState
+    });
+
+    this.props.updateStateToSave(autosaveState);
+  }
+
+  render() {
+
+    const TabComponent = this.tabComponent;
+    let {tab, id, period} = this.props.match.params;
+
+    if (!period) {
+      period = `${new Date().getFullYear() - 1}`;
+    }
+
+    if (this.props.complianceReporting.isGetting) {
+      return (<Loading/>);
+    }
+
+    if (this.edit && this.props.complianceReporting.item) {
+      period = this.props.complianceReporting.item.compliancePeriod.description;
+    }
+
+    return ([
+      <ScheduleTabs
+        active={tab}
+        compliancePeriod={period}
+        edit={this.edit}
+        id={id}
+        key="nav"
+      />,
+      <TabComponent
+        edit={this.edit}
+        key="tab-component"
+        period={period}
+        id={id}
+        create={!this.edit}
+        complianceReport={this.props.complianceReporting.item}
+        updateScheduleState={this._updateScheduleState}
+        updateAutosaveState={(state) => {
+          this._updateAutosaveState(tab, state)
+        }}/>,
+
+      <Modal
+        handleSubmit={event => this._handleSubmit(event)}
+        id="confirmSubmit"
+        key="confirmSubmit"
+      >
+        Are you sure you want to save this schedule?
+      </Modal>,
+      <Modal
+        handleSubmit={event => this._handleDelete(event)}
+        id="confirmDelete"
+        key="confirmDelete"
+      >
+        Are you sure you want to delete this draft?
+      </Modal>
+    ]);
+
+  };
+}
+
+ComplianceReportingEditContainer.propTypes = {
+  invalidateAutosaved: PropTypes.func.isRequired,
+  loadedState: PropTypes.any,
+  saving: PropTypes.bool,
+  updateStateToSave: PropTypes.func.isRequired
+};
+
+const mapDispatchToProps = {
+  createComplianceReport: complianceReporting.create,
+  updateComplianceReport: complianceReporting.update,
+  deleteComplianceReport: complianceReporting.remove,
+  getComplianceReport: complianceReporting.get
+};
+
+const mapStateToProps = state => ({
+  complianceReporting: {
+    isGetting: state.rootReducer.complianceReporting.isGetting,
+    isFinding: state.rootReducer.complianceReporting.isFinding,
+    isCreating: state.rootReducer.complianceReporting.isCreating,
+    isUpdating: state.rootReducer.complianceReporting.isUpdating,
+    success: state.rootReducer.complianceReporting.success,
+    item: state.rootReducer.complianceReporting.item,
+    errorMessage: state.rootReducer.complianceReporting.errorMessage
+  },
+  referenceData: {
+    approvedFuels: state.rootReducer.referenceData.data.approvedFuels,
+    isFetching: state.rootReducer.referenceData.isFetching
+  }
+});
+
+
+const config = {
+  key: 'unsaved',
+  version: 2,
+  name: 'compliance-report'
+};
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(autosaved(config)(ComplianceReportingEditContainer));

--- a/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
@@ -23,6 +23,7 @@ import Modal from "../app/components/Modal";
 import history from "../app/History";
 import toastr from "../utils/toastr";
 import autosaved from "../utils/autosave_support";
+import AutosaveNotifier from "./components/AutosaveNotifier";
 
 class ComplianceReportingEditContainer extends Component {
 
@@ -137,10 +138,6 @@ class ComplianceReportingEditContainer extends Component {
       this.tabComponent = ComplianceReportingEditContainer._componentForTabName(tab);
     }
 
-    if (this.props.saving && !nextProps.saving) {
-      reduxToastr.success('Autosaved');
-    }
-
     if (this.props.complianceReporting.isCreating && !nextProps.complianceReporting.isCreating) {
       if (!nextProps.complianceReporting.success) {
         reduxToastr.error('Error saving');
@@ -156,6 +153,7 @@ class ComplianceReportingEditContainer extends Component {
       if (!nextProps.complianceReporting.success) {
         reduxToastr.error('Error saving');
       } else {
+        history.push(COMPLIANCE_REPORTING.LIST);
         toastr.complianceReporting('Draft');
         this.props.invalidateAutosaved();
       }
@@ -189,8 +187,13 @@ class ComplianceReportingEditContainer extends Component {
       return (<Loading/>);
     }
 
-    if (this.edit && this.props.complianceReporting.item) {
-      period = this.props.complianceReporting.item.compliancePeriod.description;
+    if (this.edit) {
+      if (this.props.complianceReporting.item) {
+        period = this.props.complianceReporting.item.compliancePeriod.description;
+        if (!period) {
+          return (<Loading/>);
+        }
+      }
     }
 
     return ([
@@ -209,9 +212,11 @@ class ComplianceReportingEditContainer extends Component {
         create={!this.edit}
         complianceReport={this.props.complianceReporting.item}
         updateScheduleState={this._updateScheduleState}
+        saving={this.props.saving}
         updateAutosaveState={(state) => {
           this._updateAutosaveState(tab, state)
-        }}/>,
+        }}
+      />,
 
       <Modal
         handleSubmit={event => this._handleSubmit(event)}
@@ -229,45 +234,50 @@ class ComplianceReportingEditContainer extends Component {
       </Modal>
     ]);
 
-  };
+  }
+  ;
 }
 
-ComplianceReportingEditContainer.propTypes = {
+ComplianceReportingEditContainer
+  .propTypes = {
   invalidateAutosaved: PropTypes.func.isRequired,
   loadedState: PropTypes.any,
-  saving: PropTypes.bool,
+  saving: PropTypes.bool.isRequired,
   updateStateToSave: PropTypes.func.isRequired
 };
 
-const mapDispatchToProps = {
-  createComplianceReport: complianceReporting.create,
-  updateComplianceReport: complianceReporting.update,
-  deleteComplianceReport: complianceReporting.remove,
-  getComplianceReport: complianceReporting.get
-};
+const
+  mapDispatchToProps = {
+    createComplianceReport: complianceReporting.create,
+    updateComplianceReport: complianceReporting.update,
+    deleteComplianceReport: complianceReporting.remove,
+    getComplianceReport: complianceReporting.get
+  };
 
-const mapStateToProps = state => ({
-  complianceReporting: {
-    isGetting: state.rootReducer.complianceReporting.isGetting,
-    isFinding: state.rootReducer.complianceReporting.isFinding,
-    isCreating: state.rootReducer.complianceReporting.isCreating,
-    isUpdating: state.rootReducer.complianceReporting.isUpdating,
-    success: state.rootReducer.complianceReporting.success,
-    item: state.rootReducer.complianceReporting.item,
-    errorMessage: state.rootReducer.complianceReporting.errorMessage
-  },
-  referenceData: {
-    approvedFuels: state.rootReducer.referenceData.data.approvedFuels,
-    isFetching: state.rootReducer.referenceData.isFetching
-  }
-});
+const
+  mapStateToProps = state => ({
+    complianceReporting: {
+      isGetting: state.rootReducer.complianceReporting.isGetting,
+      isFinding: state.rootReducer.complianceReporting.isFinding,
+      isCreating: state.rootReducer.complianceReporting.isCreating,
+      isUpdating: state.rootReducer.complianceReporting.isUpdating,
+      success: state.rootReducer.complianceReporting.success,
+      item: state.rootReducer.complianceReporting.item,
+      errorMessage: state.rootReducer.complianceReporting.errorMessage
+    },
+    referenceData: {
+      approvedFuels: state.rootReducer.referenceData.data.approvedFuels,
+      isFetching: state.rootReducer.referenceData.isFetching
+    }
+  });
 
 
-const config = {
-  key: 'unsaved',
-  version: 2,
-  name: 'compliance-report'
-};
+const
+  config = {
+    key: 'unsaved',
+    version: 2,
+    name: 'compliance-report'
+  };
 
 
 export default connect(mapStateToProps, mapDispatchToProps)(autosaved(config)(ComplianceReportingEditContainer));

--- a/frontend/src/compliance_reporting/ScheduleAContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleAContainer.js
@@ -69,7 +69,6 @@ class ScheduleAContainer extends Component {
     this._addRow = this._addRow.bind(this);
     this._calculateTotal = this._calculateTotal.bind(this);
     this._handleCellsChanged = this._handleCellsChanged.bind(this);
-    this._handleSubmit = this._handleSubmit.bind(this);
   }
 
   componentDidMount() {
@@ -283,6 +282,7 @@ class ScheduleAContainer extends Component {
         scheduleType="schedule-a"
         title="Schedule A - Notional Transfers of Renewable Fuel"
         totals={this.state.totals}
+        saving={this.props.saving}
       >
         <p>
           Under section 5.1 of the Act, a fuel supplier may transfer renewable fuel supplied in
@@ -320,7 +320,8 @@ ScheduleAContainer.propTypes = {
   create: PropTypes.bool.isRequired,
   edit: PropTypes.bool.isRequired,
   period: PropTypes.string.isRequired,
-  updateScheduleState: PropTypes.func.isRequired
+  updateScheduleState: PropTypes.func.isRequired,
+  saving: PropTypes.bool.isRequired,
 
 };
 

--- a/frontend/src/compliance_reporting/ScheduleAContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleAContainer.js
@@ -3,23 +3,23 @@
  * All data handling & manipulation should be handled here.
  */
 
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { fuelClasses } from '../actions/fuelClasses';
-import { notionalTransferTypes } from '../actions/notionalTransferTypes';
+import {fuelClasses} from '../actions/fuelClasses';
+import {notionalTransferTypes} from '../actions/notionalTransferTypes';
 import Modal from '../app/components/Modal';
 import Input from './components/Input';
 import OrganizationAutocomplete from './components/OrganizationAutocomplete';
 import Select from './components/Select';
 import SchedulesPage from './components/SchedulesPage';
 import ScheduleTabs from './components/ScheduleTabs';
-import { getQuantity } from '../utils/functions';
-import { SCHEDULE_A } from '../constants/schedules/scheduleColumns';
+import {getQuantity} from '../utils/functions';
+import {SCHEDULE_A} from '../constants/schedules/scheduleColumns';
 
 class ScheduleAContainer extends Component {
-  static addHeaders () {
+  static addHeaders() {
     return {
       grid: [
         [{
@@ -60,17 +60,11 @@ class ScheduleAContainer extends Component {
     };
   }
 
-  constructor (props) {
+  constructor(props) {
     super(props);
 
     this.state = ScheduleAContainer.addHeaders();
     this.rowNumber = 1;
-
-    if (document.location.pathname.indexOf('/edit/') >= 0) {
-      this.edit = true;
-    } else {
-      this.edit = false;
-    }
 
     this._addRow = this._addRow.bind(this);
     this._calculateTotal = this._calculateTotal.bind(this);
@@ -78,14 +72,37 @@ class ScheduleAContainer extends Component {
     this._handleSubmit = this._handleSubmit.bind(this);
   }
 
-  componentDidMount () {
+  componentDidMount() {
     this.props.loadFuelClasses();
     this.props.loadNotionalTransferTypes();
-    this._addRow(5);
+
+    if (this.props.loadedState) {
+      //this.restoreFromAutosaved();
+    } else if (this.props.create || !this.props.complianceReport.scheduleA) {
+      this._addRow(5);
+    } else {
+      this.setState(ScheduleAContainer.addHeaders());
+      this.rowNumber = 1;
+      this._addRow(this.props.complianceReport.scheduleA.records.length);
+
+      for (let i = 0; i < this.props.complianceReport.scheduleA.records.length; i += 1) {
+        const {grid} = this.state;
+        const record = this.props.complianceReport.scheduleA.records[i];
+
+        grid[1 + i][SCHEDULE_A.LEGAL_NAME].value = record.tradingPartner;
+        grid[1 + i][SCHEDULE_A.POSTAL_ADDRESS].value = record.postalAddress;
+        grid[1 + i][SCHEDULE_A.FUEL_CLASS].value = record.fuelClass;
+        grid[1 + i][SCHEDULE_A.TRANSFER_TYPE].value = record.transferType;
+        grid[1 + i][SCHEDULE_A.QUANTITY].value = record.quantity;
+        this.setState({grid});
+        this._calculateTotal(grid);
+      }
+
+    }
   }
 
-  _addRow (numberOfRows = 1) {
-    const { grid } = this.state;
+  _addRow(numberOfRows = 1) {
+    const {grid} = this.state;
 
     for (let x = 0; x < numberOfRows; x += 1) {
       grid.push([{
@@ -124,7 +141,7 @@ class ScheduleAContainer extends Component {
         className: 'number',
         dataEditor: Input,
         valueViewer: (props) => {
-          const { value } = props;
+          const {value} = props;
           return <span>{value.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,')}</span>;
         }
       }]);
@@ -137,9 +154,8 @@ class ScheduleAContainer extends Component {
     });
   }
 
-  _calculateTotal (grid) {
-    let { totals } = this.state;
-    totals = {
+  _calculateTotal(grid) {
+    let totals = {
       diesel: {
         received: 0,
         transferred: 0
@@ -175,7 +191,7 @@ class ScheduleAContainer extends Component {
     });
   }
 
-  _handleCellsChanged (changes, addition = null) {
+  _handleCellsChanged(changes, addition = null) {
     const grid = this.state.grid.map(row => [...row]);
 
     changes.forEach((change) => {
@@ -213,33 +229,55 @@ class ScheduleAContainer extends Component {
       grid
     });
 
+    this._gridStateToPayload({
+      grid
+    });
+
     this._calculateTotal(grid);
   }
 
-  _handleSubmit () {
-    console.log(this.state.grid);
-  }
 
-  render () {
-    const { id } = this.props.match.params;
-    let { period } = this.props.match.params;
+  _gridStateToPayload(state) {
 
-    if (!period) {
-      period = `${new Date().getFullYear() - 1}`;
+    const startingRow = 1;
+
+    let records = [];
+
+    for (let i = startingRow; i < state.grid.length; i += 1) {
+
+
+      const row = state.grid[i];
+      const record = {
+        tradingPartner: row[SCHEDULE_A.LEGAL_NAME].value,
+        postalAddress: row[SCHEDULE_A.POSTAL_ADDRESS].value,
+        fuelClass: row[SCHEDULE_A.FUEL_CLASS].value,
+        quantity: row[SCHEDULE_A.QUANTITY].value,
+        transferType: row[SCHEDULE_A.TRANSFER_TYPE].value
+      };
+
+
+      const rowIsEmpty = !record.tradingPartner || !record.postalAddress ||
+        !record.fuelClass || !record.quantity || !record.transferType;
+
+      if (!rowIsEmpty) {
+        records.push(record);
+      }
     }
 
+    this.props.updateScheduleState({
+      scheduleA: {
+        records
+      }
+    });
+
+  }
+
+  render() {
     return ([
-      <ScheduleTabs
-        active="schedule-a"
-        compliancePeriod={period}
-        edit={this.edit}
-        id={id}
-        key="nav"
-      />,
       <SchedulesPage
         addRow={this._addRow}
         data={this.state.grid}
-        edit={this.edit}
+        edit={this.props.edit}
         handleCellsChanged={this._handleCellsChanged}
         key="schedules"
         scheduleType="schedule-a"
@@ -255,25 +293,17 @@ class ScheduleAContainer extends Component {
         <p>
           For each fuel supplier that you notionally transferred fuel to, or notionally received
           fuel from, you must report the fuel supplier name, address, contact information and the
-          total volumes notionally transferred to, and/or received from that supplier.  Volumes
+          total volumes notionally transferred to, and/or received from that supplier. Volumes
           &quot;transferred to&quot; are those volumes notionally transferred by you to another
-          supplier listed in the Schedule.  Volumes &quot;received from&quot; are those volumes
+          supplier listed in the Schedule. Volumes &quot;received from&quot; are those volumes
           notionally received by you from another supplier listed in the Schedule.
         </p>
-      </SchedulesPage>,
-      <Modal
-        handleSubmit={event => this._handleSubmit(event)}
-        id="confirmSubmit"
-        key="confirmSubmit"
-      >
-        Are you sure you want to save this schedule?
-      </Modal>
+      </SchedulesPage>
     ]);
   }
 }
 
-ScheduleAContainer.defaultProps = {
-};
+ScheduleAContainer.defaultProps = {};
 
 ScheduleAContainer.propTypes = {
   fuelClasses: PropTypes.shape({
@@ -282,16 +312,16 @@ ScheduleAContainer.propTypes = {
   }).isRequired,
   loadFuelClasses: PropTypes.func.isRequired,
   loadNotionalTransferTypes: PropTypes.func.isRequired,
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      id: PropTypes.string,
-      period: PropTypes.string
-    }).isRequired
-  }).isRequired,
   notionalTransferTypes: PropTypes.shape({
     isFetching: PropTypes.bool,
     items: PropTypes.arrayOf(PropTypes.shape())
-  }).isRequired
+  }).isRequired,
+  complianceReport: PropTypes.object,
+  create: PropTypes.bool.isRequired,
+  edit: PropTypes.bool.isRequired,
+  period: PropTypes.string.isRequired,
+  updateScheduleState: PropTypes.func.isRequired
+
 };
 
 const mapStateToProps = state => ({

--- a/frontend/src/compliance_reporting/ScheduleBContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleBContainer.js
@@ -214,20 +214,6 @@ class ScheduleBContainer extends Component {
     this.state = ScheduleBContainer.addHeaders();
     this.rowNumber = 1;
 
-    if (document.location.pathname.indexOf('/edit/') >= 0) {
-      this.edit = true;
-    } else {
-      this.edit = false;
-    }
-
-    let { period } = this.props.match.params;
-
-    if (!period) {
-      period = `${new Date().getFullYear() - 1}`;
-    }
-
-    this.period = period;
-
     this.fuelCodes = [];
     this.creditCalculationValues = [];
 
@@ -685,43 +671,17 @@ class ScheduleBContainer extends Component {
   }
 
   render () {
-    if (!this.props.referenceData ||
-    !this.props.referenceData.approvedFuels) {
-      return <Loading />;
-    }
-
-    const { id } = this.props.match.params;
-    let { period } = this.props.match.params;
-
-    if (!period) {
-      period = `${new Date().getFullYear() - 1}`;
-    }
-
     return ([
-      <ScheduleTabs
-        active="schedule-b"
-        compliancePeriod={period}
-        edit={this.edit}
-        id={id}
-        key="nav"
-      />,
       <SchedulesPage
         addRow={this._addRow}
         data={this.state.grid}
-        edit={this.edit}
+        edit={this.props.edit}
         handleCellsChanged={this._handleCellsChanged}
         key="schedules"
         scheduleType="schedule-b"
         title="Schedule B - Part 3 Fuel Supply"
         totals={this.state.totals}
-      />,
-      <Modal
-        handleSubmit={event => this._handleSubmit(event)}
-        id="confirmSubmit"
-        key="confirmSubmit"
-      >
-        Are you sure you want to save this schedule?
-      </Modal>
+      />
     ]);
   }
 }
@@ -755,15 +715,11 @@ ScheduleBContainer.propTypes = {
   compliancePeriods: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   getCompliancePeriods: PropTypes.func.isRequired,
   getCreditCalculation: PropTypes.func.isRequired,
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      id: PropTypes.string,
-      period: PropTypes.string
-    }).isRequired
-  }).isRequired,
   referenceData: PropTypes.shape({
     approvedFuels: PropTypes.arrayOf(PropTypes.shape)
-  }).isRequired
+  }).isRequired,
+  edit: PropTypes.bool.isRequired,
+  period: PropTypes.string.isRequired
 };
 
 const mapStateToProps = state => ({

--- a/frontend/src/compliance_reporting/ScheduleBContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleBContainer.js
@@ -681,6 +681,7 @@ class ScheduleBContainer extends Component {
         scheduleType="schedule-b"
         title="Schedule B - Part 3 Fuel Supply"
         totals={this.state.totals}
+        saving={this.props.saving}
       />
     ]);
   }
@@ -719,7 +720,9 @@ ScheduleBContainer.propTypes = {
     approvedFuels: PropTypes.arrayOf(PropTypes.shape)
   }).isRequired,
   edit: PropTypes.bool.isRequired,
-  period: PropTypes.string.isRequired
+  period: PropTypes.string.isRequired,
+  saving: PropTypes.bool.isRequired,
+
 };
 
 const mapStateToProps = state => ({

--- a/frontend/src/compliance_reporting/ScheduleCContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleCContainer.js
@@ -3,28 +3,19 @@
  * All data handling & manipulation should be handled here.
  */
 
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { toastr as reduxToastr } from 'react-redux-toastr';
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { complianceReporting } from '../actions/complianceReporting';
-import { expectedUses } from '../actions/expectedUses';
-import Loading from '../app/components/Loading';
-import Modal from '../app/components/Modal';
+import {expectedUses} from '../actions/expectedUses';
 import Input from './components/Input';
 import Select from './components/Select';
 import SchedulesPage from './components/SchedulesPage';
-import ScheduleTabs from './components/ScheduleTabs';
-import { SCHEDULE_C } from '../constants/schedules/scheduleColumns';
-import COMPLIANCE_REPORTING from '../constants/routes/ComplianceReporting';
-import history from '../app/History';
-import toastr from '../utils/toastr';
-import { getQuantity } from '../utils/functions';
-import autosaved from '../utils/autosave_support';
+import {SCHEDULE_C} from '../constants/schedules/scheduleColumns';
+import {getQuantity} from '../utils/functions';
 
 class ScheduleCContainer extends Component {
-  static addHeaders () {
+  static addHeaders() {
     return {
       grid: [
         [{
@@ -72,101 +63,64 @@ class ScheduleCContainer extends Component {
     };
   }
 
-  constructor (props) {
+  constructor(props) {
     super(props);
 
     this.state = ScheduleCContainer.addHeaders();
     this.rowNumber = 1;
 
-    if (document.location.pathname.indexOf('/edit/') >= 0) {
-      this.edit = true;
-    } else {
-      this.edit = false;
-    }
-
     this._addRow = this._addRow.bind(this);
     this._getFuelClasses = this._getFuelClasses.bind(this);
     this._handleCellsChanged = this._handleCellsChanged.bind(this);
-    this._handleSubmit = this._handleSubmit.bind(this);
     this._validateFuelClassColumn = this._validateFuelClassColumn.bind(this);
     this._validateFuelTypeColumn = this._validateFuelTypeColumn.bind(this);
   }
 
-  componentDidMount () {
+  componentDidMount() {
     this.props.loadExpectedUses();
 
     if (this.props.loadedState) {
       this.restoreFromAutosaved();
-    } else if (!this.edit) {
+    } else if (this.props.create || !this.props.complianceReport.scheduleC ) {
       this._addRow(5);
     } else {
-      this.loadData();
-    }
-  }
-
-  componentWillReceiveProps (nextProps, nextContext) {
-    if (this.props.saving && !nextProps.saving) {
-      reduxToastr.success('Autosaved');
-    }
-
-    if (this.props.complianceReporting.isCreating && !nextProps.complianceReporting.isCreating) {
-      if (!nextProps.complianceReporting.success) {
-        reduxToastr.error('Error saving');
-      } else {
-        history.push(COMPLIANCE_REPORTING.LIST);
-        toastr.complianceReporting('Draft');
-        this.props.invalidateAutosaved();
-      }
-      return;
-    }
-
-    if (this.props.complianceReporting.isUpdating && !nextProps.complianceReporting.isUpdating) {
-      if (!nextProps.complianceReporting.success) {
-        console.log(nextProps);
-        reduxToastr.error('Error saving');
-      } else {
-        toastr.complianceReporting('Draft');
-        this.props.invalidateAutosaved();
-      }
-    }
-
-    if (this.props.complianceReporting.isGetting && !nextProps.complianceReporting.isGetting) {
       this.setState(ScheduleCContainer.addHeaders());
       this.rowNumber = 1;
-      this._addRow(nextProps.complianceReporting.item.scheduleC.records.length);
+      this._addRow(this.props.complianceReport.scheduleC.records.length);
 
-      for (let i = 0; i < nextProps.complianceReporting.item.scheduleC.records.length; i += 1) {
-        const { grid } = this.state;
-        const record = nextProps.complianceReporting.item.scheduleC.records[i];
+      for (let i = 0; i < this.props.complianceReport.scheduleC.records.length; i += 1) {
+        const {grid} = this.state;
+        const record = this.props.complianceReport.scheduleC.records[i];
 
         grid[2 + i][SCHEDULE_C.FUEL_TYPE].value = record.fuelType;
         grid[2 + i][SCHEDULE_C.FUEL_CLASS].value = record.fuelClass;
         grid[2 + i][SCHEDULE_C.EXPECTED_USE].value = record.expectedUse;
         grid[2 + i][SCHEDULE_C.EXPECTED_USE_OTHER].value = record.rationale;
         grid[2 + i][SCHEDULE_C.QUANTITY].value = record.quantity;
+
         const selectedFuel = this.props.referenceData.approvedFuels.find(fuel =>
           fuel.name === record.fuelType);
+
         grid[2 + i][SCHEDULE_C.UNITS].value = (selectedFuel && selectedFuel.unitOfMeasure)
           ? selectedFuel.unitOfMeasure.name : '';
 
-        this.setState({ grid });
+        this.setState({grid});
       }
     }
   }
 
-  loadData () {
-    this.props.getComplianceReport(this.props.match.params.id);
+  componentWillReceiveProps(nextProps, nextContext) {
   }
 
-  restoreFromAutosaved () {
-    const { loadedState } = this.props;
+  restoreFromAutosaved() {
+    const {loadedState} = this.props;
 
     this.setState(ScheduleCContainer.addHeaders());
     this.rowNumber = 1;
     this._addRow(loadedState.grid.length - 2);
 
     for (let i = 2; i < loadedState.grid.length; i += 1) {
-      const { grid } = this.state;
+      const {grid} = this.state;
       const record = loadedState.grid[i];
 
       grid[i][SCHEDULE_C.FUEL_TYPE].value = record[SCHEDULE_C.FUEL_TYPE].value;
@@ -174,19 +128,18 @@ class ScheduleCContainer extends Component {
       grid[i][SCHEDULE_C.EXPECTED_USE].value = record[SCHEDULE_C.EXPECTED_USE].value;
       grid[i][SCHEDULE_C.EXPECTED_USE_OTHER].value = record[SCHEDULE_C.EXPECTED_USE_OTHER].value;
       grid[i][SCHEDULE_C.QUANTITY].value = record[SCHEDULE_C.QUANTITY].value;
-      if (!this.props.referenceData.isFetching) {
-        const selectedFuel = this.props.referenceData.approvedFuels.find(fuel =>
-          fuel.name === record[SCHEDULE_C.FUEL_TYPE].value);
-        grid[i][SCHEDULE_C.UNITS].value = (selectedFuel && selectedFuel.unitOfMeasure)
-          ? selectedFuel.unitOfMeasure.name : '';  
-      }
+      const selectedFuel = this.props.referenceData.approvedFuels.find(fuel =>
+        fuel.name === record[SCHEDULE_C.FUEL_TYPE].value);
+      grid[i][SCHEDULE_C.UNITS].value = (selectedFuel && selectedFuel.unitOfMeasure)
+        ? selectedFuel.unitOfMeasure.name : '';
 
-      this.setState({ grid });
+
+      this.setState({grid});
     }
   }
 
-  _addRow (numberOfRows = 1) {
-    const { grid } = this.state;
+  _addRow(numberOfRows = 1) {
+    const {grid} = this.state;
 
     for (let x = 0; x < numberOfRows; x += 1) {
       grid.push([
@@ -218,7 +171,7 @@ class ScheduleCContainer extends Component {
           className: 'number',
           dataEditor: Input,
           valueViewer: (props) => {
-            const { value } = props;
+            const {value} = props;
             return <span>{value.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,')}</span>;
           }
         }, {
@@ -245,7 +198,7 @@ class ScheduleCContainer extends Component {
     });
   }
 
-  _getFuelClasses (row) {
+  _getFuelClasses(row) {
     const fuelType = this.state.grid[row][SCHEDULE_C.FUEL_TYPE];
 
     const selectedFuel = this.props.referenceData.approvedFuels
@@ -258,7 +211,7 @@ class ScheduleCContainer extends Component {
     return [];
   }
 
-  _handleCellsChanged (changes, addition = null) {
+  _handleCellsChanged(changes, addition = null) {
     const grid = this.state.grid.map(row => [...row]);
 
     changes.forEach((change) => {
@@ -310,25 +263,22 @@ class ScheduleCContainer extends Component {
       grid
     });
 
-    this.props.updateStateToSave({ grid });
+    this._gridStateToPayload({
+      grid
+    });
+
+    this.props.updateAutosaveState({grid});
   }
 
-  _handleDelete () {
-    if (this.edit) {
-      this.props.deleteComplianceReport({ id: this.props.match.params.id });
-    }
-    history.push(COMPLIANCE_REPORTING.LIST);
-    toastr.complianceReporting('Cancelled');
-    this.props.invalidateAutosaved();
-  }
+  _gridStateToPayload(state) {
 
-  _handleSubmit () {
     const startingRow = 2;
 
-    const records = [];
+    let records = [];
 
-    for (let i = startingRow; i < this.state.grid.length; i += 1) {
-      const row = this.state.grid[i];
+    for (let i = startingRow; i < state.grid.length; i += 1) {
+
+      const row = state.grid[i];
       const record = {
         expectedUse: row[5].value,
         fuelType: row[1].value,
@@ -337,42 +287,23 @@ class ScheduleCContainer extends Component {
         rationale: row[6].value
       };
 
-      const rowIsEmpty = !record.expectedUse && !record.fuelClass &&
-        !record.fuelType && !record.quantity;
+      const rowIsEmpty = !record.expectedUse || !record.fuelClass ||
+        !record.fuelType || !record.quantity;
 
       if (!rowIsEmpty) {
         records.push(record);
       }
     }
 
-    if (!this.edit) {
-      // creating new
-      const payload = {
-        status: 'Draft',
-        type: 'Compliance Report',
-        compliancePeriod: this.props.match.params.period,
-        scheduleC: {
-          records
-        }
-      };
+    this.props.updateScheduleState({
+      scheduleC: {
+        records
+      }
+    });
 
-      this.props.createComplianceReport(payload);
-    } else {
-      // patch existing
-      const payload = {
-        scheduleC: {
-          records
-        }
-      };
-      this.props.updateComplianceReport({
-        id: this.props.match.params.id,
-        state: payload,
-        patch: true
-      });
-    }
   }
 
-  _validateFuelClassColumn (currentRow, value) {
+  _validateFuelClassColumn(currentRow, value) {
     const row = currentRow;
     const fuelType = currentRow[SCHEDULE_C.FUEL_TYPE];
 
@@ -390,7 +321,7 @@ class ScheduleCContainer extends Component {
     return row;
   }
 
-  _validateFuelTypeColumn (currentRow, value) {
+  _validateFuelTypeColumn(currentRow, value) {
     const row = currentRow;
     const selectedFuel = this.props.referenceData.approvedFuels.find(fuel => fuel.name === value);
 
@@ -415,30 +346,12 @@ class ScheduleCContainer extends Component {
     return row;
   }
 
-  render () {
-    if (this.props.complianceReporting.isGetting) {
-      return <Loading />;
-    }
-
-    const { id } = this.props.match.params;
-    let { period } = this.props.match.params;
-
-    if (!period) {
-      period = `${new Date().getFullYear() - 1}`;
-    }
-
+  render() {
     return ([
-      <ScheduleTabs
-        active="schedule-c"
-        compliancePeriod={period}
-        edit={this.edit}
-        id={id}
-        key="nav"
-      />,
       <SchedulesPage
         addRow={this._addRow}
         data={this.state.grid}
-        edit={this.edit}
+        edit={this.props.edit}
         handleCellsChanged={this._handleCellsChanged}
         key="schedules"
         scheduleType="schedule-c"
@@ -463,27 +376,14 @@ class ScheduleCContainer extends Component {
         <p>
           Report &quot;middle-distillate&quot; spec diesel heating oil as Petroleum-based diesel.
         </p>
-      </SchedulesPage>,
-      <Modal
-        handleSubmit={event => this._handleSubmit(event)}
-        id="confirmSubmit"
-        key="confirmSubmit"
-      >
-        Are you sure you want to save this schedule?
-      </Modal>,
-      <Modal
-        handleSubmit={event => this._handleDelete(event)}
-        id="confirmDelete"
-        key="confirmDelete"
-      >
-        Are you sure you want to delete this draft?
-      </Modal>
+      </SchedulesPage>
     ]);
   }
 }
 
 ScheduleCContainer.defaultProps = {
-  saving: false
+  saving: false,
+  complianceReport: null
 };
 
 ScheduleCContainer.propTypes = {
@@ -491,34 +391,18 @@ ScheduleCContainer.propTypes = {
     isFetching: PropTypes.bool,
     items: PropTypes.arrayOf(PropTypes.shape())
   }).isRequired,
-  complianceReporting: PropTypes.shape({
-    isCreating: PropTypes.bool,
-    isUpdating: PropTypes.bool,
-    isGetting: PropTypes.bool,
-    success: PropTypes.bool,
-    item: PropTypes.shape(),
-    errorMessage: PropTypes.shape()
-  }).isRequired,
   loadExpectedUses: PropTypes.func.isRequired,
-  createComplianceReport: PropTypes.func.isRequired,
-  getComplianceReport: PropTypes.func.isRequired,
-  updateComplianceReport: PropTypes.func.isRequired,
-  deleteComplianceReport: PropTypes.func.isRequired,
-
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      id: PropTypes.string,
-      period: PropTypes.string
-    }).isRequired
-  }).isRequired,
-  updateStateToSave: PropTypes.func.isRequired,
-  invalidateAutosaved: PropTypes.func.isRequired,
-  loadedState: PropTypes.any,
-  saving: PropTypes.bool,
   referenceData: PropTypes.shape({
     approvedFuels: PropTypes.arrayOf(PropTypes.shape),
     isFetching: PropTypes.bool
-  }).isRequired
+  }).isRequired,
+  edit: PropTypes.bool.isRequired,
+  create: PropTypes.bool.isRequired,
+  complianceReport: PropTypes.object,
+  loadedState: PropTypes.any,
+  period: PropTypes.string.isRequired,
+  updateScheduleState: PropTypes.func.isRequired,
+  updateAutosaveState: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
@@ -526,32 +410,13 @@ const mapStateToProps = state => ({
     isFetching: state.rootReducer.expectedUses.isFinding,
     items: state.rootReducer.expectedUses.items
   },
-  complianceReporting: {
-    isGetting: state.rootReducer.complianceReporting.isGetting,
-    isCreating: state.rootReducer.complianceReporting.isCreating,
-    isUpdating: state.rootReducer.complianceReporting.isUpdating,
-    success: state.rootReducer.complianceReporting.success,
-    item: state.rootReducer.complianceReporting.item,
-    errorMessage: state.rootReducer.complianceReporting.errorMessage
-  },
   referenceData: {
-    approvedFuels: state.rootReducer.referenceData.data.approvedFuels,
-    isFetching: state.rootReducer.referenceData.isFetching
+    approvedFuels: state.rootReducer.referenceData.data.approvedFuels
   }
 });
 
 const mapDispatchToProps = {
-  loadExpectedUses: expectedUses.find,
-  createComplianceReport: complianceReporting.create,
-  updateComplianceReport: complianceReporting.update,
-  deleteComplianceReport: complianceReporting.remove,
-  getComplianceReport: complianceReporting.get
+  loadExpectedUses: expectedUses.find
 };
 
-const config = {
-  key: 'unsaved',
-  version: 1,
-  name: 'schedule-c'
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(autosaved(config)(ScheduleCContainer));
+export default connect(mapStateToProps, mapDispatchToProps)(ScheduleCContainer);

--- a/frontend/src/compliance_reporting/ScheduleCContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleCContainer.js
@@ -356,6 +356,7 @@ class ScheduleCContainer extends Component {
         key="schedules"
         scheduleType="schedule-c"
         title="Schedule C - Fuels used for other purposes"
+        saving={this.props.saving}
       >
         <p>
           Under section 6 (3) of the
@@ -398,6 +399,7 @@ ScheduleCContainer.propTypes = {
   }).isRequired,
   edit: PropTypes.bool.isRequired,
   create: PropTypes.bool.isRequired,
+  saving: PropTypes.bool.isRequired,
   complianceReport: PropTypes.object,
   loadedState: PropTypes.any,
   period: PropTypes.string.isRequired,

--- a/frontend/src/compliance_reporting/ScheduleDContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleDContainer.js
@@ -27,12 +27,6 @@ class ScheduleDContainer extends Component {
 
     this.rowNumber = 1;
 
-    if (document.location.pathname.indexOf('/edit/') >= 0) {
-      this.edit = true;
-    } else {
-      this.edit = false;
-    }
-
     this._addHeaders = this._addHeaders.bind(this);
     this._addSheet = this._addSheet.bind(this);
     this._handleSheetChanged = this._handleSheetChanged.bind(this);
@@ -189,7 +183,7 @@ class ScheduleDContainer extends Component {
 
         <div className="sticky">
           <ScheduleButtons
-            edit={this.edit}
+            edit={this.props.edit}
             submit
             delete
           />
@@ -199,29 +193,8 @@ class ScheduleDContainer extends Component {
   }
 
   render () {
-    const { id } = this.props.match.params;
-    let { period } = this.props.match.params;
-
-    if (!period) {
-      period = `${new Date().getFullYear() - 1}`;
-    }
-
     return ([
-      <ScheduleTabs
-        active="schedule-d"
-        compliancePeriod={period}
-        edit={this.edit}
-        id={id}
-        key="nav"
-      />,
-      this.renderSheets(),
-      <Modal
-        handleSubmit={event => this._handleSubmit(event)}
-        id="confirmSubmit"
-        key="confirmSubmit"
-      >
-        Are you sure you want to save this schedule?
-      </Modal>
+      this.renderSheets()
     ]);
   }
 }
@@ -230,12 +203,6 @@ ScheduleDContainer.defaultProps = {
 };
 
 ScheduleDContainer.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      id: PropTypes.string,
-      period: PropTypes.string
-    }).isRequired
-  }).isRequired,
   referenceData: PropTypes.shape({
     approvedFuels: PropTypes.arrayOf(PropTypes.shape)
   }).isRequired
@@ -247,7 +214,4 @@ const mapStateToProps = state => ({
   }
 });
 
-const mapDispatchToProps = {
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(ScheduleDContainer);
+export default connect(mapStateToProps, null)(ScheduleDContainer);

--- a/frontend/src/compliance_reporting/components/AutosaveNotifier.js
+++ b/frontend/src/compliance_reporting/components/AutosaveNotifier.js
@@ -1,0 +1,57 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+
+class AutosaveNotifier extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showMessage: false
+    };
+    this.handle = null;
+    this.tick = this.tick.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps, nextContext) {
+    if (this.props.saving && !nextProps.saving) {
+      this.setState({
+        showMessage: true
+      });
+      this.handle = setInterval(this.tick, 1500);
+    }
+  }
+
+  tick() {
+    this.setState({
+      showMessage: false
+    })
+  }
+
+  componentWillUnmount() {
+    if (this.handle !== null) {
+       clearInterval(this.handle);
+    }
+  }
+
+
+  render() {
+
+    if (this.props.saving) {
+      return (<FontAwesomeIcon key="icon" icon="spinner" pulse/>)
+    }
+    ;
+
+    if (this.state.showMessage) {
+      return (<span>Saved...</span>)
+    }
+
+    return null;
+
+  }
+}
+
+AutosaveNotifier.propTypes = {
+  saving: PropTypes.bool.isRequired
+};
+
+export default AutosaveNotifier;

--- a/frontend/src/compliance_reporting/components/ComplianceReportIntro.js
+++ b/frontend/src/compliance_reporting/components/ComplianceReportIntro.js
@@ -77,6 +77,7 @@ const ComplianceReportIntro = (props) => {
 
       <ScheduleButtons
         edit={props.edit}
+        saving={props.saving}
       />
     </div>
   );
@@ -85,7 +86,8 @@ const ComplianceReportIntro = (props) => {
 ComplianceReportIntro.propTypes = {
   period: PropTypes.string.isRequired,
   edit: PropTypes.bool.isRequired,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  saving: PropTypes.bool.isRequired
 };
 
 export default ComplianceReportIntro;

--- a/frontend/src/compliance_reporting/components/ComplianceReportIntro.js
+++ b/frontend/src/compliance_reporting/components/ComplianceReportIntro.js
@@ -5,18 +5,12 @@ import ScheduleTabs from './ScheduleTabs';
 import ScheduleButtons from './ScheduleButtons';
 
 const ComplianceReportIntro = (props) => {
-  const complianceReportDueDate = `20${Number(props.compliancePeriod.substr(-2)) + 1}`;
+  const complianceReportDueDate = `20${Number(props.period.substr(-2)) + 1}`;
 
   return (
     <div className="page-compliance-reporting-intro">
-      <ScheduleTabs
-        active="intro"
-        compliancePeriod={props.compliancePeriod}
-        edit={props.edit}
-        id={props.id}
-      />
       <div>
-        <h1>Compliance Report for {props.compliancePeriod}</h1>
+        <h1>Compliance Report for {props.period}</h1>
         <h2>British Columbia Renewable and Low Carbon Fuel Requirements Regulation</h2>
         <p>
         It is the responsibility of anyone who manufactures or imports fuel to determine whether
@@ -88,15 +82,9 @@ const ComplianceReportIntro = (props) => {
   );
 };
 
-ComplianceReportIntro.defaultProps = {
-  compliancePeriod: null,
-  id: null
-};
-
 ComplianceReportIntro.propTypes = {
-  compliancePeriod: PropTypes.string,
+  period: PropTypes.string.isRequired,
   edit: PropTypes.bool.isRequired,
-  id: PropTypes.string,
   title: PropTypes.string.isRequired
 };
 

--- a/frontend/src/compliance_reporting/components/ComplianceReportingPage.js
+++ b/frontend/src/compliance_reporting/components/ComplianceReportingPage.js
@@ -37,7 +37,8 @@ const ComplianceReportingPage = (props) => {
                 <li key={compliancePeriod.description}>
                   <button
                     onClick={() => {
-                      const route = COMPLIANCE_REPORTING.ADD.replace(':period?', compliancePeriod.description);
+                      const route = COMPLIANCE_REPORTING.ADD.replace(':period', compliancePeriod.description)
+                        .replace(':tab', 'intro');
 
                       history.push(route);
                     }}

--- a/frontend/src/compliance_reporting/components/ComplianceReportingTable.js
+++ b/frontend/src/compliance_reporting/components/ComplianceReportingTable.js
@@ -68,7 +68,8 @@ const ComplianceReportingTable = (props) => {
         if (row && row.original) {
           return {
             onClick: (e) => {
-              const viewUrl = COMPLIANCE_REPORTING.EDIT.replace(':id', row.original.id);
+              const viewUrl = COMPLIANCE_REPORTING.EDIT.replace(':id', row.original.id)
+                .replace(':tab', 'intro');
 
               history.push(viewUrl);
             },

--- a/frontend/src/compliance_reporting/components/ScheduleButtons.js
+++ b/frontend/src/compliance_reporting/components/ScheduleButtons.js
@@ -1,42 +1,49 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
 import history from '../../app/History';
 import * as Lang from '../../constants/langEnUs';
 import COMPLIANCE_REPORTING from '../../constants/routes/ComplianceReporting';
+import AutosaveNotifier from "./AutosaveNotifier";
 
 class ScheduleButtons extends Component {
-  render () {
+  render() {
     return [
       <div className="btn-container" key="btn-container">
-        <button
-          className="btn btn-default"
-          onClick={() => history.push(COMPLIANCE_REPORTING.LIST)}
-          type="button"
-        >
-          <FontAwesomeIcon icon="arrow-circle-left" /> {Lang.BTN_APP_CANCEL}
-        </button>
-        {this.props.delete &&
-        <button
-          className="btn btn-danger"
-          data-target="#confirmDelete"
-          data-toggle="modal"
-          type="button"
-        >
-          <FontAwesomeIcon icon="minus-circle" /> {Lang.BTN_DELETE_DRAFT}
-        </button>
-        }
-        {this.props.submit &&
-        <button
-          className="btn btn-primary"
-          data-target="#confirmSubmit"
-          data-toggle="modal"
-          type="button"
-        >
-          <FontAwesomeIcon icon="save" /> Save
-        </button>
-        }
+        <div className="left">
+          <AutosaveNotifier style="text-align: left" saving={this.props.saving}/>
+        </div>
+
+        <div className="right">
+          <button
+            className="btn btn-default"
+            onClick={() => history.push(COMPLIANCE_REPORTING.LIST)}
+            type="button"
+          >
+            <FontAwesomeIcon icon="arrow-circle-left"/> {Lang.BTN_APP_CANCEL}
+          </button>
+          {this.props.delete &&
+          <button
+            className="btn btn-danger"
+            data-target="#confirmDelete"
+            data-toggle="modal"
+            type="button"
+          >
+            <FontAwesomeIcon icon="minus-circle"/> {Lang.BTN_DELETE_DRAFT}
+          </button>
+          }
+          {this.props.submit &&
+          <button 
+            className="btn btn-primary"
+            data-target="#confirmSubmit"
+            data-toggle="modal"
+            type="button"
+          >
+            <FontAwesomeIcon icon="save"/> Save
+          </button>
+          }
+        </div>
       </div>
     ];
   }
@@ -50,7 +57,8 @@ ScheduleButtons.defaultProps = {
 ScheduleButtons.propTypes = {
   edit: PropTypes.bool.isRequired,
   delete: PropTypes.bool,
-  submit: PropTypes.bool
+  submit: PropTypes.bool,
+  saving: PropTypes.bool.isRequired
 };
 
 export default ScheduleButtons;

--- a/frontend/src/compliance_reporting/components/ScheduleDSheet.js
+++ b/frontend/src/compliance_reporting/components/ScheduleDSheet.js
@@ -136,12 +136,6 @@ ScheduleDSheet.propTypes = {
   edit: PropTypes.bool,
   handleSheetChanged: PropTypes.func.isRequired,
   id: PropTypes.number.isRequired,
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      id: PropTypes.string,
-      period: PropTypes.string
-    }).isRequired
-  }).isRequired,
   referenceData: PropTypes.shape({
     approvedFuels: PropTypes.arrayOf(PropTypes.shape)
   }).isRequired,

--- a/frontend/src/compliance_reporting/components/ScheduleTabs.js
+++ b/frontend/src/compliance_reporting/components/ScheduleTabs.js
@@ -6,20 +6,20 @@ import COMPLIANCE_REPORTING from '../../constants/routes/ComplianceReporting';
 
 const ScheduleTabs = (props) => {
   let urls = {
-    intro: COMPLIANCE_REPORTING.ADD.replace(':period?', props.compliancePeriod),
-    scheduleA: COMPLIANCE_REPORTING.ADD_SCHEDULE_A.replace(':period?', props.compliancePeriod),
-    scheduleB: COMPLIANCE_REPORTING.ADD_SCHEDULE_B.replace(':period?', props.compliancePeriod),
-    scheduleC: COMPLIANCE_REPORTING.ADD_SCHEDULE_C.replace(':period?', props.compliancePeriod),
-    scheduleD: COMPLIANCE_REPORTING.ADD_SCHEDULE_D.replace(':period?', props.compliancePeriod)
+    intro: COMPLIANCE_REPORTING.ADD.replace(':period', props.compliancePeriod).replace(':tab', 'intro'),
+    scheduleA: COMPLIANCE_REPORTING.ADD.replace(':period', props.compliancePeriod).replace(':tab', 'schedule-a'),
+    scheduleB: COMPLIANCE_REPORTING.ADD.replace(':period', props.compliancePeriod).replace(':tab', 'schedule-b'),
+    scheduleC: COMPLIANCE_REPORTING.ADD.replace(':period', props.compliancePeriod).replace(':tab', 'schedule-c'),
+    scheduleD: COMPLIANCE_REPORTING.ADD.replace(':period', props.compliancePeriod).replace(':tab', 'schedule-d'),
   };
 
   if (props.edit) {
     urls = {
-      intro: COMPLIANCE_REPORTING.EDIT.replace(':id', props.id),
-      scheduleA: COMPLIANCE_REPORTING.EDIT_SCHEDULE_A.replace(':id', props.id),
-      scheduleB: COMPLIANCE_REPORTING.EDIT_SCHEDULE_B.replace(':id', props.id),
-      scheduleC: COMPLIANCE_REPORTING.EDIT_SCHEDULE_C.replace(':id', props.id),
-      scheduleD: COMPLIANCE_REPORTING.EDIT_SCHEDULE_D.replace(':id', props.id)
+      intro: COMPLIANCE_REPORTING.EDIT.replace(':id', props.id).replace(':tab', 'intro'),
+      scheduleA: COMPLIANCE_REPORTING.EDIT.replace(':id', props.id).replace(':tab', 'schedule-a'),
+      scheduleB: COMPLIANCE_REPORTING.EDIT.replace(':id', props.id).replace(':tab', 'schedule-b'),
+      scheduleC: COMPLIANCE_REPORTING.EDIT.replace(':id', props.id).replace(':tab', 'schedule-c'),
+      scheduleD: COMPLIANCE_REPORTING.EDIT.replace(':id', props.id).replace(':tab', 'schedule-d')
     };
   }
 

--- a/frontend/src/compliance_reporting/components/SchedulesPage.js
+++ b/frontend/src/compliance_reporting/components/SchedulesPage.js
@@ -72,6 +72,7 @@ const SchedulesPage = props => (
         edit={props.edit}
         submit
         delete
+        saving={props.saving}
       />
     </div>
   </div>
@@ -95,7 +96,8 @@ SchedulesPage.propTypes = {
     'schedule-a', 'schedule-b', 'schedule-c', 'schedule-d'
   ]).isRequired,
   title: PropTypes.string.isRequired,
-  totals: PropTypes.shape()
+  totals: PropTypes.shape(),
+  saving: PropTypes.bool.isRequired
 };
 
 export default SchedulesPage;

--- a/frontend/src/constants/routes/ComplianceReporting.js
+++ b/frontend/src/constants/routes/ComplianceReporting.js
@@ -3,16 +3,8 @@ const BASE_PATH = '/compliance_reporting';
 
 const COMPLIANCE_REPORTING = {
   API,
-  ADD: `${BASE_PATH}/add/:period?/intro`,
-  ADD_SCHEDULE_A: `${BASE_PATH}/add/:period?/schedule-a`,
-  ADD_SCHEDULE_B: `${BASE_PATH}/add/:period?/schedule-b`,
-  ADD_SCHEDULE_C: `${BASE_PATH}/add/:period?/schedule-c`,
-  ADD_SCHEDULE_D: `${BASE_PATH}/add/:period?/schedule-d`,
-  EDIT: `${BASE_PATH}/edit/:id/intro`,
-  EDIT_SCHEDULE_A: `${BASE_PATH}/edit/:id/schedule-a`,
-  EDIT_SCHEDULE_B: `${BASE_PATH}/edit/:id/schedule-b`,
-  EDIT_SCHEDULE_C: `${BASE_PATH}/edit/:id/schedule-c`,
-  EDIT_SCHEDULE_D: `${BASE_PATH}/edit/:id/schedule-d`,
+  ADD: `${BASE_PATH}/add/:period/:tab`,
+  EDIT: `${BASE_PATH}/edit/:id/:tab`,
   LIST: BASE_PATH
 };
 

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -52,11 +52,6 @@ import UserAddContainer from './admin/users/UserAddContainer';
 import UserEditContainer from './admin/users/UserEditContainer';
 import NotFound from './app/components/NotFound';
 import ComplianceReportingContainer from './compliance_reporting/ComplianceReportingContainer';
-import ComplianceReportIntroContainer from './compliance_reporting/ComplianceReportIntroContainer';
-import ScheduleAContainer from './compliance_reporting/ScheduleAContainer';
-import ScheduleBContainer from './compliance_reporting/ScheduleBContainer';
-import ScheduleCContainer from './compliance_reporting/ScheduleCContainer';
-import ScheduleDContainer from './compliance_reporting/ScheduleDContainer';
 import ContactUsContainer from './contact_us/ContactUsContainer';
 import CreditTransactionsContainer from './credit_transfers/CreditTransactionsContainer';
 import CreditTransferAddContainer from './credit_transfers/CreditTransferAddContainer';
@@ -74,6 +69,7 @@ import AuthCallback from './app/AuthCallback';
 import CONFIG from './config';
 import OrganizationEditContainer from './organizations/OrganizationEditContainer';
 import withReferenceData from './utils/reference_data_support';
+import ComplianceReportingEditContainer from "./compliance_reporting/ComplianceReportingEditContainer";
 
 const Router = routerProps => (
   <ConnectedRouter history={history} key={Math.random()}>
@@ -329,56 +325,22 @@ const Router = routerProps => (
           <Route
             key="compliance_reporting_add"
             path={COMPLIANCE_REPORTING.ADD}
-            component={withRouter(ComplianceReportIntroContainer)}
-          />,
-          <Route
-            key="compliance_reporting_add_schedule_a"
-            path={COMPLIANCE_REPORTING.ADD_SCHEDULE_A}
-            component={withRouter(ScheduleAContainer)}
-          />,
-          <Route
-            key="compliance_reporting_add_schedule_b"
-            path={COMPLIANCE_REPORTING.ADD_SCHEDULE_B}
-            component={withRouter(ScheduleBContainer)}
-          />,
-          <Route
-            key="compliance_reporting_add_schedule_c"
-            path={COMPLIANCE_REPORTING.ADD_SCHEDULE_C}
-            component={withRouter(ScheduleCContainer)}
-          />,
-          <Route
-            key="compliance_reporting_add_schedule_d"
-            path={COMPLIANCE_REPORTING.ADD_SCHEDULE_D}
-            component={withRouter(ScheduleDContainer)}
+            exact={false}
+            strict={false}
+            component={withRouter(ComplianceReportingEditContainer)}
           />,
           <Route
             key="compliance_reporting_edit"
             path={COMPLIANCE_REPORTING.EDIT}
-            component={withRouter(ComplianceReportIntroContainer)}
-          />,
-          <Route
-            key="compliance_reporting_edit_schedule_a"
-            path={COMPLIANCE_REPORTING.EDIT_SCHEDULE_A}
-            component={withRouter(ScheduleAContainer)}
-          />,
-          <Route
-            key="compliance_reporting_edit_schedule_b"
-            path={COMPLIANCE_REPORTING.EDIT_SCHEDULE_B}
-            component={withRouter(ScheduleBContainer)}
-          />,
-          <Route
-            key="compliance_reporting_edit_schedule_c"
-            path={COMPLIANCE_REPORTING.EDIT_SCHEDULE_C}
-            component={withRouter(withReferenceData()(ScheduleCContainer))}
-          />,
-          <Route
-            key="compliance_reporting_edit_schedule_d"
-            path={COMPLIANCE_REPORTING.EDIT_SCHEDULE_D}
-            component={withRouter(withReferenceData()(ScheduleDContainer))}
+            exact={false}
+            strict={false}
+            component={withRouter(ComplianceReportingEditContainer)}
           />,
           <Route
             key="compliance_reporting"
             path={COMPLIANCE_REPORTING.LIST}
+            exact
+            strict
             component={withRouter(ComplianceReportingContainer)}
           />
         ]}

--- a/frontend/styles/ComplianceReporting.scss
+++ b/frontend/styles/ComplianceReporting.scss
@@ -48,7 +48,6 @@
 
 .page-compliance-reporting-details {
   .btn-container {
-    text-align: right;
   }
 
   .compliance-reporting-details {
@@ -62,8 +61,8 @@
         font-weight: bold;
         min-height: 2.5rem;
         padding: 0.5rem 1rem;
-      } 
-    }  
+      }
+    }
   }
 }
 
@@ -153,6 +152,16 @@
     position: sticky;
     text-align: right;
     margin-left: auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    .left {
+      text-align: left;
+    }
+    .right {
+      text-align: right;
+    }
   }
 }
 

--- a/frontend/styles/Schedule.scss
+++ b/frontend/styles/Schedule.scss
@@ -12,17 +12,27 @@
     padding: 1rem;
     text-align: right;
     margin-left: auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    .left {
+      text-align: left;
+    }
+    .right {
+      text-align: right;
+    }
   }
 
   .data-grid-container {
     display: block;
     min-width: 1200px;
-  
+
     .schedule {
       overflow-x: auto;
       table-layout: auto;
       width: 100%;
-    
+
       &.data-grid .cell {
         color: $font;
         height: 4rem;
@@ -122,15 +132,15 @@
         padding-top: 1rem;
       }
     }
-  
+
     h2 {
       font-weight: bold;
     }
-  
+
     .row {
       margin: 1rem 0;
     }
-  
+
     .value {
       overflow: hidden;
       padding-left: 0;


### PR DESCRIPTION
# Changelog
 - Create a `ComplianceReportingEditContainer` container to hold all schedules and push state up to this level
 - Schedule A saving now works as expected, and it should now be much simpler to implement the remaining schedules
 - Child components receive `complianceReport` in a prop
