### PR TITLE
Schedule Summary Restrictions

### DIFF
--- a/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
@@ -284,7 +284,15 @@ class ComplianceReportingEditContainer extends Component {
     this.props.recomputeTotals({
       id,
       state: {
-        ...schedules
+        schedules: {
+          ...schedules,
+          summary: {
+            dieselClassDeferred: schedules.summary.dieselClassDeferred || 0,
+            dieselClassRetained: schedules.summary.dieselClassRetained || 0,
+            gasolineClassDeferred: schedules.summary.gasolineClassDeferred || 0,
+            gasolineClassRetained: schedules.summary.gasolineClassRetained || 0
+          }
+        }
       }
     });
   }

--- a/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
@@ -285,30 +285,10 @@ class ComplianceReportingEditContainer extends Component {
     const { schedules } = this.state;
     const { id } = this.props.match.params;
 
-    let dieselClassDeferred = 0;
-    let dieselClassRetained = 0;
-    let gasolineClassDeferred = 0;
-    let gasolineClassRetained = 0;
-
-    if (schedules.summmary) {
-      dieselClassDeferred = schedules.summary.dieselClassDeferred || 0;
-      dieselClassRetained = schedules.summary.dieselClassRetained || 0;
-      gasolineClassDeferred = schedules.summary.gasolineClassDeferred || 0;
-      gasolineClassRetained = schedules.summary.gasolineClassRetained || 0;
-    }
-
     this.props.recomputeTotals({
       id,
       state: {
-        schedules: {
-          ...schedules,
-          summary: {
-            dieselClassDeferred,
-            dieselClassRetained,
-            gasolineClassDeferred,
-            gasolineClassRetained
-          }
-        }
+        ...schedules
       }
     });
   }

--- a/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
@@ -125,7 +125,9 @@ class ComplianceReportingEditContainer extends Component {
         id,
         state: {
           // compliancePeriod: period,
-          ...this.state.schedules
+          schedules: {
+            ...this.state.schedules
+          }
         }
       });
 
@@ -190,8 +192,10 @@ class ComplianceReportingEditContainer extends Component {
       id,
       state: {
         compliancePeriod: period,
-        ...schedules,
-        ...mergedState
+        schedules: {
+          ...schedules,
+          ...mergedState
+        }
       }
     });
 
