### PR TITLE
Load supplemental report on create

### DIFF
--- a/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
@@ -3,15 +3,15 @@
  * All data handling & manipulation should be handled here.
  */
 
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { toastr as reduxToastr } from 'react-redux-toastr';
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
+import {toastr as reduxToastr} from 'react-redux-toastr';
 import ReactMarkdown from 'react-markdown';
 import PropTypes from 'prop-types';
 
-import { addSigningAuthorityConfirmation } from '../actions/signingAuthorityConfirmationsActions';
+import {addSigningAuthorityConfirmation} from '../actions/signingAuthorityConfirmationsActions';
 import getSigningAuthorityAssertions from '../actions/signingAuthorityAssertionsActions';
-import { complianceReporting } from '../actions/complianceReporting';
+import {complianceReporting} from '../actions/complianceReporting';
 import CheckBox from '../app/components/CheckBox';
 import AddressBuilder from '../app/components/AddressBuilder';
 import COMPLIANCE_REPORTING from '../constants/routes/ComplianceReporting';
@@ -34,7 +34,7 @@ import autosaved from '../utils/autosave_support';
 import ChangelogContainer from './ChangelogContainer';
 
 class ComplianceReportingEditContainer extends Component {
-  static cleanSummaryValues (summary) {
+  static cleanSummaryValues(summary) {
     return {
       ...summary,
       creditsOffset: Number(summary.creditsOffset),
@@ -49,7 +49,7 @@ class ComplianceReportingEditContainer extends Component {
     };
   }
 
-  static componentForTabName (tab) {
+  static componentForTabName(tab) {
     let TabComponent;
 
     switch (tab) {
@@ -92,10 +92,10 @@ class ComplianceReportingEditContainer extends Component {
     return TabComponent;
   }
 
-  constructor (props) {
+  constructor(props) {
     super(props);
     this.tabComponent = Loading;
-    const { tab } = props.match.params;
+    const {tab} = props.match.params;
     this.tabComponent = ComplianceReportingEditContainer.componentForTabName(tab);
     this.status = {
       fuelSupplierStatus: 'Draft'
@@ -130,7 +130,7 @@ class ComplianceReportingEditContainer extends Component {
     this._validate = this._validate.bind(this);
   }
 
-  componentDidMount () {
+  componentDidMount() {
     this.props.getSigningAuthorityAssertions({
       module: 'compliance_report'
     });
@@ -143,19 +143,19 @@ class ComplianceReportingEditContainer extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps, nextContext) {
-    const { tab } = nextProps.match.params;
+  componentWillReceiveProps(nextProps, nextContext) {
+    const {tab} = nextProps.match.params;
 
     if (tab !== this.props.match.params.tab) {
       this.tabComponent = ComplianceReportingEditContainer.componentForTabName(tab);
     }
 
     if (this.props.complianceReporting.isGetting && !nextProps.complianceReporting.isGetting) {
-      const { id } = this.props.match.params;
+      const {id} = this.props.match.params;
 
       if (nextProps.complianceReporting.item &&
         !nextProps.complianceReporting.item.readOnly) {
-        const { schedules } = this.state;
+        const {schedules} = this.state;
 
         if (schedules.summary && schedules.summary.dieselClassDeferred) {
           schedules.summary.dieselClassDeferred =
@@ -214,7 +214,8 @@ class ComplianceReportingEditContainer extends Component {
       } else {
         this.props.invalidateAutosaved();
         toastr.complianceReporting('Supplemental Created');
-        history.push(COMPLIANCE_REPORTING.LIST);
+        history.push(COMPLIANCE_REPORTING.EDIT_REDIRECT.replace(':id', nextProps.complianceReporting.item.id));
+
       }
     }
 
@@ -249,10 +250,10 @@ class ComplianceReportingEditContainer extends Component {
     }
   }
 
-  _updateScheduleState (_mergedState) {
+  _updateScheduleState(_mergedState) {
     const mergedState = _mergedState;
-    const { schedules } = this.state;
-    const { id } = this.props.match.params;
+    const {schedules} = this.state;
+    const {id} = this.props.match.params;
     const period = this.props.complianceReporting.item.compliancePeriod.description;
 
     if (schedules.summary && schedules.summary.dieselClassDeferred) {
@@ -345,11 +346,11 @@ class ComplianceReportingEditContainer extends Component {
     });
   }
 
-  _handleDelete () {
-    this.props.deleteComplianceReport({ id: this.props.match.params.id });
+  _handleDelete() {
+    this.props.deleteComplianceReport({id: this.props.match.params.id});
   }
 
-  _handleCreateSupplemental (event, compliancePeriodDescription) {
+  _handleCreateSupplemental(event, compliancePeriodDescription) {
     this.setState({
       createSupplementalCalled: true
     });
@@ -364,8 +365,8 @@ class ComplianceReportingEditContainer extends Component {
     });
   }
 
-  _addToFields (value) {
-    const { terms } = this.state;
+  _addToFields(value) {
+    const {terms} = this.state;
 
     const found = terms.find(term => term.id === value.id);
 
@@ -378,8 +379,8 @@ class ComplianceReportingEditContainer extends Component {
     });
   }
 
-  _toggleCheck (key) {
-    const { terms } = this.state;
+  _toggleCheck(key) {
+    const {terms} = this.state;
     const index = terms.findIndex(term => term.id === key);
     terms[index].value = !terms[index].value;
 
@@ -388,13 +389,13 @@ class ComplianceReportingEditContainer extends Component {
     });
   }
 
-  _handleSupplementalNoteUpdate (event) {
+  _handleSupplementalNoteUpdate(event) {
     this.setState({
       supplementalNote: event.target.value
     });
   }
 
-  _handleSubmit (event, status = { fuelSupplierStatus: 'Draft' }) {
+  _handleSubmit(event, status = {fuelSupplierStatus: 'Draft'}) {
     // patch existing
     const payload = {
       status,
@@ -408,7 +409,7 @@ class ComplianceReportingEditContainer extends Component {
     }
 
     if (payload.summary) {
-      const { summary } = payload;
+      const {summary} = payload;
 
       payload.summary = ComplianceReportingEditContainer.cleanSummaryValues(summary);
     }
@@ -437,15 +438,15 @@ class ComplianceReportingEditContainer extends Component {
     }
   }
 
-  _handleRecomputeRequest () {
-    const { schedules } = this.state;
+  _handleRecomputeRequest() {
+    const {schedules} = this.state;
 
-    const { id } = this.props.match.params;
+    const {id} = this.props.match.params;
 
     if (!this.props.complianceReporting.validationMessages ||
       Object.keys(this.props.complianceReporting.validationMessages).length === 0) {
 
-      const { summary } = schedules;
+      const {summary} = schedules;
 
       if (summary && !summary.dieselClassDeferred) {
         summary.dieselClassDeferred = 0;
@@ -495,17 +496,17 @@ class ComplianceReportingEditContainer extends Component {
     }
   }
 
-  _showPenaltyWarning (bool) {
+  _showPenaltyWarning(bool) {
     this.setState({
       ...this.state,
       showPenaltyWarning: bool
     });
   }
 
-  _validate (_payload) {
+  _validate(_payload) {
     const payload = _payload;
     if (payload.state && payload.state.summary) {
-      const { summary } = payload.state;
+      const {summary} = payload.state;
 
       payload.state.summary = ComplianceReportingEditContainer.cleanSummaryValues(summary);
     }
@@ -513,21 +514,21 @@ class ComplianceReportingEditContainer extends Component {
     return this.props.validateComplianceReport(payload);
   }
 
-  render () {
+  render() {
     const TabComponent = this.tabComponent;
 
-    const { tab, id } = this.props.match.params;
+    const {tab, id} = this.props.match.params;
 
     if (!this.state.getCalled) {
-      return (<Loading />);
+      return (<Loading/>);
     }
 
     if (this.props.complianceReporting.isGetting) {
-      return (<Loading />);
+      return (<Loading/>);
     }
 
     if (this.props.complianceReporting.snapshotIsLoading) {
-      return (<Loading />);
+      return (<Loading/>);
     }
 
     let period = null;
@@ -542,10 +543,10 @@ class ComplianceReportingEditContainer extends Component {
     if (this.props.complianceReporting.item.hasSnapshot &&
       this.props.complianceReporting.snapshot &&
       this.props.complianceReporting.snapshot.organization.organizationAddress) {
-      ({ organizationAddress } = this.props.complianceReporting.snapshot.organization);
+      ({organizationAddress} = this.props.complianceReporting.snapshot.organization);
     } else if (this.props.loggedInUser.organization.organizationAddress &&
       !this.props.loggedInUser.isGovernmentUser) {
-      ({ organizationAddress } = this.props.loggedInUser.organization);
+      ({organizationAddress} = this.props.loggedInUser.organization);
     }
 
     return ([
@@ -560,14 +561,14 @@ class ComplianceReportingEditContainer extends Component {
       </h2>,
       <p key="organization-address">
         {organizationAddress &&
-          AddressBuilder({
-            address_line_1: organizationAddress.addressLine_1,
-            address_line_2: organizationAddress.addressLine_2,
-            address_line_3: organizationAddress.addressLine_3,
-            city: organizationAddress.city,
-            state: organizationAddress.state,
-            postal_code: organizationAddress.postalCode
-          })
+        AddressBuilder({
+          address_line_1: organizationAddress.addressLine_1,
+          address_line_2: organizationAddress.addressLine_2,
+          address_line_3: organizationAddress.addressLine_3,
+          city: organizationAddress.city,
+          state: organizationAddress.state,
+          postal_code: organizationAddress.postalCode
+        })
         }
       </p>,
       <ScheduleTabs
@@ -619,56 +620,56 @@ class ComplianceReportingEditContainer extends Component {
         validationMessages={this.props.complianceReporting.validationMessages}
       />,
       <Modal
-        handleSubmit={event => this._handleSubmit(event, { analystStatus: 'Requested Supplemental' })}
+        handleSubmit={event => this._handleSubmit(event, {analystStatus: 'Requested Supplemental'})}
         id="confirmAnalystRequestSupplemental"
         key="confirmAnalystRequestSupplemental"
       >
         Are you sure you want to request a supplemental compliance report?
       </Modal>,
       <Modal
-        handleSubmit={event => this._handleSubmit(event, { analystStatus: 'Recommended' })}
+        handleSubmit={event => this._handleSubmit(event, {analystStatus: 'Recommended'})}
         id="confirmAnalystRecommendAcceptance"
         key="confirmAnalystRecommendAcceptance"
       >
         Are you sure you want to recommend acceptance of the compliance report?
       </Modal>,
       <Modal
-        handleSubmit={event => this._handleSubmit(event, { analystStatus: 'Not Recommended' })}
+        handleSubmit={event => this._handleSubmit(event, {analystStatus: 'Not Recommended'})}
         id="confirmAnalystRecommendRejection"
         key="confirmAnalystRecommendRejection"
       >
         Are you sure you want to recommend rejection of the compliance report?
       </Modal>,
       <Modal
-        handleSubmit={event => this._handleSubmit(event, { managerStatus: 'Requested Supplemental' })}
+        handleSubmit={event => this._handleSubmit(event, {managerStatus: 'Requested Supplemental'})}
         id="confirmManagerRequestSupplemental"
         key="confirmManagerRequestSupplemental"
       >
         Are you sure you want to request a supplemental compliance report?
       </Modal>,
       <Modal
-        handleSubmit={event => this._handleSubmit(event, { managerStatus: 'Recommended' })}
+        handleSubmit={event => this._handleSubmit(event, {managerStatus: 'Recommended'})}
         id="confirmManagerRecommendAcceptance"
         key="confirmManagerRecommendAcceptance"
       >
         Are you sure you want to recommend acceptance of the compliance report?
       </Modal>,
       <Modal
-        handleSubmit={event => this._handleSubmit(event, { managerStatus: 'Not Recommended' })}
+        handleSubmit={event => this._handleSubmit(event, {managerStatus: 'Not Recommended'})}
         id="confirmManagerRecommendRejection"
         key="confirmManagerRecommendRejection"
       >
         Are you sure you want to recommend rejection of the compliance report?
       </Modal>,
       <Modal
-        handleSubmit={event => this._handleSubmit(event, { directorStatus: 'Rejected' })}
+        handleSubmit={event => this._handleSubmit(event, {directorStatus: 'Rejected'})}
         id="confirmDirectorReject"
         key="confirmDirectorReject"
       >
         Are you sure you want to reject this compliance report?
       </Modal>,
       <Modal
-        handleSubmit={event => this._handleSubmit(event, { directorStatus: 'Accepted' })}
+        handleSubmit={event => this._handleSubmit(event, {directorStatus: 'Accepted'})}
         id="confirmDirectorAccept"
         key="confirmDirectorAccept"
       >
@@ -693,24 +694,24 @@ class ComplianceReportingEditContainer extends Component {
           (this.state.supplementalNote.trim().length === 0)) ||
         (this.state.terms.filter(term => term.value === true).length <
           this.props.signingAuthorityAssertions.items.length)}
-        handleSubmit={event => this._handleSubmit(event, { fuelSupplierStatus: 'Submitted' })}
+        handleSubmit={event => this._handleSubmit(event, {fuelSupplierStatus: 'Submitted'})}
         id="confirmSubmit"
         key="confirmSubmit"
         title="Signing Authority Declaration"
         tooltipMessage="Please complete the Signing Authority declaration."
       >
         {this.state.showPenaltyWarning &&
-          <div className="alert alert-warning">
-            <p>
-              Based on the information contained within this report, your organization is not
-              compliant with the Part 2 and/or the Part 3 requirements.
-            </p>
-            <p>
-              Please be advised that payment of penalties must be submitted to the
-              Ministry of Energy, Mines and Petroleum Resources; cheques or money orders
-              are to be made payable to the Minister of Finance.
-            </p>
-          </div>
+        <div className="alert alert-warning">
+          <p>
+            Based on the information contained within this report, your organization is not
+            compliant with the Part 2 and/or the Part 3 requirements.
+          </p>
+          <p>
+            Please be advised that payment of penalties must be submitted to the
+            Ministry of Energy, Mines and Petroleum Resources; cheques or money orders
+            are to be made payable to the Minister of Finance.
+          </p>
+        </div>
         }
         <div id="signing-assertions">
           <h2>I, {this.props.loggedInUser.displayName}{this.props.loggedInUser.title ? `, ${this.props.loggedInUser.title}` : ''}:</h2>
@@ -735,7 +736,7 @@ class ComplianceReportingEditContainer extends Component {
           ))}
           {this.state.supplementalNoteRequired &&
           <div>
-            <hr />
+            <hr/>
             <label htmlFor="supplementalReasonInput">
               Supplemental Report Reason (Required)
             </label>
@@ -750,7 +751,7 @@ class ComplianceReportingEditContainer extends Component {
               placeholder="Use this field to provide a brief explanation for the supplemental report."
               required
             />
-            <hr />
+            <hr/>
           </div>
           }
           Are you sure you want to submit this Compliance Report to the

--- a/frontend/src/compliance_reporting/ComplianceReportingEditRedirector.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingEditRedirector.js
@@ -1,0 +1,12 @@
+import React, {Component} from 'react';
+import COMPLIANCE_REPORTING from '../constants/routes/ComplianceReporting';
+import history from '../app/History';
+
+const ComplianceReportingEditRedirector = (props) => {
+
+  history.push(COMPLIANCE_REPORTING.EDIT.replace(':id', props.match.params.id).replace(':tab', 'intro'));
+
+  return null;
+};
+
+export default ComplianceReportingEditRedirector;

--- a/frontend/src/compliance_reporting/ScheduleAssessmentContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleAssessmentContainer.js
@@ -3,20 +3,23 @@
  * All data handling & manipulation should be handled here.
  */
 
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 
 import Loading from '../app/components/Loading';
 import ScheduleAssessmentPage from './components/ScheduleAssessmentPage';
 
 class ScheduleAssessmentContainer extends Component {
-  componentDidMount () {
+  componentDidMount() {
   }
 
-  render () {
-    if (this.props.snapshotIsLoading || !this.props.snapshot || !this.props.snapshot.summary) {
-      return <Loading />;
+  render() {
+    if (this.props.snapshotIsLoading
+      || !this.props.snapshot
+      || !this.props.snapshot.summary
+      || !this.props.complianceReport) {
+      return <Loading/>;
     }
 
     let part2Compliant = 'Did not supply Part 2 fuel';
@@ -82,10 +85,8 @@ ScheduleAssessmentContainer.propTypes = {
   snapshotIsLoading: PropTypes.bool
 };
 
-const mapStateToProps = state => ({
-});
+const mapStateToProps = state => ({});
 
-const mapDispatchToProps = {
-};
+const mapDispatchToProps = {};
 
 export default connect(mapStateToProps, mapDispatchToProps)(ScheduleAssessmentContainer);

--- a/frontend/src/compliance_reporting/components/ScheduleAssessmentPage.js
+++ b/frontend/src/compliance_reporting/components/ScheduleAssessmentPage.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import ComplianceReportingStatusHistory from './ComplianceReportingStatusHistory';
 import PERMISSIONS_COMPLIANCE_REPORT from '../../constants/permissions/ComplianceReport';
+import {formatNumeric} from "../../utils/functions";
+
 
 const ScheduleAssessmentPage = props => (
   <div className="schedule-assessment">
@@ -62,7 +64,7 @@ const ScheduleAssessmentPage = props => (
           <p key={transaction.id}>
             A
             <strong>
-              {` validation of ${Number(transaction.credits)} credit(s) `}
+              {` validation of ${formatNumeric(Number(transaction.credits), 0)} credit(s) `}
             </strong>
             in accordance with section 8 (8) of the
             <em> Greenhouse Gas Reduction (Renewable and Low Carbon Fuel Requirements) Act </em>
@@ -80,7 +82,7 @@ const ScheduleAssessmentPage = props => (
           <p key={transaction.id}>
             A
             <strong>
-              {` validation of ${Number(transaction.credits)} credit(s) `}
+              {` validation of ${formatNumeric(Number(transaction.credits), 0)} credit(s) `}
             </strong>
             in accordance with section 8 (8) of the
             <em> Greenhouse Gas Reduction (Renewable and Low Carbon Fuel Requirements) Act </em>
@@ -97,7 +99,7 @@ const ScheduleAssessmentPage = props => (
         return (
           <p key={transaction.id}>
             <strong> {props.snapshot.organization.name} </strong> applied
-            {` ${Number(props.snapshot.summary.lines[26])} `}
+            {` ${formatNumeric(Number(props.snapshot.summary.lines[26]), 0)} `}
             {` credit(s) to `}
             {Number(props.snapshot.summary.lines[27]) < 0 && ' partially '}
             {` offset a net debit balance in the `}
@@ -109,7 +111,7 @@ const ScheduleAssessmentPage = props => (
       if (transaction.type === 'Credit Reduction' && transaction.supplemental) {
         return (
           <p key={transaction.id}>
-            A <strong>reduction of {Number(transaction.credits)} credit(s)</strong> to
+            A <strong>reduction of {formatNumeric(Number(transaction.credits), 0)} credit(s)</strong> to
             either offset a net debit balance or to correct a discrepancy in previous
             reporting for the
             {` ${props.complianceReport.compliancePeriod.description} compliance period.`}
@@ -123,7 +125,7 @@ const ScheduleAssessmentPage = props => (
     <p>
       There were
       <strong>
-        {` ${Number(props.snapshot.summary.lines[27]) * -1} `}
+        {` ${formatNumeric(Number(props.snapshot.summary.lines[27]) * -1, 0)} `}
         {` outstanding debits `}
       </strong>
       subject to an administrative penalty under section 10 of the

--- a/frontend/src/constants/routes/ComplianceReporting.js
+++ b/frontend/src/constants/routes/ComplianceReporting.js
@@ -5,6 +5,7 @@ const COMPLIANCE_REPORTING = {
   API,
   ADD: `${BASE_PATH}/add/:period/:tab`,
   EDIT: `${BASE_PATH}/edit/:id/:tab`,
+  EDIT_REDIRECT: `${BASE_PATH}/edit_redirect/:id`,
   EXPORT: `${API}/:id/xls`,
   SNAPSHOT: `${BASE_PATH}/snapshot/:id`,
   LIST: BASE_PATH

--- a/frontend/src/constants/routes/ExclusionReports.js
+++ b/frontend/src/constants/routes/ExclusionReports.js
@@ -5,6 +5,7 @@ const EXCLUSION_REPORTS = {
   API,
   ADD: `${BASE_PATH}/add/:period/:tab`,
   EDIT: `${BASE_PATH}/edit/:id/:tab`,
+  EDIT_REDIRECT: `${BASE_PATH}/edit/:id`,
   LIST: BASE_PATH,
   SNAPSHOT: `${BASE_PATH}/snapshot/:id`,
   TRANSACTION_TYPES: `${BASE_PATH}/transaction_types`

--- a/frontend/src/exclusion_reports/ExclusionReportEditContainer.js
+++ b/frontend/src/exclusion_reports/ExclusionReportEditContainer.js
@@ -27,6 +27,7 @@ import ExclusionReportChangelogContainer from './ExclusionReportChangelogContain
 import withReferenceData from '../utils/reference_data_support';
 import autosaved from '../utils/autosave_support';
 import toastr from '../utils/toastr';
+import EXCLUSION_REPORTS from "../constants/routes/ExclusionReports";
 
 class ExclusionReportEditContainer extends Component {
   static componentForTabName (tab) {
@@ -155,7 +156,7 @@ class ExclusionReportEditContainer extends Component {
       } else {
         this.props.invalidateAutosaved();
         toastr.exclusionReports('Supplemental Created');
-        history.push(COMPLIANCE_REPORTING.LIST);
+        history.push(EXCLUSION_REPORTS.EDIT_REDIRECT.replace(':id', nextProps.complianceReporting.item.id));
       }
     }
   }
@@ -538,7 +539,8 @@ ExclusionReportEditContainer.propTypes = {
     isCreating: PropTypes.bool,
     snapshot: PropTypes.shape(),
     snapshotIsLoading: PropTypes.bool,
-    success: PropTypes.bool
+    success: PropTypes.bool,
+    item: PropTypes.object
   }),
   exclusionReports: PropTypes.shape({
     isGetting: PropTypes.bool,
@@ -621,7 +623,8 @@ const
       success: state.rootReducer.complianceReporting.success,
       errorMessage: state.rootReducer.complianceReporting.errorMessage,
       snapshot: state.rootReducer.complianceReporting.snapshotItem,
-      snapshotIsLoading: state.rootReducer.complianceReporting.isGettingSnapshot
+      snapshotIsLoading: state.rootReducer.complianceReporting.isGettingSnapshot,
+      item: state.rootReducer.complianceReporting.item
     },
     loggedInUser: state.rootReducer.userRequest.loggedInUser,
     referenceData: {

--- a/frontend/src/exclusion_reports/ExclusionReportingEditRedirector.js
+++ b/frontend/src/exclusion_reports/ExclusionReportingEditRedirector.js
@@ -1,0 +1,13 @@
+import React, {Component} from 'react';
+import COMPLIANCE_REPORTING from '../constants/routes/ComplianceReporting';
+import history from '../app/History';
+import EXCLUSION_REPORTS from "../constants/routes/ExclusionReports";
+
+const ExclusionReportingEditRedirector = (props) => {
+
+  history.push(EXCLUSION_REPORTS.EDIT.replace(':id', props.match.params.id).replace(':tab', 'intro'));
+
+  return null;
+};
+
+export default ExclusionReportingEditRedirector;

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Route, Switch, withRouter } from 'react-router';
-import { ConnectedRouter } from 'react-router-redux';
+import {Route, Switch, withRouter} from 'react-router';
+import {ConnectedRouter} from 'react-router-redux';
 
 import App from './app/App';
 import history from './app/History';
@@ -72,6 +72,8 @@ import AuthCallback from './app/AuthCallback';
 import CONFIG from './config';
 import OrganizationEditContainer from './organizations/OrganizationEditContainer';
 import ComplianceReportingEditContainer from './compliance_reporting/ComplianceReportingEditContainer';
+import ComplianceReportingEditRedirector from "./compliance_reporting/ComplianceReportingEditRedirector";
+import ExclusionReportingEditRedirector from "./exclusion_reports/ExclusionReportingEditRedirector";
 
 const Router = routerProps => (
   <ConnectedRouter history={history} key={Math.random()}>
@@ -123,11 +125,11 @@ const Router = routerProps => (
         <Route
           exact
           path={ORGANIZATIONS.ADD}
-          render={properties => <OrganizationEditContainer {...properties} mode="add" />}
+          render={properties => <OrganizationEditContainer {...properties} mode="add"/>}
         />
         <Route
           path={ORGANIZATIONS.EDIT}
-          render={properties => <OrganizationEditContainer {...properties} mode="edit" />}
+          render={properties => <OrganizationEditContainer {...properties} mode="edit"/>}
         />
         <Route
           exact
@@ -339,6 +341,13 @@ const Router = routerProps => (
             component={withRouter(ComplianceReportingEditContainer)}
           />,
           <Route
+            key="compliance_reporting_edit_redirect"
+            path={COMPLIANCE_REPORTING.EDIT_REDIRECT}
+            exact={false}
+            strict={false}
+            component={withRouter(ComplianceReportingEditRedirector)}
+          />,
+          <Route
             key="compliance_reporting"
             path={COMPLIANCE_REPORTING.LIST}
             exact
@@ -360,6 +369,13 @@ const Router = routerProps => (
             exact={false}
             strict={false}
             component={withRouter(ExclusionReportEditContainer)}
+          />,
+          <Route
+            key="exclusion_reporting_edit_redirect"
+            path={EXCLUSION_REPORTS.EDIT_REDIRECT}
+            exact={false}
+            strict={false}
+            component={withRouter(ExclusionReportingEditRedirector)}
           />
         ]}
         <Route
@@ -367,7 +383,7 @@ const Router = routerProps => (
           exact
           component={withRouter(DashboardContainer)}
         />
-        <Route component={NotFound} />
+        <Route component={NotFound}/>
       </Switch>
     </App>
   </ConnectedRouter>


### PR DESCRIPTION
Load the new supplemental report edit page (for both compliance and exclusion reports) on successful report creation, instead of kicking back to the list view.