### PR TITLE
Request Supplemental Button - Analyst

### DIFF
--- a/backend/api/permissions/ComplianceReport.py
+++ b/backend/api/permissions/ComplianceReport.py
@@ -72,7 +72,7 @@ class ComplianceReportPermissions(permissions.BasePermission):
     actions.append(ActionMap(
         _Relationship.GovernmentAnalyst, 'Submitted',
         '(Recommended|Not Recommended)', '(Recommended|Not Recommended)',
-        'Accepted',
+        '(Accepted|Unreviewed)',
         ['REQUEST_SUPPLEMENTAL']
     ))
 

--- a/backend/api/tests/test_compliance_reporting.py
+++ b/backend/api/tests/test_compliance_reporting.py
@@ -1837,7 +1837,7 @@ class TestComplianceReporting(BaseTestCase):
                 'gov_analyst': {
                     'status': 200,
                     'actor': 'ANALYST',
-                    'actions': []
+                    'actions': ['REQUEST_SUPPLEMENTAL']
                 },
                 'gov_manager': {
                     'status': 200,


### PR DESCRIPTION
#1587 

Changelog:
- Fixed an issue where request supplemental wasn't available for government analyst after it's been recommended by a compliance manager