### PR TITLE
Missing Create Supplemental Report Button Fix

### DIFF
--- a/backend/api/permissions/ComplianceReport.py
+++ b/backend/api/permissions/ComplianceReport.py
@@ -54,7 +54,10 @@ class ComplianceReportPermissions(permissions.BasePermission):
     actions.append(ActionMap(
         _Relationship.FuelSupplier,
         'Submitted', '.*', '.*', '(Unreviewed|Accepted)',
-        lambda c: ['CREATE_SUPPLEMENTAL'] if len(c.supplemental_reports.all()) == 0 else []
+        lambda c: ['CREATE_SUPPLEMENTAL']
+        if len(c.supplemental_reports.exclude(
+            status__fuel_supplier_status="Deleted"
+        ).all()) == 0 else []
     ))
 
     actions.append(ActionMap(


### PR DESCRIPTION
Changelog:
- Added a check when showing the create supplemental button to exclude deleted supplemental drafts