@@ -281,16 +285,28 @@ class ComplianceReportingEditContainer extends Component {
     const { schedules } = this.state;
     const { id } = this.props.match.params;
 
+    let dieselClassDeferred = 0;
+    let dieselClassRetained = 0;
+    let gasolineClassDeferred = 0;
+    let gasolineClassRetained = 0;
+
+    if (schedules.summmary) {
+      dieselClassDeferred = schedules.summary.dieselClassDeferred || 0;
+      dieselClassRetained = schedules.summary.dieselClassRetained || 0;
+      gasolineClassDeferred = schedules.summary.gasolineClassDeferred || 0;
+      gasolineClassRetained = schedules.summary.gasolineClassRetained || 0;
+    }
+
     this.props.recomputeTotals({
       id,
       state: {
         schedules: {
           ...schedules,
           summary: {
-            dieselClassDeferred: schedules.summary.dieselClassDeferred || 0,
-            dieselClassRetained: schedules.summary.dieselClassRetained || 0,
-            gasolineClassDeferred: schedules.summary.gasolineClassDeferred || 0,
-            gasolineClassRetained: schedules.summary.gasolineClassRetained || 0
+            dieselClassDeferred,
+            dieselClassRetained,
+            gasolineClassDeferred,
+            gasolineClassRetained
           }
         }
       }

--- a/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
@@ -336,11 +336,48 @@ class ScheduleSummaryContainer extends Component {
       let { part3, penalty } = this.state;
       const { summary } = nextProps.scheduleState;
 
-      diesel[SCHEDULE_SUMMARY.LINE_6][2].value = summary.dieselClassRetained;
-      diesel[SCHEDULE_SUMMARY.LINE_8][2].value = summary.dieselClassDeferred;
-      gasoline[SCHEDULE_SUMMARY.LINE_17][2].value = summary.gasolineClassRetained;
-      gasoline[SCHEDULE_SUMMARY.LINE_19][2].value = summary.gasolineClassDeferred;
+      const line15percent = diesel[SCHEDULE_SUMMARY.LINE_15][2].value * 0.05;
+      diesel[SCHEDULE_SUMMARY.LINE_17][2].value = summary.dieselClassRetained;
+
+      if (diesel[SCHEDULE_SUMMARY.LINE_17][2].readOnly) {
+        diesel[SCHEDULE_SUMMARY.LINE_17][2].value = 0;
+      } else if (line15percent < summary.dieselClassRetained) {
+        diesel[SCHEDULE_SUMMARY.LINE_17][2].value = line15percent;
+      }
+
+      diesel[SCHEDULE_SUMMARY.LINE_19][2].value = summary.dieselClassDeferred;
+
+      if (diesel[SCHEDULE_SUMMARY.LINE_19][2].readOnly) {
+        diesel[SCHEDULE_SUMMARY.LINE_19][2].value = 0;
+      } else if (line15percent < summary.dieselClassDeferred) {
+        diesel[SCHEDULE_SUMMARY.LINE_19][2].value = line15percent;
+      }
+
+      const line4percent = gasoline[SCHEDULE_SUMMARY.LINE_4][2].value * 0.05;
+      gasoline[SCHEDULE_SUMMARY.LINE_6][2].value = summary.gasolineClassRetained;
+
+      if (gasoline[SCHEDULE_SUMMARY.LINE_6][2].readOnly) {
+        gasoline[SCHEDULE_SUMMARY.LINE_6][2].value = 0;
+      } else if (line4percent < summary.gasolineClassRetained) {
+        gasoline[SCHEDULE_SUMMARY.LINE_6][2].value = line4percent;
+      }
+
+      gasoline[SCHEDULE_SUMMARY.LINE_8][2].value = summary.gasolineClassDeferred;
+
+      if (gasoline[SCHEDULE_SUMMARY.LINE_8][2].readOnly) {
+        gasoline[SCHEDULE_SUMMARY.LINE_8][2].value = 0;
+      } else if (line4percent < summary.gasolineClassDeferred) {
+        gasoline[SCHEDULE_SUMMARY.LINE_8][2].value = line4percent;
+      }
+
       part3[SCHEDULE_SUMMARY.LINE_26][2].value = summary.creditsOffset;
+      const line25value = part3[SCHEDULE_SUMMARY.LINE_25][2].value * -1;
+
+      if (part3[SCHEDULE_SUMMARY.LINE_26][2].readOnly) {
+        part3[SCHEDULE_SUMMARY.LINE_26][2].value = 0;
+      } else if (line25value < part3[SCHEDULE_SUMMARY.LINE_26][2].value) {
+        part3[SCHEDULE_SUMMARY.LINE_26][2].value = line25value;
+      }
 
       part3 = ScheduleSummaryContainer.calculatePart3Payable(part3);
 

--- a/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
@@ -736,26 +736,26 @@ class ScheduleSummaryContainer extends Component {
 
     gasoline[SCHEDULE_SUMMARY.LINE_6][2] = {
       ...gasoline[SCHEDULE_SUMMARY.LINE_6][2],
-      readOnly: gasoline[SCHEDULE_SUMMARY.LINE_2][2].value <=
-        gasoline[SCHEDULE_SUMMARY.LINE_4][2].value
+      readOnly: !gasoline[SCHEDULE_SUMMARY.LINE_2][2].value ||
+        gasoline[SCHEDULE_SUMMARY.LINE_2][2].value <= gasoline[SCHEDULE_SUMMARY.LINE_4][2].value
     };
 
     gasoline[SCHEDULE_SUMMARY.LINE_8][2] = {
       ...gasoline[SCHEDULE_SUMMARY.LINE_8][2],
-      readOnly: gasoline[SCHEDULE_SUMMARY.LINE_4][2].value <=
-        gasoline[SCHEDULE_SUMMARY.LINE_2][2].value
+      readOnly: !gasoline[SCHEDULE_SUMMARY.LINE_2][2].value ||
+        gasoline[SCHEDULE_SUMMARY.LINE_4][2].value <= gasoline[SCHEDULE_SUMMARY.LINE_2][2].value
     };
 
     diesel[SCHEDULE_SUMMARY.LINE_17][2] = {
       ...diesel[SCHEDULE_SUMMARY.LINE_17][2],
-      readOnly: diesel[SCHEDULE_SUMMARY.LINE_13][2].value <=
-        diesel[SCHEDULE_SUMMARY.LINE_15][2].value
+      readOnly: !diesel[SCHEDULE_SUMMARY.LINE_13][2].value ||
+        diesel[SCHEDULE_SUMMARY.LINE_13][2].value <= diesel[SCHEDULE_SUMMARY.LINE_15][2].value
     };
 
     diesel[SCHEDULE_SUMMARY.LINE_19][2] = {
       ...diesel[SCHEDULE_SUMMARY.LINE_19][2],
-      readOnly: diesel[SCHEDULE_SUMMARY.LINE_15][2].value <=
-        diesel[SCHEDULE_SUMMARY.LINE_13][2].value
+      readOnly: !diesel[SCHEDULE_SUMMARY.LINE_13][2].value ||
+        diesel[SCHEDULE_SUMMARY.LINE_15][2].value <= diesel[SCHEDULE_SUMMARY.LINE_13][2].value
     };
 
     penalty = ScheduleSummaryContainer.calculateNonCompliancePayable(penalty);

--- a/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
@@ -734,6 +734,30 @@ class ScheduleSummaryContainer extends Component {
       value: part3[SCHEDULE_SUMMARY.LINE_28][2].value
     };
 
+    gasoline[SCHEDULE_SUMMARY.LINE_6][2] = {
+      ...gasoline[SCHEDULE_SUMMARY.LINE_6][2],
+      readOnly: gasoline[SCHEDULE_SUMMARY.LINE_2][2].value <=
+        gasoline[SCHEDULE_SUMMARY.LINE_4][2].value
+    };
+
+    gasoline[SCHEDULE_SUMMARY.LINE_8][2] = {
+      ...gasoline[SCHEDULE_SUMMARY.LINE_8][2],
+      readOnly: gasoline[SCHEDULE_SUMMARY.LINE_4][2].value <=
+        gasoline[SCHEDULE_SUMMARY.LINE_2][2].value
+    };
+
+    diesel[SCHEDULE_SUMMARY.LINE_17][2] = {
+      ...diesel[SCHEDULE_SUMMARY.LINE_17][2],
+      readOnly: diesel[SCHEDULE_SUMMARY.LINE_13][2].value <=
+        diesel[SCHEDULE_SUMMARY.LINE_15][2].value
+    };
+
+    diesel[SCHEDULE_SUMMARY.LINE_19][2] = {
+      ...diesel[SCHEDULE_SUMMARY.LINE_19][2],
+      readOnly: diesel[SCHEDULE_SUMMARY.LINE_15][2].value <=
+        diesel[SCHEDULE_SUMMARY.LINE_13][2].value
+    };
+
     penalty = ScheduleSummaryContainer.calculateNonCompliancePayable(penalty);
 
     this.setState({

--- a/frontend/src/compliance_reporting/components/ScheduleSummaryDiesel.js
+++ b/frontend/src/compliance_reporting/components/ScheduleSummaryDiesel.js
@@ -226,7 +226,7 @@ class ScheduleSummaryDiesel {
       [{ // line 21
         className: 'text',
         readOnly: true,
-        value: 'Net volume of renewable Part 2 gasoline class fuel supplied ' +
+        value: 'Net volume of renewable Part 2 diesel class fuel supplied ' +
                '(Total of Line 13 + Line 16 - Line 17 + Line 18 + Line 19 - Line 20)'
       }, {
         className: 'line',


### PR DESCRIPTION
#1529 

Changelog:
- Only 1 field is enabled per section in the Summary Page
- Values get automatically adjusted if the max value is lower than the inputted value
- Fixed some bugs with how the state is managed, so there should be less issues when switching back and forth to the summary page