### PR TITLE
Added indicators for the dropdowns in spreadsheets

### DIFF
--- a/frontend/src/compliance_reporting/ScheduleAContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleAContainer.js
@@ -137,7 +137,7 @@ class ScheduleAContainer extends Component {
       }, {
         className: 'text'
       }, {
-        className: 'text',
+        className: 'text dropdown-indicator',
         dataEditor: Select,
         getOptions: () => !this.props.fuelClasses.isFetching &&
           this.props.fuelClasses.items,
@@ -146,7 +146,7 @@ class ScheduleAContainer extends Component {
           value: 'fuelClass'
         }
       }, {
-        className: 'text',
+        className: 'text dropdown-indicator',
         dataEditor: Select,
         getOptions: () => !this.props.notionalTransferTypes.isFetching &&
           this.props.notionalTransferTypes.items,

--- a/frontend/src/compliance_reporting/ScheduleBContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleBContainer.js
@@ -281,7 +281,7 @@ class ScheduleBContainer extends Component {
         readOnly: true,
         value: this.rowNumber
       }, { // fuel type
-        className: 'text',
+        className: 'text dropdown-indicator',
         dataEditor: Select,
         getOptions: () => this.props.referenceData.data.approvedFuels,
         mapping: {
@@ -289,7 +289,7 @@ class ScheduleBContainer extends Component {
           value: 'name'
         }
       }, { // fuel class
-        className: 'text',
+        className: 'text dropdown-indicator',
         dataEditor: Select,
         getOptions: () => [],
         mapping: {
@@ -297,7 +297,7 @@ class ScheduleBContainer extends Component {
           value: 'fuelClass'
         }
       }, { // provision of the act
-        className: 'text',
+        className: 'text dropdown-indicator',
         dataEditor: Select,
         valueViewer: (props) => {
           const selectedOption = props.cell.getOptions().find(e => e.provision === props.value);
@@ -313,7 +313,7 @@ class ScheduleBContainer extends Component {
           display: 'descriptiveName'
         }
       }, { // fuel code
-        className: 'text',
+        className: 'text dropdown-indicator',
         dataEditor: Select,
         getOptions: () => [],
         mapping: {

--- a/frontend/src/compliance_reporting/ScheduleCContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleCContainer.js
@@ -144,7 +144,7 @@ class ScheduleCContainer extends Component {
           readOnly: true,
           value: this.rowNumber
         }, {
-          className: 'text',
+          className: 'text dropdown-indicator',
           dataEditor: Select,
           getOptions: () => this.props.referenceData.approvedFuels,
           mapping: {
@@ -152,7 +152,7 @@ class ScheduleCContainer extends Component {
             value: 'name'
           }
         }, {
-          className: 'text',
+          className: 'text dropdown-indicator',
           dataEditor: Select,
           getOptions: this._getFuelClasses,
           mapping: {
@@ -175,7 +175,7 @@ class ScheduleCContainer extends Component {
         }, {
           readOnly: true
         }, {
-          className: 'text',
+          className: 'text dropdown-indicator',
           dataEditor: Select,
           getOptions: () => !this.props.expectedUses.isFetching && this.props.expectedUses.items,
           mapping: {

--- a/frontend/src/compliance_reporting/ScheduleDContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleDContainer.js
@@ -176,7 +176,7 @@ class ScheduleDContainer extends Component {
           value: 'Fuel Class'
         }],
         [{
-          className: 'text',
+          className: 'text dropdown-indicator',
           dataEditor: Select,
           getOptions: () => this.props.referenceData.approvedFuels,
           mapping: {
@@ -186,7 +186,7 @@ class ScheduleDContainer extends Component {
         }, {
           className: 'text'
         }, {
-          className: 'text',
+          className: 'text dropdown-indicator',
           dataEditor: Select,
           getOptions: row => this._getFuelClasses(row, id),
           mapping: {

--- a/frontend/styles/Spreadsheet.scss
+++ b/frontend/styles/Spreadsheet.scss
@@ -17,6 +17,30 @@
         padding: 0.5rem;
         vertical-align: middle;
 
+        &.dropdown-indicator {
+          padding-right: 1rem;
+          position: relative;
+
+          &:not(.read-only):not(.editing) {
+            &::before {
+              align-items: center;
+              bottom: 0;
+              color: $light-font;
+              content: "\f0d7";
+              display: flex;
+              font-family: "Font Awesome 5 Free";
+              font-size: 1.5rem;
+              font-weight: bold;
+              position: absolute;
+              right: 0.5rem;
+              text-rendering: auto;
+              top: 0;
+              vertical-align: middle;
+              -webkit-font-smoothing: antialiased;
+            }
+          }
+        }
+
         &.editing {
           padding: 0;
 


### PR DESCRIPTION
#1358 

Adds an indicator to make it clear that the cell contains a drop-down

Changelog:
- Created a class that can be used in spreadsheets
- Applied the class to anything with the ```Select``` component
- Automatically hides when using the actual drop-down to remove overlapping styles