### PR TITLE
Signing Performance

### DIFF
--- a/backend/api/async_tasks.py
+++ b/backend/api/async_tasks.py
@@ -1,0 +1,50 @@
+from typing import List
+
+from api.models.CreditTrade import CreditTrade
+from api.models.Document import Document
+from api.models.Organization import Organization
+from api.models.Role import Role
+from api.models.User import User
+from api.notifications.notification_types import NotificationType
+from api.notifications.notifications import AMQPNotificationService
+from tfrs.celery import app as celery_app
+
+
+@celery_app.task
+def async_send_notification(message: str = None,
+                            interested_organization_id = None,
+                            interested_role_names: List[str] = [],
+                            related_credit_trade_id = None,
+                            related_document_id = None,
+                            related_organization_id = None,
+                            related_user_id = None,
+                            is_error: bool = False,
+                            is_warning: bool = False,
+                            is_global: bool = False,
+                            notification_type: NotificationType = None,
+                            originating_user_id = None):
+    print('sending notification')
+
+    interested_organization = Organization.objects.get(id=interested_organization_id) if interested_organization_id else None
+    interested_roles=Role.objects.filter(name__in=interested_role_names).all()
+    related_credit_trade=CreditTrade.objects.get(id=related_credit_trade_id) if related_credit_trade_id else None
+    related_document=Document.objects.get(id=related_document_id) if related_document_id else None
+    related_organization=Organization.objects.get(id=related_organization_id) if related_organization_id else None
+    related_user=User.objects.get(id=related_user_id) if related_user_id else None
+    originating_user=User.objects.get(id=originating_user_id) if originating_user_id else None
+    notification_type_value = NotificationType(notification_type)
+
+    AMQPNotificationService.send_notification(
+        message,
+        interested_organization,
+        interested_roles,
+        related_credit_trade,
+        related_document,
+        related_organization,
+        related_user,
+        is_error,
+        is_warning,
+        is_global,
+        notification_type_value,
+        originating_user
+    )

--- a/backend/api/notifications/notifications.py
+++ b/backend/api/notifications/notifications.py
@@ -21,7 +21,6 @@ from tfrs.settings import AMQP_CONNECTION_PARAMETERS, EMAIL
 
 subscription_cache = caches['notification_subscriptions']
 
-
 def send_amqp_notification(user):
     try:
         parameters = AMQP_CONNECTION_PARAMETERS

--- a/backend/api/services/CreditTradeService.py
+++ b/backend/api/services/CreditTradeService.py
@@ -14,7 +14,9 @@ from api.models.CreditTrade import CreditTrade
 
 from api.exceptions import PositiveIntegerException
 from api.notifications.notification_types import NotificationType
-from api.notifications.notifications import AMQPNotificationService
+from api.async_tasks import async_send_notification
+
+from django.db.transaction import on_commit
 
 
 class CreditTradeService(object):
@@ -52,16 +54,16 @@ class CreditTradeService(object):
             #   show "Submitted" and other transactions where the fuel
             #   supplier is the respondent
             credit_trades = CreditTrade.objects.filter((
-                (
-                    (~Q(status__status__in=[
-                        "Recorded", "Cancelled"]) &
-                     Q(type__is_gov_only_type=False)) |
-                    (Q(status__status__in=[
-                        "Approved", "Declined"]) &
-                     Q(type__is_gov_only_type=True))
+                    (
+                            (~Q(status__status__in=[
+                                "Recorded", "Cancelled"]) &
+                             Q(type__is_gov_only_type=False)) |
+                            (Q(status__status__in=[
+                                "Approved", "Declined"]) &
+                             Q(type__is_gov_only_type=True))
                     ) &
-                ((~Q(status__status__in=["Draft"]) &
-                  Q(respondent=organization)) | Q(initiator=organization))
+                    ((~Q(status__status__in=["Draft"]) &
+                      Q(respondent=organization)) | Q(initiator=organization))
             ))
 
         return credit_trades
@@ -97,7 +99,7 @@ class CreditTradeService(object):
             type_id=credit_trade.type.id,
             number_of_credits=credit_trade.number_of_credits,
             fair_market_value_per_credit=credit_trade.
-            fair_market_value_per_credit,
+                fair_market_value_per_credit,
             zero_reason_id=zero_reason,
             trade_effective_date=credit_trade.trade_effective_date,
             compliance_period_id=credit_trade.compliance_period_id,
@@ -232,7 +234,7 @@ class CreditTradeService(object):
                     "[ID: {}] "
                     "Can't complete transaction,"
                     "`{}` has insufficient credits.".
-                    format(credit_trade.id, credit_trade.credits_from.name))
+                        format(credit_trade.id, credit_trade.credits_from.name))
 
         if errors:
             raise PositiveIntegerException(errors)
@@ -339,7 +341,7 @@ class CreditTradeService(object):
                 allowed_statuses.append("Not Recommended")
 
         elif credit_trade.status.status in [
-                "Not Recommended", "Recommended"
+            "Not Recommended", "Recommended"
         ]:
             if request.user.has_perm('APPROVE_CREDIT_TRANSFER'):
                 allowed_statuses.append("Approved")
@@ -454,14 +456,16 @@ class CreditTradeService(object):
         ]
 
         for notification in notifications_to_send:
-            AMQPNotificationService.send_notification(
-                interested_organization=notification.recipient,
-                message=notification.notification_type.name,
-                notification_type=notification.notification_type,
-                related_credit_trade=credit_trade,
-                related_organization=credit_trade.respondent,
-                originating_user=credit_trade.update_user
-            )
+            on_commit(lambda:
+                      async_send_notification.delay(
+                          interested_organization_id=notification.recipient.id,
+                          message=notification.notification_type.name,
+                          notification_type=notification.notification_type.value,
+                          related_credit_trade_id=credit_trade.id,
+                          related_organization_id=credit_trade.respondent.id,
+                          originating_user_id=credit_trade.update_user.id
+                      )
+                      )
 
     @staticmethod
     def pvr_notification(previous_state, credit_trade):
@@ -527,11 +531,13 @@ class CreditTradeService(object):
         ]
 
         for notification in notifications_to_send:
-            AMQPNotificationService.send_notification(
-                interested_organization=notification.recipient,
-                message=notification.notification_type.name,
-                notification_type=notification.notification_type,
-                related_credit_trade=credit_trade,
-                related_organization=credit_trade.respondent,
-                originating_user=credit_trade.update_user
-            )
+            on_commit(lambda:
+                      async_send_notification.delay(
+                          interested_organization_id=notification.recipient.id,
+                          message=notification.notification_type.name,
+                          notification_type=notification.notification_type.value,
+                          related_credit_trade_id=credit_trade.id,
+                          related_organization_id=credit_trade.respondent.id,
+                          originating_user_id=credit_trade.update_user.id
+                      )
+                      )

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -10,7 +10,6 @@ def remove_orphans():
     print('starting orphan removal')
     DocumentService.remove_orphans()
 
-
 @celery_app.task
 def reap_autosave():
     print('starting autosave cache reaper')


### PR DESCRIPTION
# Changelog
 - Profiling showed that sending notifications was the slow aspect of signing credit transfers, since the number of interested people was very large (23 in dev). Specifically RabbitMQ channel acquisition was slow.
 - Made sending notifications asynchronous (runs in Celery)
 - Much faster now (though notifications might arrive slightly delayed as they are processed in the background)
 - Further improvements would be possible by pooling Rabbit connections, batching notifications, or using NIO to dispatch them (but this code no longer occurs on the critical path so I think it's less urgent)
