### PR TITLE
Fixed an issue with effective and expiry date causing 500 errors in add fuel code

### DIFF
--- a/backend/api/serializers/FuelCode.py
+++ b/backend/api/serializers/FuelCode.py
@@ -128,7 +128,10 @@ class FuelCodeCreateSerializer(serializers.ModelSerializer):
                     )
                 )
 
-        if data['expiry_date'] < data['effective_date']:
+        effective_date = data.get('effective_date')
+        expiry_date = data.get('expiry_date')
+
+        if effective_date and expiry_date and expiry_date < effective_date:
             raise serializers.ValidationError({
                 'invalid': "The expiry date precedes the effective date"
             })
@@ -210,7 +213,10 @@ class FuelCodeSaveSerializer(serializers.ModelSerializer):
         Checks that the expiry date is after the effective date.
         Also, checks if the renewable percentage should be cleared.
         """
-        if data['expiry_date'] < data['effective_date']:
+        effective_date = data.get('effective_date')
+        expiry_date = data.get('expiry_date')
+
+        if effective_date and expiry_date and expiry_date < effective_date:
             raise serializers.ValidationError({
                 'invalid': "The expiry date precedes the effective date"
             })


### PR DESCRIPTION
ZEVA - 88
Changelog:
- Add a check to see if expiry date and effective dates are populated before doing the comparison so we don't run into key errors