### PR TITLE
fix: updated transfer labels for BCeID users according to new Act

### DIFF
--- a/backend/api/migrations/0012_update_signing_authority_declaration_statement.py
+++ b/backend/api/migrations/0012_update_signing_authority_declaration_statement.py
@@ -22,7 +22,8 @@ def update_sign_auth_assertion(apps, schema_editor):
         )
         assertion.save()
     except signing_authority_assertion.DoesNotExist:
-        logging.error('Failed to update SigningAuthorityAssertion: No entry found with id "1".')
+        logging.warning('Failed to update SigningAuthorityAssertion: No entry found with id "1".')
+        raise
 
 class Migration(migrations.Migration):
     """

--- a/backend/api/migrations/0012_update_signing_authority_declaration_statement.py
+++ b/backend/api/migrations/0012_update_signing_authority_declaration_statement.py
@@ -1,0 +1,37 @@
+import logging
+from django.db import migrations
+
+def update_sign_auth_assertion(apps, schema_editor):
+    """
+    Updates the signing authority declaration statement
+
+    Previous label:
+    "I confirm that records evidencing each matter reported under section 11.11 (2) of the 
+    Regulation are available on request."
+
+    New label:
+    "I confirm that records evidencing each matter reported under section 17 of the Low Carbon
+    Fuel (General) Regulation are available on request."
+    """
+    signing_authority_assertion = apps.get_model('api', 'SigningAuthorityAssertion')
+    try:
+        assertion = signing_authority_assertion.objects.get(id=1)
+        assertion.description = (
+            'I confirm that records evidencing each matter reported under section 17 '
+            'of the Low Carbon Fuel (General) Regulation are available on request.'
+        )
+        assertion.save()
+    except signing_authority_assertion.DoesNotExist:
+        logging.error('Failed to update SigningAuthorityAssertion: No entry found with id "1".')
+
+class Migration(migrations.Migration):
+    """
+    Attaches the update function to the migration operations
+    """
+    dependencies = [
+        ('api', '0011_report_history_grouping'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_sign_auth_assertion),
+    ]

--- a/frontend/src/credit_transfers/components/CreditTransferFormDetails.js
+++ b/frontend/src/credit_transfers/components/CreditTransferFormDetails.js
@@ -51,7 +51,7 @@ class CreditTransferFormDetails extends Component {
               onChange={this.props.handleInputChange}
               required="required"
             >
-              <option key="0" value="" default>Select a Fuel Supplier</option>
+              <option key="0" value="" default>Select an Organization</option>
               {this.props.fuelSuppliers &&
               this.props.fuelSuppliers.map(organization => (
                 this.props.fields.initiator.id !== organization.id &&


### PR DESCRIPTION
This commit makes the following updates to the New Transfer page for BCeID users, ensuring alignment with the new Act:

- Change the dropdown label from 'Select a Fuel Supplier' to 'Select an Organization'.

- The signing authority declaration statement is now updated to: 'I confirm that records evidencing each matter reported under section 17 of the Low Carbon Fuel (General) Regulation are available on request.'

Additionally, a database migration is added to apply the signing authority declaration statement label change within the existing record.

Closes #2690