### PR TITLE
fix: pin python-dotenv to 1.2.1 for Python 3.9 backend image

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,7 +8,7 @@ charset-normalizer==2.1.1
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==6.5.0
-cryptography==43.0.3
+cryptography==46.0.7
 Django==4.2.30
 django-celery-beat==2.5.0
 django-cors-headers==3.10.1
@@ -39,7 +39,7 @@ pycparser==2.21
 pyjwt==2.12.0
 python-crontab==2.6.0
 python-dateutil==2.8.2
-python-dotenv==1.2.2
+python-dotenv==1.2.1
 pytz==2022.5
 requests==2.33.0
 six==1.16.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,7 +8,7 @@ charset-normalizer==2.1.1
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==6.5.0
-cryptography==46.0.7
+cryptography==43.0.3
 Django==4.2.30
 django-celery-beat==2.5.0
 django-cors-headers==3.10.1


### PR DESCRIPTION
## Root cause (from OpenShift build #13 logs)

```
ERROR: Could not find a version that satisfies the requirement python-dotenv==1.2.2
ERROR: Ignored the following versions that require a different python version:
       1.2.2 Requires-Python >=3.10
```

Dependabot #2989 bumped `python-dotenv` 0.21.0 → **1.2.2**, but 1.2.2 requires Python ≥3.10. The backend image is `python:3.9.20-bullseye` ([backend/Dockerfile-Openshift:2](backend/Dockerfile-Openshift)). `1.2.1` is the highest release with a cp39-compatible distribution.

## Change
- `python-dotenv` 1.2.2 → **1.2.1**

(The branch contains a first commit that downgraded `cryptography` to 43.0.3 based on a wrong guess before I had the build logs — the second commit reverts it back to 46.0.7. The 46.0.7 wheel resolves cleanly on cp39.)

## Test plan
- [ ] Backend OpenShift build succeeds
- [ ] Backend pod starts cleanly
- [ ] `.env` loading still works at boot (`load_dotenv()` API is unchanged between 0.21 → 1.2)

## Follow-up to consider
The base image is on Python 3.9, which the Python core team has now EOL'd. A future bump to 3.11 or 3.12 in `Dockerfile-Openshift` would unblock dependabot fully — but that's out of scope for this fix.