### PR TITLE
fix: Django 4.2 source + dependency compat for backend startup

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -19,7 +19,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-from django.conf.urls import url, include
+from django.urls import include, re_path
 from rest_framework.documentation import include_docs_urls
 from rest_framework.routers import DefaultRouter
 
@@ -138,8 +138,8 @@ if EXCLUSION_REPORTS_API['ENABLED'] or TESTING:
 
 urlpatterns = [
     # Swagger documentation
-    url(r'^doc/', include_docs_urls(title='TFRS API Documentation')),
-    url(r'^', include(ROUTER.urls))
+    re_path(r'^doc/', include_docs_urls(title='TFRS API Documentation')),
+    re_path(r'^', include(ROUTER.urls))
 ]
 
 urlpatterns += ROUTER.urls

--- a/backend/db_comments/patch_fields.py
+++ b/backend/db_comments/patch_fields.py
@@ -35,13 +35,11 @@ class PatchedField(Field):
     _db_comment = None
 
     def __init__(self, *args, **kwargs):
-        """Strip the db_comment kwarg (if any) and delegate to super"""
+        """Delegate to super; Django 4.2+ accepts db_comment natively and our
+        setter routes the value into self._db_comment for the property getter
+        below to read."""
 
         self._db_comment = None
-
-        if 'db_comment' in kwargs:
-            self._db_comment = kwargs['db_comment']
-            del kwargs['db_comment']
 
         super().__init__(*args, **kwargs)
 
@@ -76,6 +74,13 @@ class PatchedField(Field):
                 return None
 
         return self._db_comment
+
+    @db_comment.setter
+    def db_comment(self, value):
+        """Receive db_comment assignments from Django 4.2+ Field.__init__
+        (which does ``self.db_comment = db_comment``) and store the raw
+        value for the getter to format."""
+        self._db_comment = value
 
 
 def patch_fields():

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,11 +15,11 @@ django-cors-headers==3.10.1
 django-debug-toolbar==3.2.4
 django-debug-toolbar-request-history==0.1.3
 nplusone==1.0.0
-django-extensions==1.7.7
+django-extensions==3.2.3
 django-filter==2.4.0
 django-nose==1.4.7
 django-timezone-field==5.0
-djangorestframework==3.11.2
+djangorestframework==3.14.0
 djangorestframework-bulk==0.2.1
 djangorestframework-camel-case==1.3.0
 django-redis==5.4.0
@@ -52,4 +52,4 @@ vine==5.1.0
 whitenoise==5.3.0
 xlwt==1.3.0
 zipp==3.10.0
-setuptools>=65.5.1
+setuptools>=65.5.1,<81

--- a/backend/tfrs/urls.py
+++ b/backend/tfrs/urls.py
@@ -1,14 +1,12 @@
-from django.conf.urls import url
-from django.urls import path, include
+from django.urls import include, path, re_path
 from django.contrib import admin
 # import debug_toolbar
 from . import views
-from django.urls import path
 
 urlpatterns = [
-    url(r'^$', views.blank),
-    url(r'^api/', include('api.urls')),
-    url(r'^health$', views.health),
-    url(r'^api_admin/', admin.site.urls),
+    re_path(r'^$', views.blank),
+    re_path(r'^api/', include('api.urls')),
+    re_path(r'^health$', views.health),
+    re_path(r'^api_admin/', admin.site.urls),
     # path('__debug__/', include(debug_toolbar.urls)),
 ]


### PR DESCRIPTION
## Problem
Prod backend pod is in `Init:CrashLoopBackOff` (init container `dbmigration`) due to a cascade of Django 4.2 incompatibilities exposed by the Django 3.2 → 4.2 bump in #2998. Each one only surfaces after the previous one is fixed, so iterating through prod redeploys would take many cycles.

I reproduced the full backend startup locally against the matching base image (`python:3.9.20-bullseye`) and iterated `python manage.py check` until the run was clean. This PR contains the remaining fixes after #3005 landed the first one.

## Changes

### 1. `backend/tfrs/urls.py`, `backend/api/urls.py`
`django.conf.urls.url` was removed in Django 4.0. Replaced with `django.urls.re_path` (same behavior, takes a regex). Also dedup'd a duplicate `path` import in `tfrs/urls.py`.

### 2. `backend/requirements.txt`
| Package | Before | After | Why |
|---|---|---|---|
| django-extensions | 1.7.7 | **3.2.3** | 1.7.7 (2017) imports `django.utils.translation.ugettext`, removed in Django 4.0 |
| djangorestframework | 3.11.2 | **3.14.0** | 3.11 internally uses `django.conf.urls.url`. 3.14 is the latest stable on Django 4.2 + Python 3.9 |
| setuptools | `>=65.5.1` | **`>=65.5.1,<81`** | setuptools 81 removed `pkg_resources`, which `coreapi 2.3.3` (transitive dep of DRF's `include_docs_urls`) still imports |

(The diff also includes the db_comments change from #3005 since this branch was cut before that PR merged — the change is identical so the net effect is zero, but it's visible in the PR file list.)

## Verification
Ran the actual prod startup path locally:
```
docker run --rm -v $PWD/backend:/app:ro --platform linux/amd64 \
  python:3.9.20-bullseye bash -c '
    apt-get update -qq && apt-get install -y -qq build-essential libpq-dev >/dev/null
    pip install --upgrade pip==24.0 -q
    pip install --no-cache-dir -q -r /app/requirements.txt
    cd /app && python manage.py check
'
```
Output: `System check identified no issues (0 silenced).`

Before this patch (with #3005 already merged), the same command failed at three successive errors:
1. `ImportError: cannot import name 'ugettext'` (django-extensions)
2. `ImportError: cannot import name 'url' from 'django.conf.urls'` (tfrs/urls.py + DRF)
3. `AssertionError: 'coreapi' must be installed for schema support` (pkg_resources/setuptools)

## Test plan
- [ ] Backend OpenShift build succeeds
- [ ] Backend pod starts past the `dbmigration` init container
- [ ] Database migrations apply
- [ ] `/api/doc/` Swagger endpoint still loads (uses coreapi via DRF docs)
- [ ] Auditable model fields still carry their FK comments through to Postgres after a migration

## Follow-ups (not in this PR)
- `coreapi` is unmaintained (last release 2018) and `include_docs_urls` is deprecated in DRF. Eventually the `/api/doc/` route should move to drf-spectacular or be removed; that lets us drop the setuptools cap.
- Several other deps still on Django 3.x-era pins (django-filter 2.4, django-debug-toolbar 3.2, djangorestframework-bulk 0.2 from 2018, django-nose). They didn't break `manage.py check`, but they're brittle. Worth a separate hygiene pass.
- Move the base image off Python 3.9 (EOL) so dependabot bumps stop tripping on the 3.10+ floor.