### PR TITLE
Fix: Hide LCFS email line on organizations details page for IDIR users - 2677

### DIFF
--- a/frontend/src/organizations/components/OrganizationDetails.js
+++ b/frontend/src/organizations/components/OrganizationDetails.js
@@ -105,12 +105,14 @@ const OrganizationDetails = props => {
           </dl>
         </div>
         }
-        <div className="address">
-          <dl className="dl-horizontal">
-            <dt style={{ width: '300px' }}>&nbsp;</dt>
-            <dd>Email <a href="mailto:lcfs@gov.bc.ca?subject=TFRS Address Update">lcfs@gov.bc.ca</a> to update address information.</dd>
-          </dl>
-        </div>
+        {! props.loggedInUser.isGovernmentUser && (
+          <div className="address">
+            <dl className="dl-horizontal">
+              <dt style={{ width: '300px' }}>&nbsp;</dt>
+              <dd>Email <a href="mailto:lcfs@gov.bc.ca?subject=TFRS Address Update">lcfs@gov.bc.ca</a> to update address information.</dd>
+            </dl>
+          </div>
+        )}
         <div className="address">
           <dl className="dl-horizontal">
           {props.loggedInUser.isGovernmentUser && (


### PR DESCRIPTION
This PR implements a change to hide the LCFS email line on the organizations details page for IDIR users.

Closes #2677