### PR TITLE
feat: TFRS - hide BCeID login button - 4286

### DIFF
--- a/frontend/src/app/Login.js
+++ b/frontend/src/app/Login.js
@@ -50,17 +50,6 @@ class Login extends React.Component {
               <div className="oidc">
                 <button
                   type="button"
-                  onClick={() => login(IDENTITY_PROVIDERS.BCEID_BUSINESS)}
-                  id="link-bceid"
-                  className="button"
-                >
-                  <span className="text"> Login with </span>
-                  <span className="display-name"> BCeID </span>
-                </button>
-              </div>
-              <div className="oidc">
-                <button
-                  type="button"
                   onClick={() => login(IDENTITY_PROVIDERS.IDIR)}
                   id="link-idir"
                   className="button"


### PR DESCRIPTION
## Summary
- Removes the BCeID login button from the TFRS login page
- IDIR login is unaffected
- BCeID authentication remains functional via the existing `login(IDENTITY_PROVIDERS.BCEID_BUSINESS)` action, so invitation/controlled access can still be wired up later if needed

## Acceptance criteria
- [x] BCeID login button is removed from the TFRS login page UI
- [x] BCeID authentication remains functional if accessed via direct/controlled entry points (the underlying Keycloak action and `bceidbusiness` IDP hint are unchanged)
- [x] No impact to IDIR or other login methods

## Test plan
- [ ] Load the login page in staging — only the IDIR button is visible
- [ ] Click IDIR — IDIR login flow works as before
- [ ] Verify no console errors on the login page
- [ ] Verify rendering on desktop and mobile viewports

Refs bcgov/lcfs#4286