### PR TITLE
Customize Autosave URLs

### DIFF
--- a/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
@@ -304,9 +304,17 @@ const
 
 const
   config = {
-    key: 'unsaved',
-    version: 2,
-    name: 'compliance-report'
+    key: '-',
+    version: 3,
+    name: 'compliance-report',
+    customPathGenerator: (props) => {
+      if (props.match.path.indexOf('/edit/') >= 0) {
+        return `edit:${props.match.params.id}`;
+      } else if (props.match.path.indexOf('/add/') >= 0) {
+        return `add:${props.match.params.period}`;
+      }
+      return props.location.pathname;
+    }
   };
 
 export default connect(

--- a/frontend/src/utils/autosave_support.js
+++ b/frontend/src/utils/autosave_support.js
@@ -45,7 +45,11 @@ function autosaved (config) {
 
       _getKey () {
         const s = this.state;
-        return `autosave-${s.name}:${s.key}:${s.version}:${this.props.location.pathname}`;
+        if (config.customPathGenerator) {
+          return `autosave-${s.name}:${s.key}:${s.version}:${config.customPathGenerator(this.props)}`;
+        } else {
+          return `autosave-${s.name}:${s.key}:${s.version}:${this.props.location.pathname}`;
+        }
       }
 
       invalidateAutosaved () {
@@ -124,7 +128,7 @@ function autosaved (config) {
       mapDispatchToProps = dispatch => ({
         loadState: key => (
           new Promise((resolve, reject) => {
-            dispatch(loadAutosaveData({ key, resolve, reject }));
+            dispatch(loadAutosaveData({ key: encodeURIComponent(key), resolve, reject }));
           })
         ),
         saveState: (key, state) => (


### PR DESCRIPTION
This is a prerequisite to getting autosave working correctly for compliance reporting, since we need to autosave based on a partial pathname.

Also fixed a URI-escaping issue.