### PR TITLE
Automatically set email based on bceid email if left blank

### DIFF
--- a/frontend/src/admin/users/UserAddContainer.js
+++ b/frontend/src/admin/users/UserAddContainer.js
@@ -118,12 +118,18 @@ class UserAddContainer extends Component {
   _handleSubmit (event) {
     event.preventDefault();
 
+    let email = this.state.fields.userCreationRequest.keycloakEmail;
+
+    if (this.state.fields.email) {
+      ({ email } = this.state.fields.email);
+    }
+
     // API data structure
     const data = {
       user: {
         cellPhone: this.state.fields.mobilePhone,
         username: `user${(new Date().getTime())}`,
-        email: this.state.fields.email,
+        email,
         firstName: this.state.fields.firstName,
         lastName: this.state.fields.lastName,
         organization: this.state.fields.organization ? this.state.fields.organization.id : null,

--- a/frontend/src/admin/users/UserEditContainer.js
+++ b/frontend/src/admin/users/UserEditContainer.js
@@ -127,10 +127,16 @@ class UserEditContainer extends Component {
 
     this.submitted = true;
 
+    let email = this.state.fields.userCreationRequest.keycloakEmail;
+
+    if (this.state.fields.email) {
+      ({ email } = this.state.fields.email);
+    }
+
     // API data structure
     const data = {
       cellPhone: this.state.fields.mobilePhone,
-      email: this.state.fields.email,
+      email,
       firstName: this.state.fields.firstName,
       lastName: this.state.fields.lastName,
       organization: this.state.fields.organization ? this.state.fields.organization.id : null,

--- a/frontend/src/admin/users/components/UserFormDetails.js
+++ b/frontend/src/admin/users/components/UserFormDetails.js
@@ -51,7 +51,7 @@ const UserFormDetails = props => (
           <div className="form-group">
             <label htmlFor="keycloak-email">
               {document.location.pathname.indexOf('/admin/users/') < 0 &&
-                'BCeID Email Address:'}
+                'Email address associated with BCeID user:'}
               {document.location.pathname.indexOf('/admin/users/') >= 0 &&
                 'IDIR Email Address:'}
               {props.isAdding &&
@@ -165,7 +165,7 @@ const UserFormDetails = props => (
       <div className="row">
         <div className="col-sm-6">
           <div className="form-group">
-            <label htmlFor="email">Email:
+            <label htmlFor="email">Alternate email address (to receive notifications):
               <input
                 className="form-control"
                 id="email"
@@ -274,6 +274,7 @@ const UserFormDetails = props => (
 
               if (fileSubmissionRole &&
                 props.fields.organization &&
+                props.fields.organization.status &&
                 props.fields.organization.status.status === 'Archived') {
                 return false;
               }


### PR DESCRIPTION
#1563

Changelog:
- Label changes
- Automatically copy bceid email to the email field when email is left blank