### PR TITLE
Dashboard should now take into account supplemental report statuses

### DIFF
--- a/frontend/src/compliance_reporting/components/ComplianceReportingTable.js
+++ b/frontend/src/compliance_reporting/components/ComplianceReportingTable.js
@@ -54,7 +54,7 @@ class ComplianceReportingTable extends Component {
     }, {
       accessor: ComplianceReportStatus,
       className: 'col-status',
-      Header: 'Status',
+      Header: 'Original Status',
       id: 'status',
       minWidth: 75
     }, {
@@ -72,6 +72,25 @@ class ComplianceReportingTable extends Component {
       className: 'col-supplemental-status',
       Header: 'Supplemental Status',
       id: 'supplemental-status',
+      minWidth: 75
+    }, {
+      accessor: (item) => {
+        let report = item;
+        const { supplementalReports } = item;
+
+        if (supplementalReports.length > 0) {
+          [report] = supplementalReports;
+        }
+
+        while (report.supplementalReports && report.supplementalReports.length > 0) {
+          [report] = report.supplementalReports;
+        }
+
+        return ComplianceReportStatus(report);
+      },
+      className: 'col-status',
+      Header: 'Current Status',
+      id: 'current-status',
       minWidth: 75
     }, {
       accessor: item => (item.sortDate ? item.sortDate : null),

--- a/frontend/src/dashboard/components/ComplianceReports.js
+++ b/frontend/src/dashboard/components/ComplianceReports.js
@@ -28,44 +28,35 @@ const ComplianceReports = (props) => {
   };
 
   items.forEach((item) => {
-    if (item.type === 'Compliance Report') {
-      if (item.status.fuelSupplierStatus === 'Submitted' &&
-      item.status.analystStatus === 'Unreviewed') {
-        awaitingReview.complianceReports.analyst += 1;
-        awaitingReview.complianceReports.total += 1;
-      }
+    let { status } = item;
+    const { supplementalReports, type } = item;
+    const reportType = (type === 'Compliance Report') ? 'complianceReports' : 'exclusionReports';
 
-      if (['Not Recommended', 'Recommended'].indexOf(item.status.analystStatus) >= 0 &&
-      item.status.managerStatus === 'Unreviewed') {
-        awaitingReview.complianceReports.manager += 1;
-        awaitingReview.complianceReports.total += 1;
-      }
+    if (supplementalReports.length > 0) {
+      let [deepestSupplementalReport] = supplementalReports;
 
-      if (['Not Recommended', 'Recommended'].indexOf(item.status.managerStatus) >= 0 &&
-      item.status.directorStatus === 'Unreviewed') {
-        awaitingReview.complianceReports.director += 1;
-        awaitingReview.complianceReports.total += 1;
+      while (deepestSupplementalReport.supplementalReports &&
+        deepestSupplementalReport.supplementalReports.length > 0) {
+        [deepestSupplementalReport] = deepestSupplementalReport.supplementalReports;
       }
+      ({ status } = deepestSupplementalReport);
     }
 
-    if (item.type === 'Exclusion Report') {
-      if (item.status.fuelSupplierStatus === 'Submitted' &&
-      item.status.analystStatus === 'Unreviewed') {
-        awaitingReview.exclusionReports.analyst += 1;
-        awaitingReview.exclusionReports.total += 1;
-      }
+    if (status.fuelSupplierStatus === 'Submitted' && status.analystStatus === 'Unreviewed') {
+      awaitingReview[reportType].analyst += 1;
+      awaitingReview[reportType].total += 1;
+    }
 
-      if (['Not Recommended', 'Recommended'].indexOf(item.status.analystStatus) >= 0 &&
-      item.status.managerStatus === 'Unreviewed') {
-        awaitingReview.exclusionReports.manager += 1;
-        awaitingReview.exclusionReports.total += 1;
-      }
+    if (['Not Recommended', 'Recommended'].indexOf(status.analystStatus) >= 0 &&
+    status.managerStatus === 'Unreviewed') {
+      awaitingReview[reportType].manager += 1;
+      awaitingReview[reportType].total += 1;
+    }
 
-      if (['Not Recommended', 'Recommended'].indexOf(item.status.managerStatus) >= 0 &&
-      item.status.directorStatus === 'Unreviewed') {
-        awaitingReview.exclusionReports.director += 1;
-        awaitingReview.exclusionReports.total += 1;
-      }
+    if (['Not Recommended', 'Recommended'].indexOf(status.managerStatus) >= 0 &&
+    status.directorStatus === 'Unreviewed') {
+      awaitingReview[reportType].director += 1;
+      awaitingReview[reportType].total += 1;
     }
   });
 
@@ -88,10 +79,10 @@ const ComplianceReports = (props) => {
                   id: 'compliance-period',
                   value: ''
                 }, {
-                  id: 'type',
+                  id: 'displayname',
                   value: 'Compliance Report'
                 }, {
-                  id: 'status',
+                  id: 'current-status',
                   value: 'Submitted'
                 }], 'compliance-reporting');
 
@@ -109,10 +100,10 @@ const ComplianceReports = (props) => {
                   id: 'compliance-period',
                   value: ''
                 }, {
-                  id: 'type',
+                  id: 'displayname',
                   value: 'Compliance Report'
                 }, {
-                  id: 'status',
+                  id: 'current-status',
                   value: 'Analyst'
                 }], 'compliance-reporting');
 
@@ -130,10 +121,10 @@ const ComplianceReports = (props) => {
                   id: 'compliance-period',
                   value: ''
                 }, {
-                  id: 'type',
+                  id: 'displayname',
                   value: 'Compliance Report'
                 }, {
-                  id: 'status',
+                  id: 'current-status',
                   value: 'Manager'
                 }], 'compliance-reporting');
 
@@ -161,10 +152,10 @@ const ComplianceReports = (props) => {
                   id: 'compliance-period',
                   value: ''
                 }, {
-                  id: 'type',
+                  id: 'displayname',
                   value: 'Exclusion Report'
                 }, {
-                  id: 'status',
+                  id: 'current-status',
                   value: 'Submitted'
                 }], 'compliance-reporting');
 
@@ -182,10 +173,10 @@ const ComplianceReports = (props) => {
                   id: 'compliance-period',
                   value: ''
                 }, {
-                  id: 'type',
+                  id: 'displayname',
                   value: 'Exclusion Report'
                 }, {
-                  id: 'status',
+                  id: 'current-status',
                   value: 'Analyst'
                 }], 'compliance-reporting');
 
@@ -203,10 +194,10 @@ const ComplianceReports = (props) => {
                   id: 'compliance-period',
                   value: ''
                 }, {
-                  id: 'type',
+                  id: 'displayname',
                   value: 'Exclusion Report'
                 }, {
-                  id: 'status',
+                  id: 'current-status',
                   value: 'Manager'
                 }], 'compliance-reporting');
 


### PR DESCRIPTION
Changelog:
- Added new status column called "Current Status"
- Dashboard should now take into account the statuses of supplemental reports
- "Current Status" column is used as a filter from the dashboard. This allows us to get the actual status based on the original + supplemental report