### PR TITLE
Alternative carbon intensity

### DIFF
--- a/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
@@ -185,6 +185,8 @@ class ComplianceReportingEditContainer extends Component {
       return (<Loading />);
     }
 
+    let item = {};
+
     if (this.edit) {
       if (this.props.complianceReporting.item) {
         period = this.props.complianceReporting.item.compliancePeriod.description;
@@ -192,6 +194,8 @@ class ComplianceReportingEditContainer extends Component {
           return (<Loading />);
         }
       }
+    } else {
+      ({ item } = this.props.complianceReporting);
     }
 
     return ([
@@ -207,7 +211,7 @@ class ComplianceReportingEditContainer extends Component {
         period={period}
         id={id}
         create={!this.edit}
-        complianceReport={this.props.complianceReporting.item}
+        complianceReport={item}
         loadedState={this.props.loadedState}
         loggedInUser={this.props.loggedInUser}
         updateScheduleState={this._updateScheduleState}

--- a/frontend/src/compliance_reporting/ScheduleBContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleBContainer.js
@@ -74,11 +74,11 @@ class ScheduleBContainer extends Component {
         }, {
           className: 'density',
           readOnly: true,
-          value: <div>Carbon Intensity Limit<br/>(gCO₂e/MJ)</div>
+          value: <div>Carbon Intensity Limit<br />(gCO₂e/MJ)</div>
         }, {
           className: 'density',
           readOnly: true,
-          value: <div>Carbon Intensity of Fuel<br/>(gCO₂e/MJ)</div>
+          value: <div>Carbon Intensity of Fuel<br />(gCO₂e/MJ)</div>
         }, {
           className: 'density',
           readOnly: true,

--- a/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
@@ -27,6 +27,7 @@ import ScheduleSummaryPage from './components/ScheduleSummaryPage';
 import ScheduleSummaryPart3 from './components/ScheduleSummaryPart3';
 import ScheduleSummaryPenalty from './components/ScheduleSummaryPenalty';
 import { SCHEDULE_PENALTY, SCHEDULE_SUMMARY } from '../constants/schedules/scheduleColumns';
+import ComplianceReportingService from './services/ComplianceReportingService';
 import { formatNumeric } from '../utils/functions';
 
 class ScheduleSummaryContainer extends Component {
@@ -237,6 +238,8 @@ class ScheduleSummaryContainer extends Component {
     scheduleB.records.forEach((row) => {
       const selectedFuel = getSelectedFuel(this.props.referenceData.approvedFuels, row.fuelType);
 
+      const scheduleDFuels = ComplianceReportingService.getAvailableScheduleDFuels(this.props.complianceReport);
+
       const promise = this.props.getCreditCalculation(selectedFuel.id, {
         compliance_period_id: compliancePeriod.id
       }).then(() => {
@@ -270,7 +273,8 @@ class ScheduleSummaryContainer extends Component {
           creditCalculationValues,
           selectedFuel,
           determinationType,
-          row.fuelCode
+          row,
+          scheduleDFuels
         );
 
         const energyEffectivenessRatio = getEnergyEffectivenessRatio(

--- a/frontend/src/compliance_reporting/components/ScheduleBGHGeniusProvisionModal.js
+++ b/frontend/src/compliance_reporting/components/ScheduleBGHGeniusProvisionModal.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Modal from "../../app/components/Modal";
+import Modal from '../../app/components/Modal';
 
 const RoundedNumericSpan = (props) => {
   return (
@@ -9,13 +9,12 @@ const RoundedNumericSpan = (props) => {
       <span>{Number(props.value).toFixed(2).toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,')}</span>
       || <span><i>pending</i></span>)
   );
-}
+};
 
 class ScheduleBGHGeniusProvisionModal extends React.Component {
-
-  render() {
+  render () {
     const
-      filteredSelections = this.props.availableSelections.filter(sel => {
+      filteredSelections = this.props.availableSelections.filter((sel) => {
         if (this.props.matchFuelClass) {
           if (this.props.matchFuelClass !== sel.fuelClass) {
             return false;
@@ -31,7 +30,7 @@ class ScheduleBGHGeniusProvisionModal extends React.Component {
 
     return (
       <Modal
-        id='schedule-d-modal'
+        id="schedule-d-modal"
         title="Select Schedule D Entry"
         initiallyShown
         key="schedule-d-modal"
@@ -53,7 +52,8 @@ class ScheduleBGHGeniusProvisionModal extends React.Component {
                     href="#"
                     onClick={() => this.props.handleSelection(sel)}
                     data-dismiss="modal"
-                  >Select {sel.fuelType} <RoundedNumericSpan value={sel.intensity}/></a>
+                  >Select {sel.fuelType} <RoundedNumericSpan value={sel.intensity} />
+                  </a>
                 </li>
               ))}
             </ul>
@@ -75,7 +75,7 @@ ScheduleBGHGeniusProvisionModal.propTypes = {
     PropTypes.shape({
       fuelType: PropTypes.string,
       fuelClass: PropTypes.string,
-      intensity: PropTypes.oneOf(PropTypes.number, PropTypes.string)
+      intensity: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
     })
   ).isRequired,
   matchFuelType: PropTypes.string,

--- a/frontend/src/compliance_reporting/components/ScheduleFunctions.js
+++ b/frontend/src/compliance_reporting/components/ScheduleFunctions.js
@@ -28,21 +28,32 @@ const getCreditCalculationValues = (creditCalculationValues, id) => (
   creditCalculationValues.find(fuel => fuel.id === id)
 );
 
-const getDefaultCarbonIntensity = (values, selectedFuel, determinationType, fuelCodeId) => {
+const getDefaultCarbonIntensity = (
+  values,
+  selectedFuel,
+  determinationType,
+  row,
+  scheduleDFuels = null
+) => {
   if (selectedFuel.provisions.length === 1 ||
     (determinationType.theType === 'Default Carbon Intensity')) {
     return values.defaultCarbonIntensity.toFixed(2);
   }
 
-  if (determinationType.theType === 'Fuel Code' && fuelCodeId && fuelCodeId !== '') {
+  if (determinationType.theType === 'Fuel Code' && row.fuelCodeId && row.fuelCodeId !== '') {
     const { fuelCodes } = values;
-    const selectedFuelCode = getFuelCode(fuelCodes, fuelCodeId);
+    const selectedFuelCode = getFuelCode(fuelCodes, row.fuelCodeId);
 
     return selectedFuelCode.carbonIntensity;
   }
 
+  if (determinationType.theType === 'GHGenius' && row.scheduleD_sheetIndex !== null) {
+    const GHGenius = scheduleDFuels[row.scheduleD_sheetIndex];
+    return GHGenius.intensity;
+  }
+
   if (determinationType.theType === 'Alternative') {
-    return '-';
+    return row.intensity;
   }
 
   return '-';

--- a/frontend/src/compliance_reporting/services/ComplianceReportingService.js
+++ b/frontend/src/compliance_reporting/services/ComplianceReportingService.js
@@ -7,7 +7,6 @@
 class ComplianceReportingService {
 
   static getAvailableScheduleDFuels(complianceReport) {
-
     if(!complianceReport) {
       throw 'complianceReport is a required parameter'
     }


### PR DESCRIPTION
#1329 

Rob already fixed the issue with saving and loading the carbon intensity when alternate method is selected. This is so that the page loads it as an input field and fixes the summary page.

Changelog:
- Should now load carbon intensity as an input field when alternate method is selected
- Summary screen now takes into account GHGenius and Alternate methods
- Fixed a caching issue with GHGenius options when creating a new compliance report