### PR TITLE
fix: attorny address if null/empty

### DIFF
--- a/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
+++ b/frontend/src/compliance_reporting/ComplianceReportingEditContainer.js
@@ -38,7 +38,7 @@ import autosaved from '../utils/autosave_support'
 import ChangelogContainer from './ChangelogContainer'
 import Tooltip from '../app/components/Tooltip'
 import { withRouter } from '../utils/withRouter'
-import { atLeastOneAttorneyAddressFieldExists } from '../utils/functions'
+import { atLeastOneAttorneyAddressFieldExists, attornyAddressCheck } from '../utils/functions'
 
 class ComplianceReportingEditContainer extends Component {
   static cleanSummaryValues (summary) {
@@ -631,7 +631,7 @@ class ComplianceReportingEditContainer extends Component {
         }
       </p>,
       <p className="schedule-organization-address" key="organization-attorney-address">
-      {organizationAddress && atLeastOneAttorneyAddressFieldExists(organizationAddress)
+      {organizationAddress && attornyAddressCheck(organizationAddress)
         ? ['B.C. Attorney Office: ',
             organizationAddress.attorneyRepresentativename ? organizationAddress.attorneyRepresentativename + ', ' : '',
             AddressBuilder({

--- a/frontend/src/organizations/components/OrganizationDetails.js
+++ b/frontend/src/organizations/components/OrganizationDetails.js
@@ -12,6 +12,7 @@ import PERMISSIONS_ORGANIZATIONS from '../../constants/permissions/Organizations
 import Tooltip from '../../app/components/Tooltip'
 import { useNavigate } from 'react-router'
 import AddressBuilder from '../../app/components/AddressBuilder'
+import { attornyAddressCheck } from '../../utils/functions'
 
 const OrganizationDetails = props => {
   const navigate = useNavigate()
@@ -92,8 +93,7 @@ const OrganizationDetails = props => {
           </dl>
         </div>
         }
-        {props.organization.organizationAddress &&
-        props.organization.organizationAddress.attorneyStreetAddress &&
+        {props.organization.organizationAddress && attornyAddressCheck(props.organization.organizationAddress) &&
         <div className="address">
           <dl className="dl-horizontal">
             <dt style={{ width: '300px' }}><strong>Corporation or BC Attorney address:</strong></dt>
@@ -121,10 +121,10 @@ const OrganizationDetails = props => {
               <dt style={{ width: '300px' }}>
                 <strong>Company Profile, EDRMS Record #:</strong>
               </dt>
-            
+
             <dd>{props.organization.edrmsRecord ? props.organization.edrmsRecord : ''}</dd>
             </>
-            )}
+          )}
           </dl>
         </div>
         <div className="status">

--- a/frontend/src/utils/functions.js
+++ b/frontend/src/utils/functions.js
@@ -256,15 +256,9 @@ const attornyAddressCheck = (address) => {
     if (address.attorneyCity) {
       return true
     }
-    // if (address.attorneyProvince) {
-    //   return true
-    // }
     if (address.attorneyPostalCode) {
       return true
     }
-    // if (address.attorneyCountry) {
-    //   return true
-    // }
   }
   return false
 }

--- a/frontend/src/utils/functions.js
+++ b/frontend/src/utils/functions.js
@@ -242,7 +242,34 @@ const atLeastOneAttorneyAddressFieldExists = (address) => {
   return false
 }
 
+const attornyAddressCheck = (address) => {
+  if (address) {
+    if (address.attorneyRepresentativename) {
+      return true
+    }
+    if (address.attorneyStreetAddress) {
+      return true
+    }
+    if (address.attorneyAddressOther) {
+      return true
+    }
+    if (address.attorneyCity) {
+      return true
+    }
+    // if (address.attorneyProvince) {
+    //   return true
+    // }
+    if (address.attorneyPostalCode) {
+      return true
+    }
+    // if (address.attorneyCountry) {
+    //   return true
+    // }
+  }
+  return false
+}
+
 export {
   arrayMove, download, getFileSize, getIcon, getQuantity, getScanStatusIcon,
-  formatFacilityNameplate, formatNumeric, validateFiles, calculatePages, cellFormatNumeric, cellFormatTotal, atLeastOneAttorneyAddressFieldExists
+  formatFacilityNameplate, formatNumeric, validateFiles, calculatePages, cellFormatNumeric, cellFormatTotal, atLeastOneAttorneyAddressFieldExists, attornyAddressCheck
 }


### PR DESCRIPTION
- fixes an issue with attorney address appearing empty as the address checker checks for any fields that are not empty. the prefilled fields trigger the check and displays an empty attorney address in the ui
- created another similar check that omits the prefilled fields. Seems like the previous checker is still used somewhere so created a new one to not interfere