### PR TITLE
fix: use bitnamilegacy nginx image so frontend build succeeds

### DIFF
--- a/frontend/Dockerfile-Openshift
+++ b/frontend/Dockerfile-Openshift
@@ -8,7 +8,7 @@ RUN npm install -g npm@9.1.1 \
 RUN yes | npm run build-prod
 
 # Stage 2: Copy the JS React SPA into the Nginx HTML directory
-FROM artifacts.developer.gov.bc.ca/docker-remote/bitnami/nginx:1.21.6
+FROM artifacts.developer.gov.bc.ca/docker-remote/bitnamilegacy/nginx:1.21.6
 COPY ./nginx.conf /opt/bitnami/nginx/conf/
 COPY --from=builder /usr/src/app/public/build /app
 EXPOSE 8080


### PR DESCRIPTION
## Summary

- The `TFRS New Pipeline Dev release-3.1.0` frontend build is failing on `release-3.1.0` ([run 26619393101](https://github.com/bcgov/tfrs/actions/runs/26619393101)) — OpenShift build fails in ~25s, well before npm install would even start.
- Root cause: Bitnami moved their legacy image tags to a separate `bitnamilegacy/` namespace earlier this year. `release-3.0.1` already has the fix (PR #2985, commit `529be298`), but `release-3.1.0` was branched before that and never picked it up, so `FROM artifacts.developer.gov.bc.ca/docker-remote/bitnami/nginx:1.21.6` now 404s at pull time.
- This PR cherry-picks `529be298` onto `release-3.1.0`. One-character image-path change in `frontend/Dockerfile-Openshift`. No code changes.
- Author/sign-off preserved from the original commit (Kuan Fan).

## Test plan

- [ ] CI: the `Build TFRS Frontend` job in the dev pipeline succeeds after merge (run lasts minutes, not seconds).
- [ ] Frontend pod on dev comes up healthy and serves the SPA.
- [ ] No regression in the backend / scan-coordinator / celery / notification-server / scan-handler builds (they don't touch this Dockerfile).