### PR TITLE
Fix: Update Act citations in transaction history - 2813

### DIFF
--- a/backend/api/serializers/CreditTradeHistory.py
+++ b/backend/api/serializers/CreditTradeHistory.py
@@ -127,4 +127,5 @@ class CreditTradeHistoryReviewedSerializer(serializers.ModelSerializer):
     class Meta:
         model = CreditTradeHistory
         fields = ('credit_trade', 'status', 'is_rescinded',
-                  'create_timestamp', 'user', 'user_role')
+                  'create_timestamp', 'user', 'user_role',
+                  'trade_effective_date')

--- a/frontend/src/credit_transfers/components/CreditTransferSigningHistory.js
+++ b/frontend/src/credit_transfers/components/CreditTransferSigningHistory.js
@@ -35,7 +35,7 @@ class CreditTransferSigningHistory extends Component {
     // was from the historical data entry
     // show "the Director" at all times
     // use effective date as well
-    const approveTimeStamp = history.createTimestamp >= moment('2024-01-01')
+    const approveTimeStamp = moment(history.tradeEffectiveDate).isSameOrAfter(moment('2024-01-01'))
     return (
       <li key={history.createTimestamp}>
         <strong className="text-success">


### PR DESCRIPTION
This PR introduces logic to accurately cite the "Low Carbon Fuels Act" for credit transactions effective from January 1st, 2024, and retains references to the "Greenhouse Gas Reduction Act" for transactions before this date.

Closes #2813