### PR TITLE
Fix: Resolve Compliance Report Acceptance Error - 2829

### DIFF
--- a/backend/api/services/ComplianceReportService.py
+++ b/backend/api/services/ComplianceReportService.py
@@ -308,7 +308,7 @@ class ComplianceReportService(object):
             # Code 26C is used to identify credits that must be refunded to the supplier.
             # This occurs when our debit position decreases and we have already spent credits. 
             # In such cases, any excess credits must be returned to the supplier.
-            if is_supplemental and Decimal(lines['26C']) > 0:
+            if is_supplemental and Decimal(lines.get('26C', 0)) > 0:
                 print("*** DIRECTOR 26C Increase to Credits ***")
                 required_credit_transaction = Decimal(lines['26C'])
             


### PR DESCRIPTION
This PR fixes the 'Error saving' issue when accepting compliance report #1872, ensuring the status updates to 'Accepted' successfully.

Closes #2829