### PR TITLE
Prevent signing sell offers as the initiator based on credit balance and pending transfers 

### DIFF
--- a/backend/api/permissions/SigningAuthorityConfirmation.py
+++ b/backend/api/permissions/SigningAuthorityConfirmation.py
@@ -25,7 +25,6 @@ from enum import Enum
 from rest_framework import permissions
 
 from api.models.ComplianceReport import ComplianceReport
-from api.models.CreditTrade import CreditTrade
 from api.services.CreditTradeService import CreditTradeService
 
 

--- a/backend/api/permissions/SigningAuthorityConfirmation.py
+++ b/backend/api/permissions/SigningAuthorityConfirmation.py
@@ -21,10 +21,12 @@
 """
 from collections import defaultdict
 from enum import Enum
+from django.db.models import Q, Sum
 
 from rest_framework import permissions
 
 from api.models.ComplianceReport import ComplianceReport
+from api.models.CreditTrade import CreditTrade
 from api.services.CreditTradeService import CreditTradeService
 
 
@@ -53,6 +55,27 @@ class SigningAuthorityConfirmationPermissions(permissions.BasePermission):
             relationship = SigningAuthorityConfirmationPermissions._Relationship.INITIATOR
         if credit_trade.respondent.id == user.organization.id:
             relationship = SigningAuthorityConfirmationPermissions._Relationship.RESPONDENT
+
+        pending_trades = CreditTrade.objects.filter(
+            (Q(status__status__in=[
+                "Submitted", "Recommended", "Not Recommended"
+            ]) &
+             Q(type__the_type="Sell") &
+             Q(initiator_id=user.organization_id) &
+             Q(is_rescinded=False)) |
+            (Q(status__status__in=[
+                "Accepted", "Recommended", "Not Recommended"
+            ]) &
+             Q(type__the_type="Buy") &
+             Q(respondent_id=user.organization.id) &
+             Q(is_rescinded=False))
+        ).aggregate(total_credits=Sum('number_of_credits'))
+
+        temp_balance = user.organization.organization_balance['validated_credits']
+        temp_balance -= pending_trades['total_credits']
+        temp_balance -= credit_trade.number_of_credits
+        if temp_balance < 0:
+            return False
 
         return SigningAuthorityConfirmationPermissions.action_mapping[(
             relationship,

--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -189,7 +189,6 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
             ).aggregate(total_credits=Sum('number_of_credits'))
 
             if pending_trades['total_credits'] is not None:
-                print(pending_trades)
                 temp_balance = balance
                 temp_balance -= pending_trades['total_credits']
                 temp_balance -= number_of_credits

--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -165,9 +165,12 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
 
             if balance < number_of_credits:
                 raise serializers.ValidationError({
-                    'insufficientCredits': "{} does not have enough credits "
-                                           "for the proposal.".format(
-                                               request.user.organization.name)
+                    'insufficientCredits':
+                    "Unable to initiate this Credit Transfer Proposal. "
+                    "Your organization either does not have enough "
+                    "validated credits or has pending Credit Transfer "
+                    "Proposal(s) that could result in an insufficient "
+                    "credit balance for this transfer."
                 })
 
             pending_trades = CreditTrade.objects.filter(
@@ -194,10 +197,11 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
                 if temp_balance < 0:
                     raise serializers.ValidationError({
                         'insufficientCredits':
-                        "{} does not have enough credits "
-                        "for the proposal.".format(
-                            request.user.organization.name
-                        )
+                        "Unable to initiate this Credit Transfer Proposal. "
+                        "Your organization either does not have enough "
+                        "validated credits or has pending Credit Transfer "
+                        "Proposal(s) that could result in an insufficient "
+                        "credit balance for this transfer."
                     })
 
         if request.user.organization.actions_type.the_type == 'None':
@@ -522,9 +526,12 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
                 data.get('is_rescinded') is not True:
             if balance < number_of_credits:
                 raise serializers.ValidationError({
-                    'insufficientCredits': "{} does not have enough credits "
-                                           "for the proposal.".format(
-                                               request.user.organization.name)
+                    'insufficientCredits':
+                    "Unable to initiate this Credit Transfer Proposal. "
+                    "Your organization either does not have enough "
+                    "validated credits or has pending Credit Transfer "
+                    "Proposal(s) that could result in an insufficient "
+                    "credit balance for this transfer."
                 })
 
             pending_trades = CreditTrade.objects.filter(
@@ -550,10 +557,11 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
                 if temp_balance < 0:
                     raise serializers.ValidationError({
                         'insufficientCredits':
-                        "{} does not have enough credits for the "
-                        "proposal.".format(
-                            request.user.organization.name
-                        )
+                        "Unable to initiate this Credit Transfer Proposal. "
+                        "Your organization either does not have enough "
+                        "validated credits or has pending Credit Transfer "
+                        "Proposal(s) that could result in an insufficient "
+                        "credit balance for this transfer."
                     })
 
         return data

--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -45,6 +45,11 @@ from .CompliancePeriod import CompliancePeriodSerializer
 from .Organization import OrganizationMinSerializer, OrganizationSerializer
 from .User import UserMinSerializer
 
+INSUFFICIENT_CREDITS_MESSAGE = "Unable to initiate this Credit Transfer " \
+    "Proposal. Your organization either does not have enough " \
+    "validated credits or has pending Credit Transfer Proposal(s) that " \
+    "could result in an insufficient credit balance for this transfer."
+
 
 class CreditTradeCreateSerializer(serializers.ModelSerializer):
     """
