### PR TITLE
Delete function for exclusion report

### DIFF
--- a/backend/api/viewsets/ComplianceReport.py
+++ b/backend/api/viewsets/ComplianceReport.py
@@ -1,5 +1,5 @@
 from django.db import transaction
-from rest_framework import viewsets, mixins, filters
+from rest_framework import viewsets, mixins, filters, status
 from rest_framework.decorators import list_route, detail_route
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -21,7 +21,6 @@ from auditable.views import AuditableMixin
 class ComplianceReportViewSet(AuditableMixin, mixins.CreateModelMixin,
                               mixins.RetrieveModelMixin,
                               mixins.UpdateModelMixin,
-                              mixins.DestroyModelMixin,
                               mixins.ListModelMixin, viewsets.GenericViewSet):
     """
     This viewset automatically provides `list`, `create`, `retrieve`,
@@ -60,6 +59,20 @@ class ComplianceReportViewSet(AuditableMixin, mixins.CreateModelMixin,
             return self.serializer_classes[self.action]
 
         return self.serializer_classes['default']
+
+    def destroy(self, request, *args, **kwargs):
+        """
+        Override the base destroy method.
+        This is to explicitly call the destroy function in the serializer.
+
+        """
+        instance = self.get_object()
+
+        serializer = self.get_serializer(
+            instance)
+        serializer.destroy()
+
+        return Response(None, status=status.HTTP_200_OK)
 
     def perform_create(self, serializer):
         _compliance_report = serializer.save(

--- a/frontend/src/exclusion_reports/ExclusionReportEditContainer.js
+++ b/frontend/src/exclusion_reports/ExclusionReportEditContainer.js
@@ -7,18 +7,19 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
+import { complianceReporting } from '../actions/complianceReporting';
 import { exclusionReports } from '../actions/exclusionReports';
 import history from '../app/History';
 import Loading from '../app/components/Loading';
 import Modal from '../app/components/Modal';
 import ExclusionReportButtons from './components/ExclusionReportButtons';
 import ExclusionReportTabs from './components/ExclusionReportTabs';
-import EXCLUSION_REPORTS from '../constants/routes/ExclusionReports';
 import ExclusionAgreementContainer from './ExclusionAgreementContainer';
 import ExclusionReportIntroContainer from './ExclusionReportIntroContainer';
 import withReferenceData from '../utils/reference_data_support';
 import autosaved from '../utils/autosave_support';
 import toastr from '../utils/toastr';
+import COMPLIANCE_REPORTING from '../constants/routes/ComplianceReporting';
 
 class ExclusionReportEditContainer extends Component {
   static componentForTabName (tab) {
@@ -87,7 +88,11 @@ class ExclusionReportEditContainer extends Component {
   }
 
   _handleDelete () {
-    history.push(EXCLUSION_REPORTS.LIST);
+    this.props.deleteComplianceReport({ id: this.props.match.params.id });
+
+    this.props.getComplianceReports();
+    history.push(COMPLIANCE_REPORTING.LIST);
+    toastr.complianceReporting('Cancelled');
     this.props.invalidateAutosaved();
   }
 
@@ -192,6 +197,8 @@ ExclusionReportEditContainer.defaultProps = {
 };
 
 ExclusionReportEditContainer.propTypes = {
+  deleteComplianceReport: PropTypes.func.isRequired,
+  getComplianceReports: PropTypes.func.isRequired,
   exclusionReports: PropTypes.shape({
     isCreating: PropTypes.bool,
     isGetting: PropTypes.bool,
@@ -224,6 +231,8 @@ ExclusionReportEditContainer.propTypes = {
 
 const
   mapDispatchToProps = {
+    deleteComplianceReport: complianceReporting.remove,
+    getComplianceReports: complianceReporting.find,
     getExclusionReport: exclusionReports.get,
     updateExclusionReport: exclusionReports.update
   };


### PR DESCRIPTION
#1422 #1423 #1424 

Delete should now be working for exclusion report

Changelog:
- I added a destroy method to explicitly call the serializer, it was skipping it in some instances
- Notification alert is reused from compliance reporting