### PR TITLE
fix/feat: tfrs-496 -- pagination for compliance reports

### DIFF
--- a/frontend/src/compliance_reporting/ComplianceReportingContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingContainer.js
@@ -104,7 +104,7 @@ class ComplianceReportingContainer extends Component {
 
   loadData () {
     this.props.getCompliancePeriods();
-    this.props.getComplianceReports();
+    this.props.getComplianceReports({page: 1, pageSize: 10, filters: []});
   }
 
   render () {
@@ -118,8 +118,10 @@ class ComplianceReportingContainer extends Component {
           .reverse()}
         complianceReports={{
           isFetching: this.props.complianceReports.isFinding,
-          items: this.props.complianceReports.items
+          items: this.props.complianceReports.items,
+          itemsCount: this.props.complianceReports.totalCount
         }}
+        getComplianceReports={this.props.getComplianceReports}
         createComplianceReport={this.createComplianceReport}
         createExclusionReport={this.createExclusionReport}
         key="compliance-reporting-list"
@@ -228,7 +230,7 @@ const mapDispatchToProps = {
   createComplianceReport: complianceReporting.create,
   createExclusionReport: exclusionReports.create,
   getCompliancePeriods,
-  getComplianceReports: complianceReporting.find
+  getComplianceReports: complianceReporting.findPaginated
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(ComplianceReportingContainer));

--- a/frontend/src/compliance_reporting/components/ComplianceReportingPage.js
+++ b/frontend/src/compliance_reporting/components/ComplianceReportingPage.js
@@ -2,14 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
-import Loading from '../../app/components/Loading';
 import CONFIG from '../../config';
 import * as Lang from '../../constants/langEnUs';
 import PERMISSIONS_COMPLIANCE_REPORT from '../../constants/permissions/ComplianceReport';
 import ComplianceReportingTable from './ComplianceReportingTable';
 
 const ComplianceReportingPage = (props) => {
-  const { isFetching, items } = props.complianceReports;
+  const { isFetching, items, itemsCount } = props.complianceReports;
   const isEmpty = items.length === 0;
 
   return (
@@ -106,15 +105,14 @@ const ComplianceReportingPage = (props) => {
         </div>
       </div>
       }
-      {isFetching && <Loading />}
-      {!isFetching &&
       <ComplianceReportingTable
+        getComplianceReports={props.getComplianceReports}
         items={items}
+        itemsCount={itemsCount}
         isFetching={isFetching}
         isEmpty={isEmpty}
         loggedInUser={props.loggedInUser}
       />
-      }
     </div>
   );
 };
@@ -130,6 +128,7 @@ ComplianceReportingPage.propTypes = {
     isFetching: PropTypes.bool,
     items: PropTypes.arrayOf(PropTypes.shape)
   }).isRequired,
+  getComplianceReports: PropTypes.func.isRequired,
   loggedInUser: PropTypes.shape({
     hasPermission: PropTypes.func
   }).isRequired,

--- a/frontend/src/notifications/components/NotificationsTable.js
+++ b/frontend/src/notifications/components/NotificationsTable.js
@@ -15,16 +15,10 @@ import CREDIT_TRANSACTIONS from '../../constants/routes/CreditTransactions';
 import SECURE_DOCUMENT_UPLOAD from '../../constants/routes/SecureDocumentUpload';
 import ReactTable from '../../app/components/StateSavingReactTable';
 import { useNavigate } from 'react-router';
+import { calculatePages} from '../../utils/functions'
 
 const NotificationsTable = (props) => {
   const navigate = useNavigate()
-
-  const calculatePages = (numberOfItems, pageSize) => {
-    if (numberOfItems === 0) {
-      return 1;
-    }
-    return Math.ceil(numberOfItems / pageSize);
-  }
 
   const columns = [{
     accessor: item => item.id,

--- a/frontend/src/utils/functions.js
+++ b/frontend/src/utils/functions.js
@@ -170,7 +170,14 @@ const validateFiles = files => (
   })
 );
 
+const calculatePages = (numberOfItems, pageSize) => {
+  if (numberOfItems === 0) {
+    return 1;
+  }
+  return Math.ceil(numberOfItems / pageSize);
+}
+
 export {
   arrayMove, download, getFileSize, getIcon, getQuantity, getScanStatusIcon,
-  formatFacilityNameplate, formatNumeric, validateFiles
+  formatFacilityNameplate, formatNumeric, validateFiles, calculatePages
 };


### PR DESCRIPTION
Remarks:

(1) Like in the TFRS-495 issue, filtering had to be done server-side. However, a lot of fields that were originally filtered on the frontend were not straightforward database fields or straightforward derivations of database fields; I put in some "todo" comments for filtering against these fields.

(2) Another thing that could be slowing the compliance reports page down is the fact that, for each report, we're also grabbing all the supplemental reports associated with that report.

(3) The original sort order of the reports were based on a @property field called "sortDate". Therefore, the queryset was evaluated and the sorting took place on the server; I think keeping this behaviour would reduce the performance benefits of pagination, so I removed it. It was probably also contributing to the slowness of the page (see discussion here: https://stackoverflow.com/questions/8478494/ordering-django-queryset-by-a-property)