### PR TITLE
Create supplemental report copy values

### DIFF
--- a/backend/api/permissions/ComplianceReport.py
+++ b/backend/api/permissions/ComplianceReport.py
@@ -54,7 +54,10 @@ class ComplianceReportPermissions(permissions.BasePermission):
     actions.append(ActionMap(
         _Relationship.FuelSupplier,
         'Submitted', '.*', '.*', '(Unreviewed|Accepted)',
-        lambda c: ['CREATE_SUPPLEMENTAL'] if len(c.supplemental_reports.all()) == 0 else []
+        lambda c: ['CREATE_SUPPLEMENTAL']
+        if len(c.supplemental_reports.exclude(
+            status__fuel_supplier_status="Deleted"
+        ).all()) == 0 else []
     ))
 
     actions.append(ActionMap(

--- a/backend/api/serializers/ComplianceReport.py
+++ b/backend/api/serializers/ComplianceReport.py
@@ -936,6 +936,14 @@ class ComplianceReportCreateSerializer(serializers.ModelSerializer):
                 summary.diesel_class_deferred = \
                     original_summary.diesel_class_deferred
                 summary.credits_offset = original_summary.credits_offset
+                summary.gasoline_class_previously_retained = \
+                    original_summary.gasoline_class_previously_retained
+                summary.gasoline_class_obligation = \
+                    original_summary.gasoline_class_obligation
+                summary.diesel_class_previously_retained = \
+                    original_summary.diesel_class_previously_retained
+                summary.diesel_class_obligation = \
+                    original_summary.diesel_class_obligation
                 summary.save()
 
             if original_report.exclusion_agreement is not None:

--- a/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
@@ -216,8 +216,6 @@ class ScheduleSummaryContainer extends Component {
     const { diesel, gasoline } = this.state;
     let { part3, penalty, showModal } = this.state;
 
-    showModal = false;
-
     if (nextProps.snapshot && nextProps.readOnly) {
       const { summary } = nextProps.snapshot;
 
@@ -321,7 +319,7 @@ class ScheduleSummaryContainer extends Component {
       diesel[SCHEDULE_SUMMARY.LINE_17][2].value = summary.dieselClassRetained;
 
       if (diesel[SCHEDULE_SUMMARY.LINE_17][2].readOnly ||
-        line15percent < summary.dieselClassRetained) {
+        (line15percent && line15percent < summary.dieselClassRetained)) {
         diesel[SCHEDULE_SUMMARY.LINE_17][2].value = 0;
       }
 
@@ -330,7 +328,7 @@ class ScheduleSummaryContainer extends Component {
       diesel[SCHEDULE_SUMMARY.LINE_19][2].value = summary.dieselClassDeferred;
 
       if (diesel[SCHEDULE_SUMMARY.LINE_19][2].readOnly ||
-        line15percent < summary.dieselClassDeferred) {
+        (line15percent && line15percent < summary.dieselClassDeferred)) {
         diesel[SCHEDULE_SUMMARY.LINE_19][2].value = 0;
       }
 
@@ -340,7 +338,7 @@ class ScheduleSummaryContainer extends Component {
       gasoline[SCHEDULE_SUMMARY.LINE_6][2].value = summary.gasolineClassRetained;
 
       if (gasoline[SCHEDULE_SUMMARY.LINE_6][2].readOnly ||
-        line4percent < summary.gasolineClassRetained) {
+        (line4percent && line4percent < summary.gasolineClassRetained)) {
         gasoline[SCHEDULE_SUMMARY.LINE_6][2].value = 0;
       }
 
@@ -349,7 +347,7 @@ class ScheduleSummaryContainer extends Component {
       gasoline[SCHEDULE_SUMMARY.LINE_8][2].value = summary.gasolineClassDeferred;
 
       if (gasoline[SCHEDULE_SUMMARY.LINE_8][2].readOnly ||
-        line4percent < summary.gasolineClassDeferred) {
+        (line4percent && line4percent < summary.gasolineClassDeferred)) {
         gasoline[SCHEDULE_SUMMARY.LINE_8][2].value = 0;
       }
 
@@ -359,7 +357,7 @@ class ScheduleSummaryContainer extends Component {
       const line25value = part3[SCHEDULE_SUMMARY.LINE_25][2].value * -1;
 
       if (part3[SCHEDULE_SUMMARY.LINE_26][2].readOnly ||
-        line25value < part3[SCHEDULE_SUMMARY.LINE_26][2].value) {
+        (line25value && line25value < part3[SCHEDULE_SUMMARY.LINE_26][2].value)) {
         part3[SCHEDULE_SUMMARY.LINE_26][2].value = 0;
       }
 


### PR DESCRIPTION
Changelog:
- Fixed previously retained and obligation not being copied when creating a supplemental report
- Modal warning in summary page should stay up
- It should no longer always clear values when switching schedules