@@ -107,8 +112,8 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
                     raise serializers.ValidationError({
                         'forbidden': "Please provide an explanation in the "
                                      "comments as to why the Credit Transfer "
-                                     "Proposal has a fair market value of zero "
-                                     "dollars per credit."
+                                     "Proposal has a fair market value of "
+                                     "zero dollars per credit."
                     })
 
         if credit_trade_status not in allowed_statuses:
@@ -165,12 +170,7 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
 
             if balance < number_of_credits:
                 raise serializers.ValidationError({
-                    'insufficientCredits':
-                    "Unable to initiate this Credit Transfer Proposal. "
-                    "Your organization either does not have enough "
-                    "validated credits or has pending Credit Transfer "
-                    "Proposal(s) that could result in an insufficient "
-                    "credit balance for this transfer."
+                    'insufficientCredits': INSUFFICIENT_CREDITS_MESSAGE
                 })
 
             pending_trades = CreditTrade.objects.filter(
@@ -196,12 +196,7 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
 
                 if temp_balance < 0:
                     raise serializers.ValidationError({
-                        'insufficientCredits':
-                        "Unable to initiate this Credit Transfer Proposal. "
-                        "Your organization either does not have enough "
-                        "validated credits or has pending Credit Transfer "
-                        "Proposal(s) that could result in an insufficient "
-                        "credit balance for this transfer."
+                        'insufficientCredits': INSUFFICIENT_CREDITS_MESSAGE
                     })
 
         if request.user.organization.actions_type.the_type == 'None':
@@ -526,12 +521,7 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
                 data.get('is_rescinded') is not True:
             if balance < number_of_credits:
                 raise serializers.ValidationError({
-                    'insufficientCredits':
-                    "Unable to initiate this Credit Transfer Proposal. "
-                    "Your organization either does not have enough "
-                    "validated credits or has pending Credit Transfer "
-                    "Proposal(s) that could result in an insufficient "
-                    "credit balance for this transfer."
+                    'insufficientCredits': INSUFFICIENT_CREDITS_MESSAGE
                 })
 
             pending_trades = CreditTrade.objects.filter(
@@ -556,12 +546,7 @@ class CreditTradeUpdateSerializer(serializers.ModelSerializer):
 
                 if temp_balance < 0:
                     raise serializers.ValidationError({
-                        'insufficientCredits':
-                        "Unable to initiate this Credit Transfer Proposal. "
-                        "Your organization either does not have enough "
-                        "validated credits or has pending Credit Transfer "
-                        "Proposal(s) that could result in an insufficient "
-                        "credit balance for this transfer."
+                        'insufficientCredits': INSUFFICIENT_CREDITS_MESSAGE
                     })
 
         return data
@@ -728,7 +713,9 @@ class CreditTrade2Serializer(serializers.ModelSerializer):
     def get_comment_actions(self, obj):
         """Attach available commenting actions"""
         request = self.context.get('request')
-        return CreditTradeCommentActions.available_comment_actions(request, obj)
+        return CreditTradeCommentActions.available_comment_actions(
+            request, obj
+        )
 
     def get_comments(self, obj):
         """

--- a/backend/api/services/CreditTradeService.py
+++ b/backend/api/services/CreditTradeService.py
@@ -215,10 +215,10 @@ class CreditTradeService(object):
                 get_temp_balance(temp_storage, credit_trade.credits_to.id)
 
             from_credits_remaining = from_starting_balance - \
-                                     credit_trade.number_of_credits
+                credit_trade.number_of_credits
 
             to_credits_remaining = to_starting_balance + \
-                                   credit_trade.number_of_credits
+                credit_trade.number_of_credits
 
             CreditTradeService.update_temp_balance(
                 temp_storage,
@@ -236,8 +236,10 @@ class CreditTradeService(object):
                 errors.append(
                     "[ID: {}] "
                     "Can't complete transaction,"
-                    "`{}` has insufficient credits.".
-                        format(credit_trade.id, credit_trade.credits_from.name))
+                    "`{}` has insufficient credits.".format(
+                        credit_trade.id, credit_trade.credits_from.name
+                    )
+                )
 
         if errors:
             raise PositiveIntegerException(errors)
@@ -247,7 +249,7 @@ class CreditTradeService(object):
         """
         Gets the credits of an organization stored in a temporary list
         This allows us to simulate credit transfers without actually
-        needing to write to the database. (e.g. Lets us find out if
+        needing to write to the database. (e.g. Lets find out if
         the organization has enough credits to do the transfer)
         """
         starting_balance = None

--- a/backend/api/services/CreditTradeService.py
+++ b/backend/api/services/CreditTradeService.py
@@ -54,14 +54,14 @@ class CreditTradeService(object):
             #   show "Submitted" and other transactions where the fuel
             #   supplier is the respondent
             credit_trades = CreditTrade.objects.filter((
-                    (
-                            (~Q(status__status__in=[
-                                "Recorded", "Cancelled"]) &
-                             Q(type__is_gov_only_type=False)) |
-                            (Q(status__status__in=[
-                                "Approved", "Declined"]) &
-                             Q(type__is_gov_only_type=True))
-                    ) &
+                    ((~Q(status__status__in=[
+                            "Recorded", "Cancelled"
+                        ]) &
+                      Q(type__is_gov_only_type=False)) |
+                     (Q(status__status__in=[
+                            "Approved", "Declined"
+                        ]) &
+                      Q(type__is_gov_only_type=True))) &
                     ((~Q(status__status__in=["Draft"]) &
                       Q(respondent=organization)) | Q(initiator=organization))
             ))


### PR DESCRIPTION
Changelog:
- Added a validation to prevent the user from signing a sell offer if it would put them over their credit balance, after counting the pending transactions