### PR TITLE
Updated schedule c instructions. Disabled two options from expected use

### DIFF
--- a/backend/api/fixtures/operational/0020_update_expected_uses.py
+++ b/backend/api/fixtures/operational/0020_update_expected_uses.py
@@ -1,0 +1,29 @@
+from django.db import transaction
+
+from api.management.data_script import OperationalDataScript
+from api.models.ExpectedUse import ExpectedUse
+
+
+class UpdateExpectedUses(OperationalDataScript):
+    """
+    Updates Permission Labels and Descriptions
+    """
+    is_revertable = False
+    comment = "Expires Aviation and National Defense as they are not " \
+              "required to be reported."
+
+    def check_run_preconditions(self):
+        return True
+
+    @transaction.atomic
+    def run(self):
+        ExpectedUse.objects.filter(
+            description__in=[
+                "Department of National Defence (Canada)",
+                "Aviation"
+            ]
+        ).update(
+            expiration_date="2017-01-01"
+        )
+
+script_class = UpdateExpectedUses

--- a/backend/api/viewsets/ExpectedUse.py
+++ b/backend/api/viewsets/ExpectedUse.py
@@ -1,4 +1,6 @@
 from rest_framework import viewsets, permissions, mixins
+from datetime import date
+from django.db.models import Q
 
 from api.models.ExpectedUse import ExpectedUse
 from api.serializers.ExpectedUse import ExpectedUseSerializer
@@ -26,3 +28,19 @@ class ExpectedUseViewSet(AuditableMixin, mixins.ListModelMixin,
             return self.serializer_classes[self.action]
 
         return self.serializer_classes['default']
+
+    def get_queryset(self):
+        """
+        This view should return a list of all the compliance reports
+        for the currently authenticated user.
+        """
+        as_of = date.today()
+
+        result = ExpectedUse.objects.filter(
+            Q(expiration_date__gte=as_of) | Q(expiration_date=None)
+        )
+        result = result.filter(
+            effective_date__lte=as_of
+        )
+
+        return result

--- a/frontend/src/compliance_reporting/ScheduleCContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleCContainer.js
@@ -531,16 +531,30 @@ class ScheduleCContainer extends Component {
           Under section 6 (3) of the
           <em> Greenhouse Gas Reduction (Renewable and Low Carbon Fuel Requirements) Act
           </em>
-          , Part 3 requirements do not apply in relation to fuel quantities that the Part 3 fuel
-          supplier expects, on reasonable grounds, will be used for a purpose other than
-          transportation. The quantities and expected uses of excluded fuels must be reported in
-          accordance with section 11.08 (4) (d) (ii) of the Regulation.
+          , Part 3 requirements do not apply in relation to fuel quantities that the Part 3
+          fuel supplier expects, on reasonable grounds, will be used for a purpose other than
+          transportation. The quantities and expected uses of excluded fuels must be reported
+          in accordance with section 11.08 (4) (d) (ii) of the Regulation.
         </p>
         <p>
           <strong>
-            The volumes reported here should not be reported in Schedule B. This form will
-            include the quantities entered in this Schedule in the Part 2 Summary section
-            as appropriate.
+            Do not report fuels that are excluded from &quot;gasoline class fuel&quot; and
+            &quot;diesel class fuel&quot;.
+          </strong>
+          Under section (3) of the Renewable and Low Carbon Fuel Requirements Regulation,
+          gasoline class fuel does not include fuel that, at the time of sale, the fuel
+          supplier reasonably expects will be used in an aircraft. Under section 3.1 (2),
+          diesel class fuel does not include fuel that is sold to the Department of National
+          Defence (Canada) if at the time of sale the fuel supplier reasonably expects that
+          the fuel will be used in an aircraft, by the Department of National Defence (Canada)
+          in military vessels, vehicles, aircraft or equipment for military operations, or in
+          military vessels, vehicles, aircraft or equipment of a foreign country.
+        </p>
+        <p>
+          <strong>
+            The volumes reported here should not be reported in Schedule B. The quantities of Part
+            2 fuel entered into this Schedule will be included in the Part 2 Summary section as
+            appropriate.
           </strong>
         </p>
         <p>


### PR DESCRIPTION
#1543 

Changelog:
- Updated schedule c instructions as noted in the card
- Set expiration dates to Aviation and National Defence to disable them