### PR TITLE
ci: drop unassignable approvers from manual-approval action

### DIFF
--- a/.github/workflows/prod-ci.yaml
+++ b/.github/workflows/prod-ci.yaml
@@ -89,7 +89,7 @@ jobs:
         uses: trstringer/manual-approval@v1.6.0
         with:
           secret: ${{ github.TOKEN }}
-          approvers: AlexZorkin,kuanfandevops,prv-proton,JulianForeman,kevin-hashimoto,dhaselhan
+          approvers: AlexZorkin,kuanfandevops,prv-proton,kevin-hashimoto
           minimum-approvals: 2
           issue-title: "TFRS ${{ env.BUILD_SUFFIX }} Prod Deployment at ${{ steps.get-current-time.outputs.CURRENT_TIME }}"
 

--- a/.github/workflows/test-ci.yaml
+++ b/.github/workflows/test-ci.yaml
@@ -92,7 +92,7 @@ jobs:
         uses: trstringer/manual-approval@v1.6.0
         with:
           secret: ${{ github.TOKEN }}
-          approvers: AlexZorkin,kuanfandevops,prv-proton,JulianForeman,kevin-hashimoto,dhaselhan
+          approvers: AlexZorkin,kuanfandevops,prv-proton,kevin-hashimoto
           minimum-approvals: 1
           issue-title: "TFRS ${{ env.BUILD_SUFFIX }} Test Deployment at ${{ steps.get-current-time.outputs.CURRENT_TIME }}"
 


### PR DESCRIPTION
## Summary

- The Test deploy on `release-3.1.0` ([run 26665521073](https://github.com/bcgov/tfrs/actions/runs/26665521073)) failed in 7 seconds at the `Ask for approval for TFRS Test deployment` step.
- The `trstringer/manual-approval` action creates a GitHub issue and assigns the approver list to it. Two of the listed approvers can no longer be assigned to issues in this repo:

```
error creating issue: POST https://api.github.com/repos/bcgov/tfrs/issues: 422 Validation Failed
assignees dhaselhan, julianforeman cannot be assigned to this issue
```

- Drop `JulianForeman` and `dhaselhan` from the approver list in both `.github/workflows/test-ci.yaml` and `.github/workflows/prod-ci.yaml`.
- Remaining approvers (`AlexZorkin`, `kuanfandevops`, `prv-proton`, `kevin-hashimoto`) still comfortably satisfy `minimum-approvals`: 1 for test, 2 for prod.
- `release-3.0.1` has the same broken list — not touched here per scope; can backport in a follow-up if you want.

## Test plan

- [ ] Re-run the Test pipeline on `release-3.1.0`; the approval step opens an issue successfully (no 422) and waits for an approver.
- [ ] One of the remaining four approvers comments `approve` / `lgtm` and the deploy proceeds.
- [ ] Spot-check the Prod pipeline trigger path: the approval issue is created successfully (don't need to deploy prod to verify, just need the issue to open).