### PR TITLE
Disable Browser Autocomplete

### DIFF
--- a/frontend/src/app/components/AutocompletedInput.js
+++ b/frontend/src/app/components/AutocompletedInput.js
@@ -73,6 +73,7 @@ class AutocompletedInput extends Component {
   render () {
     return (
       <Autocomplete
+        autoComplete="off"
         getItemValue={this.props.getItemValue}
         inputProps={this.props.inputProps}
         items={this.state.items}

--- a/frontend/src/app/components/InputWithTooltip.js
+++ b/frontend/src/app/components/InputWithTooltip.js
@@ -187,6 +187,7 @@ class InputWithTooltip extends Component {
           <span className="input-group-addon">$</span>
         }
         <input
+          autoComplete="off"
           className={this.props.className}
           data-number-to-fixed={this.props.dataNumberToFixed}
           id={this.props.id}


### PR DESCRIPTION
The built-in autocomplete from the browser sometimes can add annoyances to our autocomplete fields. They sometimes clash and can overwrite some data.

This PR is supposed to turn off the autocomplete from our Autocomplete fields in the spreadsheet, as well as the input fields with tooltips (Those are mostly for numeric values so they also don't need autocomplete)