### PR TITLE
Fix/prashanth saving user profile bug 2269

### DIFF
--- a/backend/api/viewsets/Document.py
+++ b/backend/api/viewsets/Document.py
@@ -126,6 +126,8 @@ class DocumentViewSet(AuditableMixin,
                 sortType = "-" if sortCondition else ""
                 sortString = f"{sortType}{key_maps[sortId]}"
                 qs = qs.order_by(sortString)
+            else:
+                qs = qs.order_by('-submitted_date')
             if filters:
                 for filter in filters:
                     id = filter.get('id')

--- a/backend/api/viewsets/Document.py
+++ b/backend/api/viewsets/Document.py
@@ -126,8 +126,6 @@ class DocumentViewSet(AuditableMixin,
                 sortType = "-" if sortCondition else ""
                 sortString = f"{sortType}{key_maps[sortId]}"
                 qs = qs.order_by(sortString)
-            else:
-                qs = qs.order_by('-submitted_date')
             if filters:
                 for filter in filters:
                     id = filter.get('id')

--- a/frontend/src/app/components/Modal.js
+++ b/frontend/src/app/components/Modal.js
@@ -24,6 +24,7 @@ class Modal extends React.Component {
       show: false
     }
     this.handleCloseModal = this._handleCloseModal.bind(this)
+    this.handleSubmitModal = this._handleSubmitModal.bind(this)
   }
 
   componentDidMount () {
@@ -47,6 +48,13 @@ class Modal extends React.Component {
     if (this.props.handleCancel) {
       this.props.handleCancel()
     }
+  }
+
+  _handleSubmitModal (event) {
+    this.setState({ show: false })
+    if (this.props.handleSubmit) {
+      this.props.handleSubmit(event)
+    } 
   }
 
   show () {
@@ -111,7 +119,7 @@ class Modal extends React.Component {
                     this.props.canBypassExtraConfirm
                   ) || this.props.disabled
                 }
-                onClick={this.props.handleSubmit}
+                onClick={this.handleSubmitModal}
               >
                 {this.props.confirmLabel}
               </button>


### PR DESCRIPTION
Since same component is used across, this fix would solve below problems as well.

1. When a user marks all notifications as read from the dropdown in the main notification centre.
2. When a BCeID user saves a draft compliance report.
3. When an IDIR user commits a credit transaction through the Historical Data Entry tool.