### PR TITLE
feat: enabled visibility of agreement date and categorization for BCeID users

### DIFF
--- a/frontend/src/credit_transfers/components/CreditTransferSigningHistory.js
+++ b/frontend/src/credit_transfers/components/CreditTransferSigningHistory.js
@@ -163,7 +163,7 @@ class CreditTransferSigningHistory extends Component {
 
     const lastHistoryItem = history[history.length - 1]
     const createdByGov = history[0].creditTrade?.initiator?.id === 1
-    if (history.length > 0 && loggedInUser.isGovernmentUser && !createdByGov) {
+    if (history.length > 0 && !createdByGov) {
       const agreementDate = dateOfWrittenAgreement || history[0].createTimestamp
       const { category, nextChangeInMonths } = CreditTransferSigningHistory
         .calculateTransferCategoryAndNextChange(agreementDate, history[0].createTimestamp, categoryDSelected)


### PR DESCRIPTION
This PR introduces new functionality to the Transaction History section, making the date of the written credit transfer agreement and its categorization details visible to BCeID users.

Closes #2558