### PR TITLE
fix: pin py3.9-compatible deps (requests, urllib3, cffi, typing_extensions)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,7 @@ asgiref==3.6.0
 billiard==4.2.0
 celery==5.3.6
 certifi==2023.7.22
-cffi==1.15.1
+cffi==2.0.0
 charset-normalizer==2.1.1
 coreapi==2.3.3
 coreschema==0.0.4
@@ -44,10 +44,10 @@ pytz==2022.5
 requests==2.32.5
 six==1.16.0
 sqlparse==0.5.4
-typing_extensions==4.4.0
+typing_extensions==4.13.2
 tzdata>=2022.6
 uritemplate==4.1.1
-urllib3==2.7.0
+urllib3==2.6.3
 vine==5.1.0
 whitenoise==5.3.0
 xlwt==1.3.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -41,7 +41,7 @@ python-crontab==2.6.0
 python-dateutil==2.8.2
 python-dotenv==1.2.1
 pytz==2022.5
-requests==2.33.0
+requests==2.32.5
 six==1.16.0
 sqlparse==0.5.4
 typing_extensions==4.4.0


### PR DESCRIPTION
## Root cause
The dependabot rollup in #2998 introduced multiple version pins that are incompatible with the backend's Python 3.9.20 image. Each `oc start-build` only surfaces the **first** failure, so we'd been seeing them one PR at a time. Reproduced the build locally against `python:3.9.20-bullseye` to flush out **all** of them in a single pass.

## Changes (all in `backend/requirements.txt`)

| Package | Before | After | Why |
|---|---|---|---|
| requests | 2.33.0 | **2.32.5** | 2.33.0 requires Python ≥3.10 |
| urllib3 | 2.7.0 | **2.6.3** | 2.7.0 requires Python ≥3.10 |
| cffi | 1.15.1 | **2.0.0** | `cryptography==46.0.7` requires `cffi>=2.0.0` |
| typing_extensions | 4.4.0 | **4.13.2** | `cryptography==46.0.7` requires `typing-extensions>=4.13.2` on Python <3.11 |

All four are minimum-bumps to satisfy the resolver — picked the lowest version in each case that unblocks the install, to keep the diff conservative.

## Verification
Ran the actual install in the matching base image:

```
docker run --rm -v $PWD/backend:/app:ro --platform linux/amd64 \
  python:3.9.20-bullseye bash -c \
  "apt-get update -qq && apt-get install -y -qq build-essential libpq-dev && \
   pip install --upgrade pip==24.0 && \
   pip install --no-cache-dir -r /app/requirements.txt"
```

Result: `Successfully installed Django-4.2.30 ... cffi-2.0.0 cryptography-46.0.7 ... requests-2.32.5 ... typing_extensions-4.13.2 ... urllib3-2.6.3 ...` — full clean install, no resolver conflicts, no compile failures.

## Follow-up still relevant
The backend image is on Python 3.9 (upstream EOL). Dependabot will keep nominating versions that drop 3.9 support. Bumping `backend/Dockerfile-Openshift` to `python:3.11` or `3.12` would let the resolver pick freely and stop this firefighting cycle — out of scope for this fix.

## Test plan
- [x] Backend dependencies install cleanly in `python:3.9.20-bullseye` (verified locally)
- [ ] Backend OpenShift build succeeds
- [ ] Backend pod starts cleanly
- [ ] Auth path still works (cryptography/cffi/typing_extensions touched but no API surface change in user code)
- [ ] Outbound HTTPS calls work (requests/urllib3 are patch-level downshifts)