### PR TITLE
fix: make db_comments PatchedField compatible with Django 4.2

### DIFF
--- a/backend/db_comments/patch_fields.py
+++ b/backend/db_comments/patch_fields.py
@@ -35,13 +35,11 @@ class PatchedField(Field):
     _db_comment = None
 
     def __init__(self, *args, **kwargs):
-        """Strip the db_comment kwarg (if any) and delegate to super"""
+        """Delegate to super; Django 4.2+ accepts db_comment natively and our
+        setter routes the value into self._db_comment for the property getter
+        below to read."""
 
         self._db_comment = None
-
-        if 'db_comment' in kwargs:
-            self._db_comment = kwargs['db_comment']
-            del kwargs['db_comment']
 
         super().__init__(*args, **kwargs)
 
@@ -76,6 +74,13 @@ class PatchedField(Field):
                 return None
 
         return self._db_comment
+
+    @db_comment.setter
+    def db_comment(self, value):
+        """Receive db_comment assignments from Django 4.2+ Field.__init__
+        (which does ``self.db_comment = db_comment``) and store the raw
+        value for the getter to format."""
+        self._db_comment = value
 
 
 def patch_fields():


### PR DESCRIPTION
## Problem
Prod backend pod is in `Init:CrashLoopBackOff` (init container `dbmigration`):

```
File "/app/db_comments/patch_fields.py", line 46, in __init__
    super().__init__(verbose_name, name, **kwargs)
File "django/db/models/fields/__init__.py", line 225, in __init__
    self.db_comment = db_comment
AttributeError: can't set attribute
```

## Root cause
- Django 4.2 added a native `db_comment` argument to `Field.__init__` and assigns it as `self.db_comment = db_comment`.
- `backend/db_comments/patch_fields.py` defines `db_comment` as a **read-only `@property`** on `PatchedField` (no setter).
- `PatchedField` sits in the MRO between Django subclasses (CharField, IntegerField, ForeignKey, etc.) and `Field`, so the assignment in `Field.__init__` resolves to our property → `AttributeError`.

On Django 3.2 this latent bug was invisible because Django never assigned `self.db_comment`; the project carried its own kwarg-stripping logic instead. The Django 3.2 → 4.2 bump in #2998 exposed it.

## Fix
- Add a setter to the `db_comment` property that stores the value in `self._db_comment` — same backing field the existing getter already reads.
- Stop stripping the `db_comment` kwarg before `super().__init__()`. Django 4.2 now accepts it natively; letting it through means the setter funnels it into `_db_comment` for us. The getter's ForeignKey-aware formatting still composes the final value at read time.

Net code change: small surgical edit to one file, no behavioral change to the model layer at read time.

## Verification (local, against the matching base image)
```
docker run --rm -v $PWD/backend:/app:ro --platform linux/amd64 \
  python:3.9.20-bullseye bash -c '
    apt-get update -qq && apt-get install -y -qq build-essential libpq-dev >/dev/null
    pip install --upgrade pip==24.0 -q
    pip install --no-cache-dir -q -r /app/requirements.txt
    cd /app && python -c "
from db_comments.patch_fields import patch_fields
patch_fields()
from django.db import models
f = models.CharField(max_length=10, db_comment=\"some-comment\")
print(f.db_comment)
f.db_comment = \"changed\"
print(f.db_comment)
"'
```
Output:
```
some-comment
changed
```

(Before this patch: `AttributeError: can't set attribute` on the first line.)

## Test plan
- [ ] Prod backend pod starts past the `dbmigration` init container
- [ ] Database migrations apply
- [ ] Auditable model fields still carry their FK comments through to Postgres (read after a migration cycle)