### PR TITLE
Bugfix for spreadsheet line 10

### DIFF
--- a/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
@@ -501,8 +501,13 @@ class ScheduleSummaryContainer extends Component {
     let {penalty} = this.state;
     const {summary} = this.props.scheduleState;
 
-    const {totalCredits, totalDebits} = this.props.recomputedTotals.scheduleB;
 
+    let totalCredits = 0;
+    let totalDebits= 0;
+    if (this.props.recomputedTotals.scheduleB) {
+      totalCredits = this.props.recomputedTotals.scheduleB.totalCredits;
+      totalDebits = this.props.recomputedTotals.scheduleB.totalDebits;
+    }
     if (summary.creditsOffset) {
       part3[SCHEDULE_SUMMARY.LINE_26][2].value = summary.creditsOffset;
     }


### PR DESCRIPTION
Schedule summary now works if Schedule B is not supplied, fixing a crash recorded on line 10 of the bug spreadsheet