### PR TITLE
Request Supplemental Button no longer hides after being recommended

### DIFF
--- a/backend/api/permissions/ComplianceReport.py
+++ b/backend/api/permissions/ComplianceReport.py
@@ -66,7 +66,13 @@ class ComplianceReportPermissions(permissions.BasePermission):
     actions.append(ActionMap(
         _Relationship.GovernmentAnalyst, 'Submitted',
         '(Recommended|Not Recommended)', 'Unreviewed', 'Unreviewed',
-        ['RETRACT']
+        ['RETRACT', 'REQUEST_SUPPLEMENTAL']
+    ))
+
+    actions.append(ActionMap(
+        _Relationship.GovernmentComplianceManager, 'Submitted',
+        'Unreviewed', 'Unreviewed', 'Unreviewed',
+        ['REQUEST_SUPPLEMENTAL']
     ))
 
     actions.append(ActionMap(
@@ -80,7 +86,7 @@ class ComplianceReportPermissions(permissions.BasePermission):
         _Relationship.GovernmentComplianceManager, 'Submitted',
         '(Recommended|Not Recommended)', '(Recommended|Not Recommended)',
         'Unreviewed',
-        ['RETRACT']
+        ['RETRACT', 'REQUEST_SUPPLEMENTAL']
     ))
 
     actions.append(ActionMap(
@@ -196,6 +202,14 @@ class ComplianceReportPermissions(permissions.BasePermission):
                 ComplianceReportPermissions._Relationship.GovernmentAnalyst:
             if oldstatus.fuel_supplier_status.status not in ['Submitted']:
                 return False  # Not submitted
+            # if either analyst or compliance manager requested supplemental
+            # prevent further status change
+            if oldstatus.analyst_status.status in ['Requested Supplemental'] \
+                or oldstatus.manager_status.status in \
+                    ['Requested Supplemental']:
+                return False  # already requested supplemental
+            if new_analyst_status == 'Requested Supplemental':
+                return True
             if oldstatus.manager_status.status not in [
                     'Unreviewed', 'Returned'
             ]:
@@ -211,6 +225,14 @@ class ComplianceReportPermissions(permissions.BasePermission):
                 ComplianceReportPermissions._Relationship.GovernmentComplianceManager:
             if oldstatus.fuel_supplier_status.status not in ['Submitted']:
                 return False  # Not submitted
+            # if either analyst or compliance manager requested supplemental
+            # prevent further status change
+            if oldstatus.analyst_status.status in ['Requested Supplemental'] \
+                or oldstatus.manager_status.status in \
+                    ['Requested Supplemental']:
+                return False  # already requested supplemental
+            if new_manager_status == 'Requested Supplemental':
+                return True
             if oldstatus.director_status.status not in [
                     'Unreviewed', 'Returned'
             ]:

--- a/backend/api/tests/test_compliance_reporting.py
+++ b/backend/api/tests/test_compliance_reporting.py
@@ -1798,7 +1798,7 @@ class TestComplianceReporting(BaseTestCase):
                 'gov_manager': {
                     'status': 200,
                     'actor': 'MANAGER',
-                    'actions': []
+                    'actions': ['REQUEST_SUPPLEMENTAL']
                 },
                 'gov_director': {
                     'status': 200,
@@ -1815,7 +1815,7 @@ class TestComplianceReporting(BaseTestCase):
                 'gov_analyst': {
                     'status': 200,
                     'actor': 'ANALYST',
-                    'actions': ['RETRACT']
+                    'actions': ['RETRACT', 'REQUEST_SUPPLEMENTAL']
                 },
                 'gov_manager': {
                     'status': 200,
@@ -1842,7 +1842,7 @@ class TestComplianceReporting(BaseTestCase):
                 'gov_manager': {
                     'status': 200,
                     'actor': 'MANAGER',
-                    'actions': ['RETRACT']
+                    'actions': ['RETRACT', 'REQUEST_SUPPLEMENTAL']
                 },
                 'gov_director': {
                     'status': 200,

--- a/frontend/src/admin/users/UserAddContainer.js
+++ b/frontend/src/admin/users/UserAddContainer.js
@@ -121,7 +121,7 @@ class UserAddContainer extends Component {
     let email = this.state.fields.userCreationRequest.keycloakEmail;
 
     if (this.state.fields.email) {
-      ({ email } = this.state.fields.email);
+      ({ email } = this.state.fields);
     }
 
     // API data structure

--- a/frontend/src/admin/users/UserEditContainer.js
+++ b/frontend/src/admin/users/UserEditContainer.js
@@ -130,7 +130,7 @@ class UserEditContainer extends Component {
     let email = this.state.fields.userCreationRequest.keycloakEmail;
 
     if (this.state.fields.email) {
-      ({ email } = this.state.fields.email);
+      ({ email } = this.state.fields);
     }
 
     // API data structure

--- a/frontend/src/compliance_reporting/ComplianceReportingContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingContainer.js
@@ -144,8 +144,8 @@ class ComplianceReportingContainer extends Component {
         show={this.state.showModal}
       >
         <p>
-          Your organization has already submitted a {this.state.reportType} report for
-          the {this.state.selectedComplianceYear} compliance period.
+          Your organization has already submitted {this.state.reportType === 'exclusion' ? 'an ' : 'a ' }
+          {this.state.reportType} report for the {this.state.selectedComplianceYear} compliance period.
           Are you trying to provide new or updated information to the
           Government of British Columbia?
         </p>

--- a/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
@@ -156,6 +156,7 @@ class ComplianceReportingEditContainer extends Component {
       if (nextProps.complianceReporting.item &&
         !nextProps.complianceReporting.item.readOnly) {
         const { schedules } = this.state;
+
         if (schedules.summary && schedules.summary.dieselClassDeferred) {
           schedules.summary.dieselClassDeferred =
             String(schedules.summary.dieselClassDeferred).replace(/,/g, '');

--- a/frontend/src/compliance_reporting/ScheduleAContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleAContainer.js
@@ -110,7 +110,7 @@ class ScheduleAContainer extends Component {
     this.props.loadFuelClasses();
     this.props.loadNotionalTransferTypes();
 
-    if (this.props.scheduleState.scheduleA || this.props.snapshot) {
+    if (this.props.scheduleState.scheduleA || (this.props.snapshot && this.props.readOnly)) {
       // we already have the state. don't load it. just render it.
     } else if (!this.props.complianceReport.scheduleA) {
       this._addRow(5);

--- a/frontend/src/compliance_reporting/ScheduleBContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleBContainer.js
@@ -333,7 +333,7 @@ class ScheduleBContainer extends Component {
   }
 
   componentDidMount () {
-    if (this.props.scheduleState.scheduleB || this.props.snapshot) {
+    if (this.props.scheduleState.scheduleB || (this.props.snapshot && this.props.readOnly)) {
       // we already have the state. don't load it. just render it.
       this.componentWillReceiveProps(this.props);
     } else if (!this.props.complianceReport.scheduleB) {

--- a/frontend/src/compliance_reporting/ScheduleCContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleCContainer.js
@@ -115,7 +115,7 @@ class ScheduleCContainer extends Component {
   componentDidMount () {
     this.props.loadExpectedUses();
 
-    if (this.props.scheduleState.scheduleC || this.props.snapshot) {
+    if (this.props.scheduleState.scheduleC || (this.props.snapshot && this.props.readOnly)) {
       // we already have the state. don't load it. just render it.
     } else if (!this.props.complianceReport.scheduleC) {
       this._addRow(5);

--- a/frontend/src/compliance_reporting/ScheduleDContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleDContainer.js
@@ -58,7 +58,7 @@ class ScheduleDContainer extends Component {
   }
 
   componentDidMount () {
-    if (this.props.scheduleState.scheduleD || this.props.snapshot) {
+    if (this.props.scheduleState.scheduleD || (this.props.snapshot && this.props.readOnly)) {
       // it's probably more elegant to use getDerivedStateFromProps,
       // but it is defined static and we need to access instance methods to set the headers
       this.componentWillReceiveProps(this.props);

--- a/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
@@ -187,7 +187,6 @@ class ScheduleSummaryContainer extends Component {
       }
     };
 
-    this.modalHasBeenShown = false;
     this.rowNumber = 1;
 
     this._closeModal = this._closeModal.bind(this);
@@ -389,6 +388,17 @@ class ScheduleSummaryContainer extends Component {
         gasoline[SCHEDULE_SUMMARY.LINE_8][2].value < summary.gasolineClassDeferred ||
         part3[SCHEDULE_SUMMARY.LINE_26][2].value < summary.creditsOffset) {
         showModal = true;
+
+        this.props.updateScheduleState({
+          summary: {
+            ...summary,
+            creditsOffset: part3[SCHEDULE_SUMMARY.LINE_26][2].value,
+            dieselClassDeferred: diesel[SCHEDULE_SUMMARY.LINE_19][2].value,
+            dieselClassRetained: diesel[SCHEDULE_SUMMARY.LINE_17][2].value,
+            gasolineClassDeferred: gasoline[SCHEDULE_SUMMARY.LINE_8][2].value,
+            gasolineClassRetained: gasoline[SCHEDULE_SUMMARY.LINE_6][2].value
+          }
+        });
       }
     }
 
@@ -1047,15 +1057,11 @@ class ScheduleSummaryContainer extends Component {
       <CallableModal
         cancelLabel={Lang.BTN_OK}
         close={() => {
-          this.modalHasBeenShown = true;
           this._closeModal();
-        }}
-        handleOnLoad={() => {
-          this.modalHasBeenShown = true;
         }}
         id="warning"
         key="warning"
-        show={this.state.showModal && !this.modalHasBeenShown}
+        show={this.state.showModal}
       >
         <p>
           The values you previously entered in the Summary &amp; Declaration tab have been cleared

--- a/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
@@ -187,6 +187,7 @@ class ScheduleSummaryContainer extends Component {
       }
     };
 
+    this.modalHasBeenShown = false;
     this.rowNumber = 1;
 
     this._closeModal = this._closeModal.bind(this);
@@ -1046,11 +1047,15 @@ class ScheduleSummaryContainer extends Component {
       <CallableModal
         cancelLabel={Lang.BTN_OK}
         close={() => {
+          this.modalHasBeenShown = true;
           this._closeModal();
+        }}
+        handleOnLoad={() => {
+          this.modalHasBeenShown = true;
         }}
         id="warning"
         key="warning"
-        show={this.state.showModal}
+        show={this.state.showModal && !this.modalHasBeenShown}
       >
         <p>
           The values you previously entered in the Summary &amp; Declaration tab have been cleared

--- a/frontend/src/compliance_reporting/components/ScheduleButtons.js
+++ b/frontend/src/compliance_reporting/components/ScheduleButtons.js
@@ -46,8 +46,14 @@ const getValidationMessages = (props) => {
     item.type === type
   ));
 
+  let typeString = `A ${type}`;
+
+  if (type === 'Exclusion Report') {
+    typeString = `An ${type}`;
+  }
+
   if (found && !props.complianceReport.isSupplemental) {
-    return `A ${type} for ${period} has already been submitted
+    return `${typeString} for ${period} has already been submitted
       to the Government of British Columbia. If the information in the previous report does not
       completely and accurately disclose the information required to be included in the report,
       please create a supplemental report by opening the previous report and clicking on the

--- a/frontend/src/dashboard/components/DashboardPage.js
+++ b/frontend/src/dashboard/components/DashboardPage.js
@@ -157,6 +157,7 @@ const IDIRDashboardPage = obj => (
     <div className="col-md-4">
       {(typeof obj.loggedInUser.hasPermission === 'function' &&
       obj.loggedInUser.hasPermission(PERMISSIONS_SECURE_DOCUMENT_UPLOAD.VIEW)) &&
+      CONFIG.SECURE_DOCUMENT_UPLOAD.ENABLED &&
       <FileSubmissions
         documentUploads={obj.documentUploads}
         setFilter={obj.setFilter}

--- a/frontend/src/exclusion_reports/ExclusionReportEditContainer.js
+++ b/frontend/src/exclusion_reports/ExclusionReportEditContainer.js
@@ -550,7 +550,7 @@ ExclusionReportEditContainer.propTypes = {
         PropTypes.string
       ]),
       hasSnapshot: PropTypes.bool,
-      organization: PropTypes.shape,
+      organization: PropTypes.shape(),
       type: PropTypes.shape()
     }),
     success: PropTypes.bool,

--- a/frontend/src/settings/components/SettingsDetails.js
+++ b/frontend/src/settings/components/SettingsDetails.js
@@ -66,7 +66,7 @@ const SettingsDetails = props => (
           type="credit-transfer"
         />,
         <h3 key="header-pvr">
-          Part 3 Awards, Credit Validations, and Credit Reductions
+          Part 3 Awards
         </h3>,
         <NotificationsTable
           addToFields={props.addToFields}


### PR DESCRIPTION
#1587 

Changelog:
- Fixed some grammar issues
- Fixed an issue where new schedules would not have any initial rows
- Modal warning no longer shows up after saving
- Request Supplemental button is now available to analyst and compliance manager throughout the review process