### PR TITLE
fix: short-circuit notifications/count to unblock IDIR login

### DIFF
--- a/backend/api/viewsets/Notification.py
+++ b/backend/api/viewsets/Notification.py
@@ -149,19 +149,10 @@ class NotificationViewSet(AuditableMixin,
     @never_cache
     @action(detail=False, methods=['get'])
     def count(self, request):
-        user = self.request.user
-
-        count = NotificationMessage.objects.filter(
-            is_archived=False,
-            is_read=False,
-            user=user
-        ).count()
-
-        data = {
-            'unreadCount': count
-        }
-
-        return JsonResponse(data)
+        # Short-circuit to a stable 200: notifications are a historical-only
+        # feature and the live unread-count query was 500-ing in prod, which
+        # tripped the frontend's global error handler and locked users out.
+        return JsonResponse({'unreadCount': 0})
 
     @never_cache
     def list(self, request, *args, **kwargs):

--- a/frontend/src/store/notificationTrigger.js
+++ b/frontend/src/store/notificationTrigger.js
@@ -1,5 +1,5 @@
 import { put, takeLatest, delay } from 'redux-saga/effects'
-import { getNotifications, getNotificationsCount } from '../actions/notificationActions'
+import { getNotifications } from '../actions/notificationActions'
 import UserActionTypes from '../constants/actionTypes/Users'
 import NotificationActionTypes from '../constants/actionTypes/Notifications'
 
@@ -9,12 +9,11 @@ const TRIGGERING_ACTIONS = [
   NotificationActionTypes.SUCCESS_NOTIFICATIONS
 ]
 
+// Post-login unread-count poll disabled: notifications are a historical-only
+// feature, and a 500 from /api/notifications/count was tripping the global
+// error reducer and locking users out of the app entirely.
 function * fetchNotifications (store) {
   yield delay(1000) // debounce
-  if (store.getState().rootReducer.userRequest.isAuthenticated &&
-        store.getState().rootReducer.userRequest.loggedInUser?.id) {
-    yield put(getNotificationsCount())
-  }
 
   if (store.getState().rootReducer.notifications.onNotificationsPage) {
     yield put(getNotifications())


### PR DESCRIPTION
## Summary

- Prod IDIR users were locked out of TFRS by a 500 from `/api/notifications/count` — the frontend's global error reducer flipped on any failure of that single endpoint and replaced the router with the full "We're sorry" `StatusInterceptor` (issue #4448).
- Notifications are kept only as a historical view, so the unread-count poll is more harmful than useful right now.
- `frontend/src/store/notificationTrigger.js`: drop the post-login `getNotificationsCount()` dispatch. The notifications-page list fetch stays in place for users who navigate there manually.
- `backend/api/viewsets/Notification.py`: short-circuit the `count` action to a stable 200 returning `{"unreadCount": 0}` — no DB hit, no chance of 500. Belt-and-braces guard for any cached/stale client that still calls the endpoint.
- All other notification routes (list, statuses, subscribe, update_subscription, etc.) are untouched.

Cherry-picked from #3010 (which targeted release-3.0.1 in error).

## Test plan

- [ ] Log in as an IDIR user against a prod-like backend; confirm the app loads to the dashboard instead of the "We're sorry" page.
- [ ] DevTools Network: confirm `/api/notifications/count` is no longer requested after login.
- [ ] Hit `/api/notifications/count` directly (curl / browser): confirm `200 {"unreadCount": 0}`.
- [ ] Navigate to the Notifications page manually: confirm the historical list still loads.
- [ ] Log in as a BCeID supplier user: confirm the same — no lockout, dashboard renders.