### PR TITLE
Testing PR master to Jan release

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1,11 +1,11 @@
 ## For each release, the value of name, branches, RELEASE_NAME and PR_NUMBER need to be adjusted accordingly
 ## For each release, update lib/config.js: version and releaseBranch
 
-name: TFRS Dev release-2.11.0
+name: TFRS Dev release-2.12.0
 
 on:
   push:
-    branches: [ release-2.11.0 ]
+    branches: [ release-2.12.0 ]
     paths:
       - frontend/**
       - backend/**
@@ -15,8 +15,8 @@ on:
 env:
   ## The pull request number of the Tracking pull request to merge the release branch to main
   ## Also remember to update the version in .pipeline/lib/config.js
-  PR_NUMBER: 2634
-  RELEASE_NAME: release-2.11.0
+  PR_NUMBER: 2701
+  RELEASE_NAME: release-2.12.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tfrs-release.yaml
+++ b/.github/workflows/tfrs-release.yaml
@@ -1,7 +1,7 @@
 ## For each release, the value of name, branches, RELEASE_NAME and PR_NUMBER need to be adjusted accordingly
 ## For each release, update lib/config.js: version and releaseBranch
 
-name: TFRS release-2.11.0
+name: TFRS release-2.12.0
 
 on:
   workflow_dispatch:
@@ -10,8 +10,8 @@ on:
 env:
   ## The pull request number of the Tracking pull request to merge the release branch to main
   ## Also remember to update the version in .pipeline/lib/config.js
-  PR_NUMBER: 2634
-  RELEASE_NAME: release-2.11.0
+  PR_NUMBER: 2701
+  RELEASE_NAME: release-2.12.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.pipeline/lib/config.js
+++ b/.pipeline/lib/config.js
@@ -1,7 +1,7 @@
 'use strict';
 const options= require('@bcgov/pipeline-cli').Util.parseArguments()
 const changeId = options.pr //aka pull-request
-const version = '2.11.0'
+const version = '2.12.0'
 const name = 'tfrs'
 const ocpName = 'apps.silver.devops'
 
@@ -13,7 +13,7 @@ options.git.repository='tfrs'
 const phases = {
   build: {  namespace:'0ab226-tools'    , name: `${name}`, phase: 'build'  , changeId:changeId, suffix: `-build-${changeId}`  , 
             instance: `${name}-build-${changeId}`  , version:`${version}-${changeId}`, tag:`build-${version}-${changeId}`,
-            releaseBranch: 'release-2.11.0'
+            releaseBranch: 'release-2.12.0'
           },
   dev: {namespace:'0ab226-dev'    , name: `${name}`, phase: 'dev'  , changeId:changeId, suffix: `-dev`  , 
         instance: `${name}-dev`  , version:`${version}`, tag:`dev-${version}`, dbServiceName: 'tfrs-spilo',

--- a/backend/Dockerfile-django
+++ b/backend/Dockerfile-django
@@ -1,8 +1,12 @@
-FROM --platform=linux/amd64 python:3.7-stretch
+FROM --platform=linux/amd64 python:3.7-buster
 ENV PYTHONUNBUFFERED 1
+
 RUN mkdir /app
 WORKDIR /app
+
 RUN apt-get update
 RUN apt-get install -y git supervisor
+
+# Add necessary files and clone repositories
 ADD https://github.com/vishnubob/wait-for-it/compare/master...HEAD /dev/null
 RUN git clone https://github.com/vishnubob/wait-for-it.git /wfi

--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -281,6 +281,11 @@ class CreditTradeCreateSerializer(serializers.ModelSerializer):
                                       "the transaction."
                 }
             },
+            'date_of_written_agreement': {
+                'error_messages': {
+                    'invalid': "Please enter a valid date in the Agreement Date field: YYYY-MM-DD."
+                }
+            },
             'trade_effective_date': {
                 'required': False
             }

--- a/backend/api/services/SpreadSheetBuilder.py
+++ b/backend/api/services/SpreadSheetBuilder.py
@@ -178,8 +178,8 @@ class SpreadSheetBuilder(object):
         worksheet.col(4).width = 7500
         worksheet.col(5).width = 4500
         worksheet.col(6).width = 4500
-        worksheet.col(8).width = 3500
-        worksheet.col(9).width = 10000
+        worksheet.col(9).width = 3500
+        worksheet.col(10).width = 10000
 
     def add_fuel_suppliers(self, fuel_suppliers):
         """

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,7 +10,7 @@ coreapi==2.3.3
 coreschema==0.0.4
 coverage==6.5.0
 cryptography==39.0.1
-Django==3.2.20
+Django==3.2.23
 django-celery-beat==1.4.0
 django-cors-headers==3.10.1
 django-debug-toolbar==3.2.4
@@ -47,7 +47,7 @@ sqlparse==0.4.4
 typing_extensions==4.4.0
 tzdata==2022.6
 uritemplate==4.1.1
-urllib3==1.26.12
+urllib3==1.26.18
 vine==1.3.0
 whitenoise==5.3.0
 xlwt==1.3.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfrs",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "dependencies": {
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-object-rest-spread": "^7.20.7",

--- a/frontend/src/compliance_reporting/components/ComplianceReportingPage.js
+++ b/frontend/src/compliance_reporting/components/ComplianceReportingPage.js
@@ -220,9 +220,10 @@ const ComplianceReportingPage = (props) => {
                 <span className='sr-only'>Toggle Dropdown</span>
               </button>
               <ul className='dropdown-menu'>
-                {props.compliancePeriods.map((compliancePeriod) => (
+                {props.compliancePeriods.map((compliancePeriod) => {
+                  if (compliancePeriod.description >= 2023) return null
+                  return (
                   <li key={compliancePeriod.description}>
-                  {compliancePeriod.description <= 2023 && (
                     <button
                       onClick={() => {
                         const found = items.findIndex(
@@ -248,9 +249,9 @@ const ComplianceReportingPage = (props) => {
                     >
                       {compliancePeriod.description}
                     </button>
-                  )}
                   </li>
-                ))}
+                  )
+                })}
               </ul>
             </div>
 
@@ -334,6 +335,7 @@ const ComplianceReportingPage = (props) => {
             {
               Array.from({ length: new Date().getFullYear() - 2017 }, (_, index) => {
                 const year = new Date().getFullYear() - index + 1
+                if (year >= 2023) return null
                 return (
                 <option key={year} value={year}>
                   {year}

--- a/frontend/src/organizations/components/OrganizationEditForm.js
+++ b/frontend/src/organizations/components/OrganizationEditForm.js
@@ -9,7 +9,6 @@ import * as Lang from "../../constants/langEnUs";
 import PERMISSIONS_ORGANIZATIONS from "../../constants/permissions/Organizations";
 import { useNavigate } from "react-router";
 import NotFound from "../../app/components/NotFound";
-import ExclusionReportingStatusHistory from "../../exclusion_reports/components/ExclusionReportStatusHistory";
 
 const OrganizationEditForm = (props) => {
   const navigate = useNavigate()
@@ -29,7 +28,7 @@ const OrganizationEditForm = (props) => {
               ) && (
                 <div className="form-group">
                   <label htmlFor="org_status" className="col-sm-4">
-                    <div className="col-sm-6"> Registered for transfers: </div>
+                    <div className="col-sm-6"> Organization status: </div>
                     <div className="col-sm-6">
                       <div key={orgStatuses[0].id}>
                         <label htmlFor="org-status-active">
@@ -45,8 +44,8 @@ const OrganizationEditForm = (props) => {
                           />
                           <span>
                             {" "}
-                            {orgStatuses[0].description === "Active" &&
-                              "Yes"}{" "}
+                            {orgStatuses[0].description}
+                            {" "}
                           </span>
                         </label>{" "}
                       </div>
@@ -64,7 +63,7 @@ const OrganizationEditForm = (props) => {
                           />
                           <span>
                             {" "}
-                            {orgStatuses[1].description === "Inactive" && "No"}
+                            {orgStatuses[1].description}
                           </span>
                         </label>{" "}
                       </div>


### PR DESCRIPTION
* Bump urllib3 from 1.26.12 to 1.26.18 in /backend

Bumps [urllib3](https://github.com/urllib3/urllib3) from 1.26.12 to 1.26.18.
- [Release notes](https://github.com/urllib3/urllib3/releases)
- [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst)
- [Commits](https://github.com/urllib3/urllib3/compare/1.26.12...1.26.18)

---
updated-dependencies:
- dependency-name: urllib3 dependency-type: direct:production ...



* update for v1.12.0

* second update for v2.12.0

* chore: updated django backend image to newwer version to fix archive dependancy

* fix: adjust credit transfer agreement date error message (#2469)

Improve the error message shown when a user tries to propose a credit transfer with an empty Agreement Date field.

Previous message: 'Error! Date has wrong format. Use one of these formats instead: YYYY-MM-DD.'
New message: 'Error! Please enter a valid date in the Agreement Date field: YYYY-MM-DD.'

* fix: adjust column widths in xls transactions sheet

Reduce the width of the 'Effective Date' column and widen the 'Comments' column in Excel export for better data readability.

Due to the previously added 'Category' column, adjust the numbers of all columns after column 7 by increasing them by one. (Column numbers start from 0)

* fix: removed 2023 option from compliance report dropdown

* fix: remove dropdown options 2023 and later

* fix: remove 2023 >= option on dropdown

* fix: revert org status label changes on edit organization page

This commit reverts unintended label changes on the 'Edit Organization' page to their original state, ensuring UI consistency for IDIR users.

Closes #2704

* Bump django from 3.2.20 to 3.2.23 in /backend

Bumps [django](https://github.com/django/django) from 3.2.20 to 3.2.23.
- [Commits](https://github.com/django/django/compare/3.2.20...3.2.23)

---
updated-dependencies:
- dependency-name: django dependency-type: direct:production ...



---------