### PR TITLE
Removing ^ from version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,7 @@
     "redux-thunk": "^2.3.0",
     "snyk": "^1.161.0",
     "socket.io": "^2.2.0",
-    "socket.io-client": "^2.2.0",
+    "socket.io-client": "2.2.0",
     "socket.io-middleware": "^0.2.1",
     "webpack": "^4.28.3",
     "winston": "^3.2.1"


### PR DESCRIPTION
Changelog:
- Even just a build number difference seems to be causing the issue, so explicit version now