### PR TITLE
fix: adjust credit transfer agreement date error message (#2469)

### DIFF
--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -281,6 +281,11 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
                                       "the transaction."
                 }
             },
+            'date_of_written_agreement': {
+                'error_messages': {
+                    'invalid': "Please enter a valid date in the Agreement Date field: YYYY-MM-DD."
+                }
+            },
             'trade_effective_date': {
                 'required': False
             }


### PR DESCRIPTION
Improve the error message shown when a user tries to propose a credit transfer with an empty Agreement Date field.

Previous message: 'Error! Date has wrong format. Use one of these formats instead: YYYY-MM-DD.'
New message: 'Error! Please enter a valid date in the Agreement Date field: YYYY-MM-DD.'