### PR TITLE
fix: updated trade effective date to be set upon approval - 2751

### DIFF
--- a/backend/api/migrations/0014_update_trade_effective_dates.py
+++ b/backend/api/migrations/0014_update_trade_effective_dates.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+update_trade_effective_dates = """
+          UPDATE credit_trade ct
+          SET trade_effective_date = ct.update_timestamp
+          FROM credit_trade_history cth, 
+              (SELECT id FROM credit_trade_status WHERE status = 'Approved') as cts
+          WHERE ct.id = cth.credit_trade_id
+              AND ct.trade_effective_date IS NULL
+              AND ct.type_id IN (1, 2)
+              AND ct.is_rescinded = false
+              AND cth.status_id = cts.id;
+        """
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('api', '0013_create_missing_rescinded_history_records'),
+    ]
+
+    operations = [
+        migrations.RunSQL(update_trade_effective_dates),
+    ]

--- a/backend/api/services/CreditTradeService.py
+++ b/backend/api/services/CreditTradeService.py
@@ -184,25 +184,21 @@ class CreditTradeService(object):
             credit_trade.trade_category = CreditTradeService.calculate_transfer_category(
                 credit_trade.date_of_written_agreement, credit_trade.create_timestamp, credit_trade.category_d_selected)
 
-        # Set the effective_date to today if credit_trade's trade_effective_date is null or in the past, 
-        # otherwise use trade_effective_date
-        today = timezone.localdate()
-        effective_date = credit_trade.trade_effective_date \
-            if credit_trade.trade_effective_date and credit_trade.trade_effective_date > today else today
-
-        # Only transfer credits if the effective_date is today or in the past
-        if effective_date <= today:
-            CreditTradeService.transfer_credits(
-                credit_trade.credits_from,
-                credit_trade.credits_to,
-                credit_trade.id,
-                credit_trade.number_of_credits,
-                effective_date
-            )
+        # Set the effective_date to today to mark the approval date of the credit trade
+        effective_date = timezone.localdate()
+        
+        CreditTradeService.transfer_credits(
+            credit_trade.credits_from,
+            credit_trade.credits_to,
+            credit_trade.id,
+            credit_trade.number_of_credits,
+            effective_date
+        )
 
         if update_user:
             credit_trade.update_user = update_user
 
+        credit_trade.trade_effective_date = effective_date
         credit_trade.status = status_approved
         CreditTradeService.create_history(credit_trade)
         credit_trade.save()
@@ -210,6 +206,7 @@ class CreditTradeService(object):
         return credit_trade
     
 
+    # Deprecated, left for reference
     @staticmethod
     def process_future_effective_dates(organization):
         """


### PR DESCRIPTION
Updated business logic on trade_effective_date to properly set today's date upon credit trade approval.
Created migration to update approved credit trade records that are missing a trade_effective_date value.