### PR TITLE
Fix: Fix UI category display mismatch for approved transfers - 2752

### DIFF
--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -44,6 +44,7 @@ from .CreditTradeComment import CreditTradeCommentSerializer
 from .CreditTradeStatus import CreditTradeStatusMinSerializer
 from .CreditTradeType import CreditTradeTypeSerializer
 from .CreditTradeZeroReason import CreditTradeZeroReasonSerializer
+from .CreditTradeCategory import CreditTradeCategoryMinSerializer
 from .CompliancePeriod import CompliancePeriodSerializer
 from .Organization import OrganizationMinSerializer, OrganizationSerializer
 from .User import UserMinSerializer
@@ -720,6 +721,7 @@ class CreditTrade2Serializer(serializers.ModelSerializer):
     history = serializers.SerializerMethodField()
     signatures = serializers.SerializerMethodField()
     documents = DocumentAuxiliarySerializer(many=True, read_only=True)
+    trade_category = CreditTradeCategoryMinSerializer(read_only=True)
 
     class Meta:
         model = CreditTrade
@@ -732,7 +734,7 @@ class CreditTrade2Serializer(serializers.ModelSerializer):
                   'update_timestamp', 'actions', 'comment_actions',
                   'compliance_period', 'comments', 'is_rescinded',
                   'signatures', 'history', 'date_of_written_agreement',
-                  'category_d_selected')
+                  'trade_category', 'category_d_selected')
 
     def get_actions(self, obj):
         """

--- a/backend/api/serializers/CreditTradeCategory.py
+++ b/backend/api/serializers/CreditTradeCategory.py
@@ -1,0 +1,37 @@
+"""
+    REST API Documentation for the NRS TFRS Credit Trading Application
+
+    The Transportation Fuels Reporting System is being designed to streamline
+    compliance reporting for transportation fuel suppliers in accordance with
+    the Renewable & Low Carbon Fuel Requirements Regulation.
+
+    OpenAPI spec version: v1
+
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+from rest_framework import serializers
+
+from api.models.CreditTradeCategory import CreditTradeCategory
+
+
+class CreditTradeCategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CreditTradeCategory
+        fields = ('id', 'category', 'description')
+
+
+class CreditTradeCategoryMinSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CreditTradeCategory
+        fields = ('id', 'category')

--- a/frontend/src/credit_transfers/CreditTransferViewContainer.js
+++ b/frontend/src/credit_transfers/CreditTransferViewContainer.js
@@ -684,6 +684,7 @@ class CreditTransferViewContainer extends Component {
       }
       selectIdForModal={this._selectIdForModal}
       signingAuthorityAssertions={this.props.signingAuthorityAssertions}
+      tradeCategory={item.tradeCategory}
       categoryDSelected={this.props.item.categoryDSelected}
       toggleCategoryDSelection={this._toggleCategoryDSelection}
       dateOfWrittenAgreement={item.dateOfWrittenAgreement}
@@ -788,6 +789,10 @@ CreditTransferViewContainer.propTypes = {
         })
       })
     })),
+    tradeCategory: PropTypes.shape({
+      id: PropTypes.number,
+      category: PropTypes.string
+    }),
     categoryDSelected: PropTypes.bool
   }),
   loggedInUser: PropTypes.shape({

--- a/frontend/src/credit_transfers/components/CreditTransferDetails.js
+++ b/frontend/src/credit_transfers/components/CreditTransferDetails.js
@@ -152,6 +152,7 @@ const CreditTransferDetails = props => (
           <CreditTransferSigningHistory
             tradeEffectiveDate={props.tradeEffectiveDate}
             dateOfWrittenAgreement={props.dateOfWrittenAgreement}
+            tradeCategory={props.tradeCategory}
             categoryDSelected={props.categoryDSelected}
             history={props.history}
             signatures={props.signatures}


### PR DESCRIPTION
This pull request addresses a bug where a few approved credit transfer transactions were displaying an incorrect category in the user interface.

_Please review the method used to choose the category to ensure it's correct and meets our needs._

Closes #2752