### PR TITLE
Fixed rounding in the schedule summary payable calculation. Also, all…

### DIFF
--- a/frontend/src/app/components/InputWithTooltip.js
+++ b/frontend/src/app/components/InputWithTooltip.js
@@ -13,6 +13,8 @@ import {
   TEXT_ERROR_NO_DECIMALS
 } from '../../constants/langEnUs';
 
+import { formatNumeric } from '../../utils/functions';
+
 class InputWithTooltip extends Component {
   constructor (props, context) {
     super(props, context);
@@ -34,7 +36,7 @@ class InputWithTooltip extends Component {
       let { value } = this.props;
 
       value = String(value).replace(/\D/g, '');
-      value = value.replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
+      value = formatNumeric(Number(value), this.props.dataNumberToFixed);
 
       return value;
     }
@@ -75,7 +77,7 @@ class InputWithTooltip extends Component {
       this.target.value = this.state.currentValue;
       showTooltip = true;
 
-      tooltipMessage = TEXT_ERROR_MAX_VALUE.replace(':number', this.props.maxValue);
+      tooltipMessage = TEXT_ERROR_MAX_VALUE.replace(':number', formatNumeric(Number(this.props.maxValue), this.props.dataNumberToFixed));
     }
 
     const parsed = event.target.value.split('.');
@@ -217,6 +219,9 @@ class InputWithTooltip extends Component {
             placement="top"
           >
             {this.state.tooltipMessage}
+            {this.props.additionalTooltip !== '' &&
+              <div>{this.props.additionalTooltip}</div>
+            }
           </Tooltip>
         </Overlay>
       </div>
@@ -226,6 +231,7 @@ class InputWithTooltip extends Component {
 
 InputWithTooltip.defaultProps = {
   addCommas: false,
+  additionalTooltip: '',
   allowNegative: false,
   className: 'form-control',
   dataNumberToFixed: 0,
@@ -244,6 +250,7 @@ InputWithTooltip.defaultProps = {
 
 InputWithTooltip.propTypes = {
   addCommas: PropTypes.bool,
+  additionalTooltip: PropTypes.string,
   allowNegative: PropTypes.bool,
   className: PropTypes.string,
   dataNumberToFixed: PropTypes.number,

--- a/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
@@ -166,7 +166,7 @@ class ScheduleSummaryContainer extends Component {
     const grid = part3;
     const balance = Number(grid[SCHEDULE_SUMMARY.LINE_25][2].value);
     let outstandingBalance = balance + Number(credits);
-    let payable = outstandingBalance * -200; // negative symbole so that the product is positive
+    let payable = outstandingBalance * -200; // negative symbol so that the product is positive
 
     if (balance > 0) {
       outstandingBalance = '';
@@ -305,26 +305,26 @@ class ScheduleSummaryContainer extends Component {
     Promise.all(promises).then(() => {
       part3[SCHEDULE_SUMMARY.LINE_23][2] = {
         ...part3[SCHEDULE_SUMMARY.LINE_23][2],
-        value: totalCredits
+        value: Math.round(totalCredits)
       };
 
       part3[SCHEDULE_SUMMARY.LINE_24][2] = {
         ...part3[SCHEDULE_SUMMARY.LINE_24][2],
-        value: totalDebits
+        value: Math.round(totalDebits)
       };
 
       const netTotal = totalCredits + totalDebits;
 
       part3[SCHEDULE_SUMMARY.LINE_25][2] = {
         ...part3[SCHEDULE_SUMMARY.LINE_25][2],
-        value: netTotal
+        value: Math.round(netTotal)
       };
 
       let maxValue = '';
 
       if (netTotal < 0) {
         const { organizationBalance } = this.props.loggedInUser.organization;
-        maxValue = (netTotal * -1).toFixed(0);
+        maxValue = Math.round(netTotal * -1);
 
         if (organizationBalance.validatedCredits < maxValue) {
           maxValue = organizationBalance.validatedCredits;

--- a/frontend/src/compliance_reporting/components/ScheduleSummaryPart3.js
+++ b/frontend/src/compliance_reporting/components/ScheduleSummaryPart3.js
@@ -63,6 +63,7 @@ class ScheduleSummaryPart3 {
         ...numericInput,
         attributes: {
           addCommas: true,
+          additionalTooltip: 'This cannot be higher than the organization\'s credit nor the net debit.',
           dataNumberToFixed: 0,
           maxLength: '20',
           step: '1'


### PR DESCRIPTION
#1324 #1325

Fixed issue with the total payable showing decimal values

Changelog:
- Added rounding early for the lines so that the total doesn't have any decimals
- Allowed additional tooltip message
- Formatted the value in the tooltip to show commas