### PR TITLE
fix: drop non-assignable users from deployment approval lists

### DIFF
--- a/.github/workflows/prod-ci.yaml
+++ b/.github/workflows/prod-ci.yaml
@@ -89,7 +89,7 @@ jobs:
         uses: trstringer/manual-approval@v1.12.0
         with:
           secret: ${{ github.TOKEN }}
-          approvers: AlexZorkin,kuanfandevops,prv-proton,JulianForeman,kevin-hashimoto,dhaselhan
+          approvers: AlexZorkin,kuanfandevops,prv-proton,kevin-hashimoto
           minimum-approvals: 2
           issue-title: "TFRS ${{ env.BUILD_SUFFIX }} Prod Deployment at ${{ steps.get-current-time.outputs.CURRENT_TIME }}"
 

--- a/.github/workflows/test-ci.yaml
+++ b/.github/workflows/test-ci.yaml
@@ -92,7 +92,7 @@ jobs:
         uses: trstringer/manual-approval@v1.12.0
         with:
           secret: ${{ github.TOKEN }}
-          approvers: AlexZorkin,kuanfandevops,prv-proton,JulianForeman,kevin-hashimoto,dhaselhan
+          approvers: AlexZorkin,kuanfandevops,prv-proton,kevin-hashimoto
           minimum-approvals: 1
           issue-title: "TFRS ${{ env.BUILD_SUFFIX }} Test Deployment at ${{ steps.get-current-time.outputs.CURRENT_TIME }}"
 


### PR DESCRIPTION
## Problem
Test deploy approval (`TFRS New Pipeline Test release-3.0.1 #16`) failed at the `manual-approval` step:

```
error creating issue: POST .../repos/bcgov/tfrs/issues: 422 Validation Failed
[{Resource:Issue Field:assignees Code:invalid
  Message:assignees dhaselhan, julianforeman cannot be assigned to this issue}]
```

GitHub's issues API requires **triage** permission or higher to set a user as an assignee. Current repo permissions of the listed approvers:

| User | Permission |
|---|---|
| AlexZorkin | admin |
| kuanfandevops | admin |
| prv-proton | write |
| kevin-hashimoto | write |
| **JulianForeman** | **read** ← rejected |
| **dhaselhan** | **read** ← rejected |

When *any* listed assignee fails the check, the whole POST is rejected — so the approval issue never gets created, even though `minimum-approvals` (1 for test, 2 for prod) would be satisfied by the others.

## Change
Drop `JulianForeman` and `dhaselhan` from the approver lists in both `test-ci.yaml` and `prod-ci.yaml`. Remaining approvers (AlexZorkin, kuanfandevops, prv-proton, kevin-hashimoto) all have `write+` access and clear the thresholds for both pipelines.

## If those users need to be approvers again
Elevate them to `triage` (or higher) on the repo first, then add them back.

## Test plan
- [ ] Re-run the Test pipeline — approval issue creates successfully
- [ ] Approval flow can be satisfied by responding `approved` on the created issue