### PR TITLE
Fixed Missing Fuel Codes

### DIFF
--- a/backend/api/serializers/CreditCalculation.py
+++ b/backend/api/serializers/CreditCalculation.py
@@ -144,7 +144,9 @@ class CreditCalculationSerializer(serializers.ModelSerializer):
             Q(effective_date__gte=self.effective_date,
               effective_date__lte=self.expiration_date) |
             Q(expiry_date__gte=self.effective_date,
-              expiry_date__lte=self.expiration_date)
+              expiry_date__lte=self.expiration_date) |
+            Q(effective_date__lte=self.effective_date,
+              expiry_date__gte=self.expiration_date)
         ).order_by(
             'fuel_code', 'fuel_code_version', 'fuel_code_version_minor'
         )


### PR DESCRIPTION
#1327 

Changelog:
- Added another condition to take into account if the fuel code effective date and expiry date is greater than the compliance period dates