### PR TITLE
Label adjustments

### DIFF
--- a/backend/api/migrations/0182_add_gov_analyst_view_compliance_report_permission.py
+++ b/backend/api/migrations/0182_add_gov_analyst_view_compliance_report_permission.py
@@ -1,0 +1,55 @@
+from django.db import migrations
+from django.db.migrations import RunPython
+
+
+def add_gov_analyst_view_compliance_report_permission(apps, schema_editor):
+    """
+    Adds the View Compliance Report to the Gov Analyst role
+    """
+    db_alias = schema_editor.connection.alias
+
+    permission = apps.get_model(
+        'api', 'Permission')
+    role = apps.get_model('api', 'Role')
+    role_permission = apps.get_model('api', 'RolePermission')
+
+    view_permission = permission.objects.using(db_alias).get(
+        code="VIEW_COMPLIANCE_REPORT"
+    )
+
+    role = role.objects.using(db_alias).get(name="GovUser")
+
+    role_permission.objects.using(db_alias).create(
+        role=role,
+        permission=view_permission
+    )
+
+
+def remove_gov_analyst_view_compliance_report_permission(apps, schema_editor):
+    """
+    Removes the View Compliance Reports from the Gov Analyst role
+    """
+    db_alias = schema_editor.connection.alias
+
+    role_permission = apps.get_model('api', 'RolePermission')
+
+    role_permission.objects.using(db_alias).filter(
+        permission__code="VIEW_COMPLIANCE_REPORT",
+        role__name="GovUser"
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    """
+    Attaches the functions for the migrations
+    """
+    dependencies = [
+        ('api', '0181_auto_20190829_2036'),
+    ]
+
+    operations = [
+        RunPython(
+            add_gov_analyst_view_compliance_report_permission,
+            remove_gov_analyst_view_compliance_report_permission
+        )
+    ]

--- a/frontend/src/compliance_reporting/ScheduleBContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleBContainer.js
@@ -53,7 +53,7 @@ class ScheduleBContainer extends Component {
         }, {
           className: 'fuel-code',
           readOnly: true,
-          value: 'Fuel Code (if applicable)'
+          value: <div>Fuel Code or Schedule D Entry<br />(if applicable)</div>
         }, {
           className: 'quantity',
           readOnly: true,

--- a/frontend/src/compliance_reporting/components/ScheduleATotals.js
+++ b/frontend/src/compliance_reporting/components/ScheduleATotals.js
@@ -8,7 +8,7 @@ const ScheduleATotals = (props) => {
       return '-';
     }
 
-    return value.toFixed(2).toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
+    return value.toFixed(0).toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
   };
 
   return (

--- a/frontend/src/compliance_reporting/components/ScheduleSummaryPart3.js
+++ b/frontend/src/compliance_reporting/components/ScheduleSummaryPart3.js
@@ -92,7 +92,7 @@ class ScheduleSummaryPart3 {
       [{ // line 26
         className: 'text',
         readOnly: true,
-        value: 'Credits used to offset debits (if applicable)'
+        value: 'Banked credits used to offset outstanding debits (if applicable)'
       }, {
         readOnly: true,
         value: (
@@ -124,7 +124,7 @@ class ScheduleSummaryPart3 {
       [{ // line 27
         className: 'text total',
         readOnly: true,
-        value: 'Outstanding Debit Balance'
+        value: 'Outstanding debit balance'
       }, {
         className: 'total',
         readOnly: true,

--- a/frontend/src/compliance_reporting/components/ScheduleSummaryPenalty.js
+++ b/frontend/src/compliance_reporting/components/ScheduleSummaryPenalty.js
@@ -49,16 +49,6 @@ class ScheduleSummaryPenalty {
       }, {
         ...totalViewer,
         className: 'total numeric'
-      }],
-      [{
-        className: 'text total',
-        readOnly: true,
-        value: 'Amount Enclosed'
-      }, {
-        readOnly: true
-      }, {
-        className: 'total',
-        readOnly: true
       }]
     ];
   }

--- a/frontend/src/exclusion_reports/ExclusionReportEditContainer.js
+++ b/frontend/src/exclusion_reports/ExclusionReportEditContainer.js
@@ -209,6 +209,12 @@ class ExclusionReportEditContainer extends Component {
       return (<Loading />);
     }
 
+    if (typeof (this.props.exclusionReports.item.compliancePeriod) === 'string') {
+      period = this.props.exclusionReports.item.compliancePeriod;
+    } else {
+      period = this.props.exclusionReports.item.compliancePeriod.description;
+    }
+
     return ([
       <ExclusionReportTabs
         active={tab}

--- a/frontend/src/exclusion_reports/ExclusionReportEditContainer.js
+++ b/frontend/src/exclusion_reports/ExclusionReportEditContainer.js
@@ -83,15 +83,15 @@ class ExclusionReportEditContainer extends Component {
     if (this.props.exclusionReports.isUpdating && !nextProps.exclusionReports.isUpdating) {
       if (nextProps.exclusionReports.success) {
         if (this.status.fuelSupplierStatus) {
-          toastr.complianceReporting(this.status.fuelSupplierStatus);
+          toastr.exclusionReports(this.status.fuelSupplierStatus);
         } else if (this.status.analystStatus && this.status.analystStatus !== 'Unreviewed') {
-          toastr.complianceReporting(this.status.analystStatus);
+          toastr.exclusionReports(this.status.analystStatus);
         } else if (this.status.managerStatus && this.status.managerStatus !== 'Unreviewed') {
-          toastr.complianceReporting(this.status.managerStatus);
+          toastr.exclusionReports(this.status.managerStatus);
         } else if (this.status.directorStatus && this.status.directorStatus !== 'Unreviewed') {
-          toastr.complianceReporting(this.status.directorStatus);
+          toastr.exclusionReports(this.status.directorStatus);
         } else {
-          toastr.complianceReporting(this.status);
+          toastr.exclusionReports(this.status);
         }
 
         this.props.invalidateAutosaved();
@@ -104,7 +104,7 @@ class ExclusionReportEditContainer extends Component {
 
     if (this.props.exclusionReports.isRemoving && !nextProps.exclusionReports.isRemoving) {
       history.push(COMPLIANCE_REPORTING.LIST);
-      toastr.complianceReporting('Cancelled');
+      toastr.exclusionReports('Cancelled');
       this.props.invalidateAutosaved();
     }
   }

--- a/frontend/src/exclusion_reports/ExclusionReportEditContainer.js
+++ b/frontend/src/exclusion_reports/ExclusionReportEditContainer.js
@@ -269,7 +269,7 @@ class ExclusionReportEditContainer extends Component {
               </div>
             </div>
           ))}
-          Are you sure you want to submit this Compliance Report to the
+          Are you sure you want to submit this Exclusion Report to the
           Government of British Columbia?
         </div>
       </Modal>,

--- a/frontend/src/exclusion_reports/components/ExclusionAgreementPage.js
+++ b/frontend/src/exclusion_reports/components/ExclusionAgreementPage.js
@@ -27,6 +27,7 @@ const ExclusionAgreementPage = props => (
         />
       </div>
 
+      {!props.exclusionReport.readOnly &&
       <div className="sheet-buttons">
         <div className="btn-group">
           <button
@@ -58,6 +59,7 @@ const ExclusionAgreementPage = props => (
           </ul>
         </div>
       </div>
+      }
     </div>
   </div>
 );
@@ -74,7 +76,9 @@ ExclusionAgreementPage.propTypes = {
     PropTypes.node
   ]),
   data: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.shape())).isRequired,
-  exclusionReport: PropTypes.shape().isRequired,
+  exclusionReport: PropTypes.shape({
+    readOnly: PropTypes.bool
+  }).isRequired,
   handleCellsChanged: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   totals: PropTypes.shape()

--- a/frontend/src/exclusion_reports/components/ExclusionReportButtons.js
+++ b/frontend/src/exclusion_reports/components/ExclusionReportButtons.js
@@ -42,7 +42,7 @@ const ExclusionReportButtons = props => (
         <TooltipWhenDisabled
           disabled={!props.loggedInUser.hasPermission(PERMISSIONS_COMPLIANCE_REPORT.SIGN)}
           key="btn-submit"
-          title="You must have the Signing Authority role to submit a Exclusion Report to the Government of British Columbia."
+          title="You must have the Signing Authority role to submit an Exclusion Report to the Government of British Columbia."
         >
           <button
             className="btn btn-primary"

--- a/frontend/src/utils/toastr.js
+++ b/frontend/src/utils/toastr.js
@@ -10,25 +10,25 @@ const toastr = {
 
     switch (status) {
       case 'Accepted':
-        reduxToastr.success('Success!', 'Compliance Report Accepted.');
+        reduxToastr.success('Success!', 'Compliance Report accepted.');
         break;
       case 'Cancelled':
         reduxToastr.success('Success!', 'Draft deleted.');
         break;
       case 'Created':
-        reduxToastr.success('Success!', 'New Compliance Report Created');
+        reduxToastr.success('Success!', 'New Compliance Report created');
         break;
       case 'Draft':
         reduxToastr.success('Success!', 'Draft saved.');
         break;
       case 'Not Recommended':
-        reduxToastr.success('Success!', 'Rejection Recommended.');
+        reduxToastr.success('Success!', 'Rejection recommended.');
         break;
       case 'Recommended':
-        reduxToastr.success('Success!', 'Acceptance Recommended.');
+        reduxToastr.success('Success!', 'Acceptance recommended.');
         break;
       case 'Rejected':
-        reduxToastr.success('Success!', 'Compliance Report Rejected.');
+        reduxToastr.success('Success!', 'Compliance Report rejected.');
         break;
       case 'Submitted':
         reduxToastr.success('Success!', 'Compliance Report submitted.');
@@ -119,6 +119,9 @@ const toastr = {
     }
 
     switch (status) {
+      case 'Accepted':
+        reduxToastr.success('Success!', 'Exclusion Report accepted.');
+        break;
       case 'Cancelled':
         reduxToastr.success('Success!', 'Draft deleted.');
         break;
@@ -126,7 +129,16 @@ const toastr = {
         reduxToastr.success('Success!', 'Draft saved.');
         break;
       case 'Created':
-        reduxToastr.success('Success!', 'New Exclusion Report Created');
+        reduxToastr.success('Success!', 'New Exclusion Report created');
+        break;
+      case 'Not Recommended':
+        reduxToastr.success('Success!', 'Rejection recommended.');
+        break;
+      case 'Recommended':
+        reduxToastr.success('Success!', 'Acceptance recommended.');
+        break;
+      case 'Rejected':
+        reduxToastr.success('Success!', 'Exclusion Report rejected.');
         break;
       case 'Submitted':
         reduxToastr.success('Success!', 'Exclusion Report submitted.');


### PR DESCRIPTION
#1457 #1458 #1459 #1461 #1462 #1463 #1464 

Changelog:
- Removed Amount enclosed in the Summary section
- Changed some labels in the Summary section
- Changed Fuel Code label in Schedule B 
- Fixed some messages in the tooltip for submitting an Exclusion Report
- Fixed an issue with the confirmation dialog when submitting an Exclusion Report
- Fixed toastr messages for Exclusion Reports
- Fixed capitalization for toastr messages
- Fixed Add row button still showing up even after the exclusion report has been submitted
- Fixed permission with Gov Analyst not seeing the compliance reporting navigation link
- Schedule A totals are now whole numbers