### PR TITLE
Sort Order for compliance reports

### DIFF
--- a/backend/api/models/ComplianceReport.py
+++ b/backend/api/models/ComplianceReport.py
@@ -324,6 +324,18 @@ class ComplianceReport(Auditable):
     def snapshot(self):
         return ComplianceReportSnapshot.objects.filter(compliance_report=self).first().snapshot
 
+    @property
+    def sort_date(self):
+        latest = self.update_timestamp if self.update_timestamp else self.create_timestamp
+        to_check = self.supplemental_reports.all()
+
+        for c in to_check:
+            c_sort_date = c.sort_date
+            if c_sort_date > latest:
+                latest = c_sort_date
+
+        return latest
+
     class Meta:
         db_table = 'compliance_report'
 

--- a/backend/api/serializers/ComplianceReport.py
+++ b/backend/api/serializers/ComplianceReport.py
@@ -172,7 +172,7 @@ class ComplianceReportListSerializer(serializers.ModelSerializer):
         model = ComplianceReport
         fields = ('id', 'status', 'type', 'organization', 'compliance_period',
                   'update_timestamp', 'has_snapshot', 'read_only',
-                  'supplemental_reports', 'supplements', 'display_name')
+                  'supplemental_reports', 'supplements', 'display_name', 'sort_date')
 
 
 class ComplianceReportMinSerializer(serializers.ModelSerializer):

--- a/frontend/src/compliance_reporting/components/ComplianceReportingTable.js
+++ b/frontend/src/compliance_reporting/components/ComplianceReportingTable.js
@@ -99,13 +99,22 @@ class ComplianceReportingTable extends Component {
       Header: 'Status',
       id: 'status',
       minWidth: 75
-    }, {
-      accessor: item => (item.updateTimestamp ? moment(item.updateTimestamp).format('YYYY-MM-DD') : '-'),
-      className: 'col-date',
-      Header: 'Last Updated On',
-      id: 'updateTimestamp',
-      minWidth: 95
-    }
+    },
+      {
+        accessor: item => (item.updateTimestamp ? moment(item.updateTimestamp).format('YYYY-MM-DD') : '-'),
+        className: 'col-date',
+        Header: 'Last Updated On',
+        id: 'updateTimestamp',
+        minWidth: 95
+      },
+      {
+        accessor: item => (item.supplements ? '' : moment(item.sortDate).format('YYYY-MM-DD')),
+        className: 'col-sdate',
+        Header: 'Last Activity',
+        id: 'sortDate',
+        minWidth: 95,
+        show: false //in discussion
+      }
     ];
 
     const filterMethod = (filter, row, column) => {
@@ -146,7 +155,8 @@ class ComplianceReportingTable extends Component {
         subRowsKey={'supplementalReports'}
 
         getTrProps={(state, row) => {
-          const stripeClass = row && row.nestingPath[0] % 2 ? 'odd':'even' || 'even';
+          console.log(row ? row.nestingPath : '');
+          const stripeClass = row && row.nestingPath[0] % 2 ? 'odd' : 'even' || 'even';
           if (row && row.original) {
             return {
               onClick: (e) => {

--- a/frontend/src/compliance_reporting/components/ComplianceReportingTable.js
+++ b/frontend/src/compliance_reporting/components/ComplianceReportingTable.js
@@ -155,7 +155,6 @@ class ComplianceReportingTable extends Component {
         subRowsKey={'supplementalReports'}
 
         getTrProps={(state, row) => {
-          console.log(row ? row.nestingPath : '');
           const stripeClass = row && row.nestingPath[0] % 2 ? 'odd' : 'even' || 'even';
           if (row && row.original) {
             return {


### PR DESCRIPTION
# Changelog
- Default sort order for compliance reports is "compliance period, last activity" where last activity is the latest update date for any report in the chain of supplementals