### PR TITLE
Fix: Exclusion Report Snapshot - 2854

### DIFF
--- a/backend/api/viewsets/ComplianceReport.py
+++ b/backend/api/viewsets/ComplianceReport.py
@@ -552,7 +552,8 @@ class ComplianceReportViewSet(AuditableMixin, mixins.CreateModelMixin,
         return Response(data)
 
     def compliance_to_new_act(self, obj, snapshot):
-        if int(obj.compliance_period.description) > 2022 and snapshot is not None:
+        if int(obj.compliance_period.description) > 2022 \
+          and snapshot is not None and obj.type.the_type != "Exclusion Report":
             lines = snapshot.get('summary').get('lines')
             if lines.get('29A') is None:
                 previous_transactions = []


### PR DESCRIPTION
- updated the snapshot for new compliance periods to ignore the summary calculation when the compliance report has an "Exclusion Report" type