### PR TITLE
Fixed value always resetting to 0 for Signing Authority

### DIFF
--- a/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
+++ b/frontend/src/compliance_reporting/ScheduleSummaryContainer.js
@@ -318,8 +318,7 @@ class ScheduleSummaryContainer extends Component {
       const line15percent = diesel[SCHEDULE_SUMMARY.LINE_15][2].value * 0.05;
       diesel[SCHEDULE_SUMMARY.LINE_17][2].value = summary.dieselClassRetained;
 
-      if (diesel[SCHEDULE_SUMMARY.LINE_17][2].readOnly ||
-        (line15percent && line15percent < summary.dieselClassRetained)) {
+      if (line15percent && line15percent < summary.dieselClassRetained) {
         diesel[SCHEDULE_SUMMARY.LINE_17][2].value = 0;
       }
 
@@ -327,8 +326,7 @@ class ScheduleSummaryContainer extends Component {
 
       diesel[SCHEDULE_SUMMARY.LINE_19][2].value = summary.dieselClassDeferred;
 
-      if (diesel[SCHEDULE_SUMMARY.LINE_19][2].readOnly ||
-        (line15percent && line15percent < summary.dieselClassDeferred)) {
+      if (line15percent && line15percent < summary.dieselClassDeferred) {
         diesel[SCHEDULE_SUMMARY.LINE_19][2].value = 0;
       }
 
@@ -337,8 +335,7 @@ class ScheduleSummaryContainer extends Component {
       const line4percent = gasoline[SCHEDULE_SUMMARY.LINE_4][2].value * 0.05;
       gasoline[SCHEDULE_SUMMARY.LINE_6][2].value = summary.gasolineClassRetained;
 
-      if (gasoline[SCHEDULE_SUMMARY.LINE_6][2].readOnly ||
-        (line4percent && line4percent < summary.gasolineClassRetained)) {
+      if (line4percent && line4percent < summary.gasolineClassRetained) {
         gasoline[SCHEDULE_SUMMARY.LINE_6][2].value = 0;
       }
 
@@ -346,8 +343,7 @@ class ScheduleSummaryContainer extends Component {
 
       gasoline[SCHEDULE_SUMMARY.LINE_8][2].value = summary.gasolineClassDeferred;
 
-      if (gasoline[SCHEDULE_SUMMARY.LINE_8][2].readOnly ||
-        (line4percent && line4percent < summary.gasolineClassDeferred)) {
+      if (line4percent && line4percent < summary.gasolineClassDeferred) {
         gasoline[SCHEDULE_SUMMARY.LINE_8][2].value = 0;
       }
 
@@ -356,8 +352,7 @@ class ScheduleSummaryContainer extends Component {
       part3[SCHEDULE_SUMMARY.LINE_26][2].value = summary.creditsOffset;
       const line25value = part3[SCHEDULE_SUMMARY.LINE_25][2].value * -1;
 
-      if (part3[SCHEDULE_SUMMARY.LINE_26][2].readOnly ||
-        (line25value && line25value < part3[SCHEDULE_SUMMARY.LINE_26][2].value)) {
+      if (line25value && line25value < part3[SCHEDULE_SUMMARY.LINE_26][2].value) {
         part3[SCHEDULE_SUMMARY.LINE_26][2].value = 0;
       }
 


### PR DESCRIPTION
Changelog:
- ReadOnly attribute is no longer a condition to reset the value to 0, the code now relies solely on whether the value is less than what it should be