### PR TITLE
Fix an issue where selecting a blank fuel class causes a js error

### DIFF
--- a/frontend/src/admin/fuel_codes/components/FuelCodesTable.js
+++ b/frontend/src/admin/fuel_codes/components/FuelCodesTable.js
@@ -2,7 +2,6 @@
  * Presentational component
  */
 import React from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { Overlay, Tooltip } from 'react-bootstrap';
 
@@ -180,7 +179,7 @@ const FuelCodesTable = (props) => {
     });
   };
 
-  const validateEffectiveDates = (row, items) => (
+  const getInvalidEffectiveDates = (row, items) => (
     items.find(item => (
       (item.effectiveDate <= row.effectiveDate && item.expiryDate >= row.effectiveDate) ||
       (item.effectiveDate <= row.expiryDate && item.effectiveDate >= row.effectiveDate)))
@@ -205,7 +204,7 @@ const FuelCodesTable = (props) => {
             (item.fuelCode === row.original.fuelCode) &&
             (item.fuelCodeVersion === row.original.fuelCodeVersion) &&
             (item.fuelCodeVersionMinor !== row.original.fuelCodeVersionMinor));
-          const hasInvalidDates = validateEffectiveDates(row.original, filtered);
+          const invalidDates = getInvalidEffectiveDates(row.original, filtered);
 
           return {
             onClick: (e) => {
@@ -215,15 +214,15 @@ const FuelCodesTable = (props) => {
             },
             onMouseOver: (e) => {
               const message = `The effective dates of this fuel code overlap with
-                ${filtered[0].fuelCode}${filtered[0].fuelCodeVersion}.${filtered[0].fuelCodeVersionMinor}`;
-              const showTooltip = Boolean(hasInvalidDates);
+                ${invalidDates.fuelCode}${invalidDates.fuelCodeVersion}.${invalidDates.fuelCodeVersionMinor}`;
+              const showTooltip = Boolean(invalidDates);
 
               handleTooltip(e, showTooltip, message);
             },
             onMouseOut: (e) => {
               handleTooltip(e, false, '');
             },
-            className: `clickable ${hasInvalidDates ? 'has-error' : ''}`
+            className: `clickable ${invalidDates ? 'has-error' : ''}`
           };
         }
 

--- a/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
@@ -219,7 +219,7 @@ class ComplianceReportingEditContainer extends Component {
         id="confirmSubmit"
         key="confirmSubmit"
       >
-        Are you sure you want to save this schedule?
+        Are you sure you want to save this compliance report?
       </Modal>,
       <Modal
         handleSubmit={event => this._handleDelete(event)}

--- a/frontend/src/compliance_reporting/ScheduleBContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleBContainer.js
@@ -53,7 +53,7 @@ class ScheduleBContainer extends Component {
         }, {
           className: 'fuel-code',
           readOnly: true,
-          value: 'Fuel Code or Determination Method'
+          value: 'Fuel Code (if applicable)'
         }, {
           className: 'quantity',
           readOnly: true,
@@ -502,11 +502,21 @@ class ScheduleBContainer extends Component {
         value: values.energyDensity.toFixed(2)
       };
 
+      let value = '';
+
+      if (values.energyEffectivenessRatio) {
+        if (values.energyEffectivenessRatio.diesel && fuelClass.value === 'Diesel') {
+          value = values.energyEffectivenessRatio.diesel.toFixed(1);
+        }
+
+        if (values.energyEffectivenessRatio.gasoline && fuelClass.value === 'Gasoline') {
+          value = values.energyEffectivenessRatio.gasoline.toFixed(1);
+        }
+      }
+
       row[SCHEDULE_B.EER] = {
         ...row[SCHEDULE_B.EER],
-        value: (fuelClass.value === 'Diesel')
-          ? values.energyEffectivenessRatio.diesel.toFixed(1)
-          : values.energyEffectivenessRatio.gasoline.toFixed(1)
+        value
       };
     }
 

--- a/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
@@ -214,7 +214,7 @@ class ScheduleSummaryContainer extends Component {
         id="confirmSubmit"
         key="confirmSubmit"
       >
-        Are you sure you want to save this schedule?
+        Are you sure you want to save this compliance report?
       </Modal>
     ]);
   }


### PR DESCRIPTION
#1241 #1274 #1275 

Updated some of the labels and fixed an issue where a blank fuel class is causing the page to crash

Changelog:
- Updated some text
- Value is checked before being added for the energy effectiveness ratio so it doesn't crash the page