### PR TITLE
Fix: Revise error message for insufficient compliance units - 2745

### DIFF
--- a/backend/api/serializers/CreditTrade.py
+++ b/backend/api/serializers/CreditTrade.py
@@ -48,10 +48,8 @@ from .CompliancePeriod import CompliancePeriodSerializer
 from .Organization import OrganizationMinSerializer, OrganizationSerializer
 from .User import UserMinSerializer
 
-INSUFFICIENT_CREDITS_MESSAGE = "Unable to initiate this Credit Transfer " \
-    "Proposal. Your organization either does not have enough " \
-    "validated credits or has pending Credit Transfer Proposal(s) that " \
-    "could result in an insufficient credit balance for this transfer."
+INSUFFICIENT_CREDITS_MESSAGE = "Unable to initiate transfer. " \
+    "Your organization does not have enough compliance units for this transfer."
 
 
 class CreditTradeCreateSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
This PR updates the error message in the transfer initiation process to be more user-friendly and in line with the new Act's terminology.

Closes #2745